### PR TITLE
Keep ARM pacman mirrors across Omarchy refresh

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,9 @@ creates the account on first boot.
   and host audio-device routing.
 - The pinned Omarchy runtime trees are copied from upstream. Guest overlays add
   the QEMU and ARM64 integration around them.
+- `omarchy-refresh-pacman` copies `/usr/share/omarchy/default/pacman/` over
+  `/etc`. Those templates are replaced with Arch Linux ARM mirrors plus the
+  local `try-omarchy` package repo. Omarchy's x86_64 mirrors are not used.
 
 Nothing is overwritten while the app runs. The app bundle and packaged factory
 disk remain unchanged. Normal user launches use one private writable disk under

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,9 +52,9 @@ creates the account on first boot.
   and host audio-device routing.
 - The pinned Omarchy runtime trees are copied from upstream. Guest overlays add
   the QEMU and ARM64 integration around them.
-- `omarchy-refresh-pacman` copies `/usr/share/omarchy/default/pacman/` over
-  `/etc`. Those templates are replaced with Arch Linux ARM mirrors plus the
-  local `try-omarchy` package repo. Omarchy's x86_64 mirrors are not used.
+- Arch Linux ARM pacman files live under `/usr/share/try-omarchy/`. A
+  Try Omarchy-owned `pre-refresh-pacman` hook restores them after Omarchy
+  copies its x86_64 channel template to `/etc`. Omarchy itself is unchanged.
 
 Nothing is overwritten while the app runs. The app bundle and packaged factory
 disk remain unchanged. Normal user launches use one private writable disk under

--- a/guest/fragments/pre-refresh-pacman-restore-arm.sh
+++ b/guest/fragments/pre-refresh-pacman-restore-arm.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Called by omarchy-refresh-pacman after it copies the x86_64 channel template
+# to /etc and before pacman -Syyuu. Restore the ARM factory files so the
+# upgrade uses Arch Linux ARM plus the local try-omarchy repo.
+set -euo pipefail
+
+sudo install -m 0644 /usr/share/try-omarchy/pacman.conf /etc/pacman.conf
+sudo install -m 0644 /usr/share/try-omarchy/mirrorlist /etc/pacman.d/mirrorlist

--- a/guest/mirrorlist.aarch64
+++ b/guest/mirrorlist.aarch64
@@ -1,0 +1,6 @@
+#
+# Arch Linux ARM repository mirrorlist
+# Pinned from archlinuxarm/PKGBUILDs 0b5418fc3f62860b191cd872cb2f933f9fc77841
+# (core/pacman-mirrorlist). pacman expands $arch.
+#
+Server = http://mirror.archlinuxarm.org/$arch/$repo

--- a/guest/pacman.aarch64.conf
+++ b/guest/pacman.aarch64.conf
@@ -1,6 +1,8 @@
 # Architecture-specific companion to the pinned Quattro pacman configuration.
-# Arch Linux ARM supplies core/extra/alarm/aur; Omarchy publishes signed ARM64
-# packages at the same stable endpoint keyed by $arch.
+# Arch Linux ARM supplies core/extra/alarm/aur. Omarchy's pkgs.omarchy.org and
+# stable-mirror.omarchy.org only publish x86_64 (and multilib), so they stay
+# off this guest. omarchy-refresh-pacman copies the ARM templates installed
+# into /usr/share/omarchy/default/pacman/.
 [options]
 Color
 ILoveCandy
@@ -28,7 +30,3 @@ Include = /etc/pacman.d/mirrorlist
 
 [aur]
 Include = /etc/pacman.d/mirrorlist
-
-[omarchy]
-SigLevel = Optional TrustAll
-Server = https://pkgs.omarchy.org/$arch

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -106,10 +106,8 @@ arm_mirrorlist="$guest_dir/mirrorlist.aarch64"
 install -m 0644 "$guest_dir/$pacman_input" "$root/etc/pacman.conf"
 install -m 0644 "$arm_mirrorlist" "$root/etc/pacman.d/mirrorlist"
 
-# omarchy-refresh-pacman copies these templates over /etc. Keep them ARM so an
-# update cannot point pacman at x86_64 Omarchy mirrors or drop the local repo.
-pacman_templates="$root/usr/share/omarchy/default/pacman"
-[[ -d $pacman_templates ]] || fail "Omarchy pacman templates are missing"
+# Keep Omarchy's x86_64 channel templates untouched. omarchy-refresh-pacman
+# copies them over /etc, then the pre-refresh-pacman hook restores these files.
 {
   cat "$guest_dir/$pacman_input"
   cat <<'EOF'
@@ -121,17 +119,18 @@ Server = file:///usr/share/try-omarchy/repo
 EOF
 } >"$root/usr/share/try-omarchy/pacman.conf"
 install -m 0644 "$arm_mirrorlist" "$root/usr/share/try-omarchy/mirrorlist"
