### PR TITLE
Keep Hyprland toggle catalog out of new-user state

### DIFF
--- a/guest/scripts/materialize-omarchy.sh
+++ b/guest/scripts/materialize-omarchy.sh
@@ -147,8 +147,9 @@ copy_tree "$source_dir/config" "$root/etc/skel/.config"
 install_file 0644 "$source_dir/default/bashrc" "$root/etc/skel/.bashrc"
 mkdir -p "$root/etc/skel/.local/share/applications"
 copy_contents "$source_dir/applications" "$root/etc/skel/.local/share/applications"
+# Presence of a file here enables that Hyprland flag. default/hypr/toggles is
+# the catalog (window-no-gaps, 1:1 single window), not the factory default.
 mkdir -p "$root/etc/skel/.local/state/omarchy/toggles/hypr"
-copy_contents "$source_dir/default/hypr/toggles" "$root/etc/skel/.local/state/omarchy/toggles/hypr"
 
 if [[ -d $source_dir/default/nautilus-python/extensions ]]; then
   copy_tree "$source_dir/default/nautilus-python/extensions" "$root/etc/skel/.local/share/nautilus-python/extensions"

--- a/guest/scripts/materialize-omarchy.sh
+++ b/guest/scripts/materialize-omarchy.sh
@@ -149,7 +149,10 @@ mkdir -p "$root/etc/skel/.local/share/applications"
 copy_contents "$source_dir/applications" "$root/etc/skel/.local/share/applications"
 # Presence of a file here enables that Hyprland flag. default/hypr/toggles is
 # the catalog (window-no-gaps, 1:1 single window), not the factory default.
+# flags.lua is a no-op sentinel so the directory is not empty; copy only that.
 mkdir -p "$root/etc/skel/.local/state/omarchy/toggles/hypr"
+install_file 0644 "$source_dir/default/hypr/toggles/flags.lua" \
+  "$root/etc/skel/.local/state/omarchy/toggles/hypr/flags.lua"
 
 if [[ -d $source_dir/default/nautilus-python/extensions ]]; then
   copy_tree "$source_dir/default/nautilus-python/extensions" "$root/etc/skel/.local/share/nautilus-python/extensions"

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -69,8 +69,9 @@ def main() -> None:
     materialize = read(GUEST / "scripts/materialize-omarchy.sh")
     check(
         'mkdir -p "$root/etc/skel/.local/state/omarchy/toggles/hypr"' in materialize
-        and 'copy_contents "$source_dir/default/hypr/toggles"' not in materialize,
-        "skel hypr toggles stay empty so catalog flags are off by default",
+        and 'copy_contents "$source_dir/default/hypr/toggles"' not in materialize
+        and 'toggles/flags.lua' in materialize,
+        "skel hypr toggles seed only flags.lua, not the catalog",
     )
 
     configure = read(GUEST / "scripts/configure-rootfs.sh")

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -66,6 +66,13 @@ def main() -> None:
     check('output="$repo_dir/dist/guest"' in container, "guest output defaults to dist/guest")
     check("try-omarchy-guest-work" in container, "guest cache has a project-scoped Docker volume")
 
+    materialize = read(GUEST / "scripts/materialize-omarchy.sh")
+    check(
+        'mkdir -p "$root/etc/skel/.local/state/omarchy/toggles/hypr"' in materialize
+        and 'copy_contents "$source_dir/default/hypr/toggles"' not in materialize,
+        "skel hypr toggles stay empty so catalog flags are off by default",
+    )
+
     configure = read(GUEST / "scripts/configure-rootfs.sh")
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")


### PR DESCRIPTION
Fixes #1

`omarchy-hyprland-toggle` treats any file in `~/.local/state/omarchy/toggles/hypr/` as an enabled flag. `materialize-omarchy.sh` was copying the catalog from `default/hypr/toggles/` into that directory for every new user.

That turned on:

- `window-no-gaps` (gaps and borders at 0)
- `single-window-aspect-ratio` (first window as a centered 1:1 square)

The catalog stays under `/usr/share/omarchy/default/hypr/toggles/` so users can still toggle the flags. New sessions start with an empty state directory.

Existing VMs already copied those files into `$HOME`. A factory reset (or deleting those two lua files from the toggle state dir) is needed to pick this up.