-for channel in stable rc edge; do
-  install -m 0644 "$root/usr/share/try-omarchy/pacman.conf" "$pacman_templates/pacman-$channel.conf"
-  install -m 0644 "$arm_mirrorlist" "$pacman_templates/mirrorlist-$channel"
-done
 grep -q '^\[multilib\]$' "$root/usr/share/try-omarchy/pacman.conf" &&
-  fail "ARM pacman templates must not include multilib"
-grep -q '^Server = https://stable-mirror.omarchy.org' "$root/usr/share/try-omarchy/pacman.conf" \
-  "$pacman_templates/mirrorlist-stable" &&
-  fail "ARM pacman templates must not use Omarchy x86_64 mirrors"
+  fail "ARM pacman files must not include multilib"
+grep -q '^Server = https://stable-mirror.omarchy.org' "$root/usr/share/try-omarchy/pacman.conf" &&
+  fail "ARM pacman files must not use Omarchy x86_64 mirrors"
 grep -q '^\[try-omarchy\]$' "$root/usr/share/try-omarchy/pacman.conf" ||
-  fail "ARM pacman refresh template must keep the local try-omarchy repository"
+  fail "ARM pacman files must keep the local try-omarchy repository"
+
+refresh_hook="$guest_dir/fragments/pre-refresh-pacman-restore-arm.sh"
+[[ -f $refresh_hook ]] || fail "ARM pacman refresh hook not found: $refresh_hook"
+install -d -m 0755 "$root/etc/skel/.config/omarchy/hooks/pre-refresh-pacman.d"
+install -m 0755 "$refresh_hook" \
+  "$root/etc/skel/.config/omarchy/hooks/pre-refresh-pacman.d/restore-arm-pacman"
 
 provision_unit="$root/usr/share/omarchy/install/provisioning/omarchy-provision-owner.service"
 [[ -f $provision_unit ]] || fail "pinned upstream owner-provisioning service is missing"

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -101,8 +101,37 @@ ln -sfn /usr/share/zoneinfo/UTC "$root/etc/localtime"
 # Keep the reviewed Arch Linux ARM package and mirror configuration.
 pacman_input=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["inputs"].get("pacmanConfig", ""))' "$spec")
 [[ -n $pacman_input ]] || fail "native guest spec must provide pacmanConfig"
+arm_mirrorlist="$guest_dir/mirrorlist.aarch64"
+[[ -f $arm_mirrorlist ]] || fail "ARM mirrorlist not found: $arm_mirrorlist"
 install -m 0644 "$guest_dir/$pacman_input" "$root/etc/pacman.conf"
-install -m 0644 /etc/pacman.d/mirrorlist "$root/etc/pacman.d/mirrorlist"
+install -m 0644 "$arm_mirrorlist" "$root/etc/pacman.d/mirrorlist"
+
+# omarchy-refresh-pacman copies these templates over /etc. Keep them ARM so an
+# update cannot point pacman at x86_64 Omarchy mirrors or drop the local repo.
+pacman_templates="$root/usr/share/omarchy/default/pacman"
+[[ -d $pacman_templates ]] || fail "Omarchy pacman templates are missing"
+{
+  cat "$guest_dir/$pacman_input"
+  cat <<'EOF'
+
+# Immutable packages assembled from the checksummed Try Omarchy build spec.
+[try-omarchy]
+SigLevel = Optional TrustAll
+Server = file:///usr/share/try-omarchy/repo
+EOF
+} >"$root/usr/share/try-omarchy/pacman.conf"
+install -m 0644 "$arm_mirrorlist" "$root/usr/share/try-omarchy/mirrorlist"
+for channel in stable rc edge; do
+  install -m 0644 "$root/usr/share/try-omarchy/pacman.conf" "$pacman_templates/pacman-$channel.conf"
+  install -m 0644 "$arm_mirrorlist" "$pacman_templates/mirrorlist-$channel"
+done
+grep -q '^\[multilib\]$' "$root/usr/share/try-omarchy/pacman.conf" &&
+  fail "ARM pacman templates must not include multilib"
+grep -q '^Server = https://stable-mirror.omarchy.org' "$root/usr/share/try-omarchy/pacman.conf" \
+  "$pacman_templates/mirrorlist-stable" &&
+  fail "ARM pacman templates must not use Omarchy x86_64 mirrors"
+grep -q '^\[try-omarchy\]$' "$root/usr/share/try-omarchy/pacman.conf" ||
+  fail "ARM pacman refresh template must keep the local try-omarchy repository"
 
 provision_unit="$root/usr/share/omarchy/install/provisioning/omarchy-provision-owner.service"
 [[ -f $provision_unit ]] || fail "pinned upstream owner-provisioning service is missing"

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -87,11 +87,18 @@ def main() -> None:
     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")
     check("omarchy-native-audio-bridge" in configure, "guest installs native host-audio integration")
     check(
-        'pacman_templates="$root/usr/share/omarchy/default/pacman"' in configure
-        and "for channel in stable rc edge" in configure
-        and "ARM pacman templates must not include multilib" in configure
+        "pre-refresh-pacman-restore-arm.sh" in configure
+        and "pre-refresh-pacman.d/restore-arm-pacman" in configure
+        and "for channel in stable rc edge" not in configure
         and "install -m 0644 /etc/pacman.d/mirrorlist" not in configure,
-        "omarchy-refresh-pacman templates stay on Arch Linux ARM",
+        "ARM pacman restore uses the pre-refresh-pacman hook, not Omarchy templates",
+    )
+    restore_hook = read(GUEST / "fragments/pre-refresh-pacman-restore-arm.sh")
+    check(
+        "install -m 0644 /usr/share/try-omarchy/pacman.conf /etc/pacman.conf" in restore_hook
+        and "install -m 0644 /usr/share/try-omarchy/mirrorlist /etc/pacman.d/mirrorlist"
+        in restore_hook,
+        "pre-refresh-pacman hook restores ARM pacman files from try-omarchy",
     )
     zram_override = read(
         GUEST
@@ -224,6 +231,7 @@ HOTPLUG=1
         display_sync,
         *GUEST.glob("*.sh"),
         *GUEST.glob("scripts/*.sh"),
+        *GUEST.glob("fragments/*.sh"),
     ]
     for path in sorted(shell_files):
         subprocess.run(["bash", "-n", str(path)], check=True)

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -51,6 +51,22 @@ def main() -> None:
     for path in spec["inputs"].values():
         check((GUEST / path).is_file(), f"spec input exists: {path}")
 
+    pacman_conf = read(GUEST / spec["inputs"]["pacmanConfig"])
+    check("[core]" in pacman_conf and "[alarm]" in pacman_conf, "factory pacman uses Arch Linux ARM repos")
+    check("[multilib]" not in pacman_conf, "factory pacman has no x86_64 multilib repo")
+    check(
+        "Server = https://stable-mirror.omarchy.org" not in pacman_conf
+        and "Server = https://pkgs.omarchy.org" not in pacman_conf,
+        "factory pacman does not use Omarchy x86_64 mirrors",
+    )
+    check("IgnorePkg = linux-aarch64" in pacman_conf, "factory pacman holds the QEMU-booted kernel")
+    arm_mirrorlist = read(GUEST / "mirrorlist.aarch64")
+    check(
+        "mirror.archlinuxarm.org/$arch/$repo" in arm_mirrorlist
+        and "stable-mirror.omarchy.org" not in arm_mirrorlist,
+        "factory mirrorlist is Arch Linux ARM",
+    )
+
     package_text = (GUEST / spec["inputs"]["packages"]).read_bytes()
     package_lock = json_file(GUEST / spec["inputs"]["packageLock"])
     check(package_lock.get("architecture") == "aarch64", "package lock is ARM64")
@@ -70,6 +86,13 @@ def main() -> None:
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")
     check("omarchy-native-audio-bridge" in configure, "guest installs native host-audio integration")
+    check(
+        'pacman_templates="$root/usr/share/omarchy/default/pacman"' in configure
+        and "for channel in stable rc edge" in configure
+        and "ARM pacman templates must not include multilib" in configure
+        and "install -m 0644 /etc/pacman.d/mirrorlist" not in configure,
+        "omarchy-refresh-pacman templates stay on Arch Linux ARM",
+    )
     zram_override = read(
         GUEST
         / "factory-overlay/etc/systemd/zram-generator.conf.d/99-try-omarchy.conf"


### PR DESCRIPTION
Fixes #2

`omarchy-refresh-pacman` overwrites `/etc/pacman.conf` and `/etc/pacman.d/mirrorlist` from `/usr/share/omarchy/default/pacman/`. Those templates were upstream x86_64 Omarchy files (`stable-mirror.omarchy.org`, `multilib`, `pkgs.omarchy.org/\$arch`).

On this guest that 404s: Arch Linux ARM has no `multilib`, and Omarchy does not publish `os/aarch64`. `pacman -Syy`, `omarchy update`, and the AUR installer then fail.

This change:

- Drops the x86_64 `[omarchy]` remote from the factory `pacman.aarch64.conf`
- Pins an Arch Linux ARM mirrorlist
- Replaces the `stable`/`rc`/`edge` templates so refresh keeps ARM mirrors and the local `try-omarchy` repo

The factory kernel stays `IgnorePkg = linux-aarch64` because QEMU boots an immutable kernel beside the disk.

Existing VMs that already ran `omarchy update` still have the x86_64 conf on disk. Factory reset, or copy the ARM templates back over `/etc/pacman.conf` and `/etc/pacman.d/mirrorlist`, then `pacman -Syy`.