### PR TITLE
Share the Mac clipboard with Omarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Try Omarchy is not official or affiliated with Omarchy.
 - Hardware-accelerated ARM64 virtualization and VirGL graphics
 - Resizable native window with automatic guest resolution and HiDPI scale updates
 - Mac audio input/output selection inside Omarchy, with live routing and system-default fallback
+- Two-way clipboard sharing for text and PNG images between macOS and Omarchy
 
 > **Current limitation:** Video decoding is CPU-only, so playback can be slow, especially at high resolutions. An improved video path is in development.
 
@@ -23,6 +24,13 @@ Try Omarchy is not official or affiliated with Omarchy.
 3. Launch **Try Omarchy** from Applications.
 
 Every launch begins at the start menu. Accessibility enables Mac Command-to-guest-Super shortcuts; microphone access is optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
+
+## Clipboard sharing
+
+Copy and paste work in both directions as soon as you sign in to Omarchy: text
+and PNG images copied on the Mac appear in the Omarchy clipboard, and content
+copied in Omarchy lands on the Mac pasteboard. Nothing is transferred until
+something is copied.
 
 ## Requirements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,8 +38,9 @@ port (`dev.tryomarchy.clipboard`) carries newline-delimited JSON between a
 Swift bridge on the Mac, which watches the `NSPasteboard` change count, and a
 Python agent in the Omarchy session, which uses wl-clipboard's data-control
 protocol. Text and PNG payloads flow both ways; each side remembers the
-fingerprint of what it last wrote for a couple of seconds so the immediate
-echo is dropped while a later genuine repeat of the same content still flows.
+fingerprint of what it last wrote so the immediate echo is dropped. The marker
+is cleared as soon as the other side moves on to new content, and expires after
+a couple of seconds regardless, so a genuine repeat of the same content still flows.
 
 ## The ARM64 image
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,13 @@ inside Linux. Graphics travel from Linux through virtio-gpu and VirGL to the
 native Cocoa window. Storage, networking, audio, and input use their matching
 QEMU virtual devices and host backends.
 
+One small host-integration channel sits beside those devices. A virtio-serial
+port (`dev.tryomarchy.clipboard`) carries newline-delimited JSON between a
+Swift bridge on the Mac, which watches the `NSPasteboard` change count, and a
+Python agent in the Omarchy session, which uses wl-clipboard's data-control
+protocol. Text and PNG payloads flow both ways; each side remembers the
+fingerprint of what it last wrote so an update is never echoed back.
+
 ## The ARM64 image
 
 The guest image is built by this project; it is not an official prebuilt image

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,8 @@ port (`dev.tryomarchy.clipboard`) carries newline-delimited JSON between a
 Swift bridge on the Mac, which watches the `NSPasteboard` change count, and a
 Python agent in the Omarchy session, which uses wl-clipboard's data-control
 protocol. Text and PNG payloads flow both ways; each side remembers the
-fingerprint of what it last wrote so an update is never echoed back.
+fingerprint of what it last wrote for a couple of seconds so the immediate
+echo is dropped while a later genuine repeat of the same content still flows.
 
 ## The ARM64 image
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,7 +33,8 @@ make release \
 1. Confirm `main` is clean and all pinned inputs have reviewable provenance.
 2. Run all tests and perform a first-boot provisioning test on a clean Mac user.
 3. Verify networking, display scaling, keyboard/mouse, microphone permission,
-   audio-device changes, persistence, reset, and ephemeral mode.
+   audio-device changes, clipboard sharing in both directions, persistence,
+   reset, and ephemeral mode.
 4. Verify the app and DMG signatures with Apple's tools and confirm notarization.
 5. Audit `THIRD_PARTY_NOTICES.md`, the bundle's license material, the guest
    package lock, and QEMU corresponding-source obligations.

--- a/guest/native-overlay/etc/udev/rules.d/92-omarchy-native-clipboard.rules
+++ b/guest/native-overlay/etc/udev/rules.d/92-omarchy-native-clipboard.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="virtio-ports", ATTR{name}=="dev.tryomarchy.clipboard", GROUP="users", MODE="0660"

--- a/guest/native-overlay/usr/lib/systemd/user/omarchy-native-clipboard-bridge.service
+++ b/guest/native-overlay/usr/lib/systemd/user/omarchy-native-clipboard-bridge.service
@@ -3,6 +3,9 @@ Description=Share the macOS clipboard with Omarchy
 PartOf=graphical-session.target
 After=graphical-session.target
 ConditionPathExists=/dev/virtio-ports/dev.tryomarchy.clipboard
+# The agent exits non-zero whenever the host bridge disconnects; keep
+# retrying for as long as the launcher keeps restarting that bridge.
+StartLimitIntervalSec=0
 
 [Service]
 ExecStart=/usr/local/bin/omarchy-native-clipboard-bridge

--- a/guest/native-overlay/usr/lib/systemd/user/omarchy-native-clipboard-bridge.service
+++ b/guest/native-overlay/usr/lib/systemd/user/omarchy-native-clipboard-bridge.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Share the macOS clipboard with Omarchy
+PartOf=graphical-session.target
+After=graphical-session.target
+ConditionPathExists=/dev/virtio-ports/dev.tryomarchy.clipboard
+
+[Service]
+ExecStart=/usr/local/bin/omarchy-native-clipboard-bridge
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=graphical-session.target

--- a/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
@@ -89,10 +89,13 @@ def decode_message(line: bytes) -> tuple[str, bytes] | None:
 class ClipboardSync:
     """Echo-safe two-way state shared by the tests and the live agent.
 
-    Each direction remembers the fingerprint of its last write for a short
-    window. Without the expiry a marker would outlive the content it
-    protects: guest copies B, Mac copies A, Mac copies B again, and the final
-    B would be mistaken for the original echo and lost.
+    A marker only protects content that is still on the other side's
+    clipboard. Accepting a new change in one direction therefore clears the
+    other direction's marker: after guest copies B and Mac copies A, the Mac
+    pasteboard no longer holds B, so a later Mac copy of B is new content and
+    must not be mistaken for the original echo. Echoes are delivered in order
+    before any later user copy, so clearing cannot let one through. A short
+    expiry backs this up for markers that never see an opposite change.
     """
 
     def __init__(self, send: Any, copy: Any, clock: Any = time.monotonic) -> None:
@@ -117,6 +120,7 @@ class ClipboardSync:
         if self._is_echo(self.last_from_host, key, now):
             return False
         self.last_from_guest = (key, now)
+        self.last_from_host = None
         self.send(encode_message(mime, payload))
         return True
 
@@ -127,6 +131,7 @@ class ClipboardSync:
         if self._is_echo(self.last_from_guest, key, now):
             return False
         self.last_from_host = (key, now)
+        self.last_from_guest = None
         self.copy(mime, payload)
         return True
 

--- a/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
@@ -1,0 +1,287 @@
+#!/usr/bin/python3
+"""Share the Wayland clipboard with the macOS pasteboard over a virtio port.
+
+Both directions travel as one JSON object per line on the
+dev.tryomarchy.clipboard virtserialport:
+
+    {"type": "clipboard", "format": "<mime>", "data": "<base64>"}
+
+The host answers {"type": "sync"} with its current pasteboard. Text and PNG
+images are supported. wl-clipboard's data-control protocol lets this agent
+observe and replace the Hyprland selection without holding keyboard focus.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import select
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+PORT = Path("/dev/virtio-ports/dev.tryomarchy.clipboard")
+TEXT_FORMAT = "text/plain;charset=utf-8"
+PNG_FORMAT = "image/png"
+FORMATS = (TEXT_FORMAT, PNG_FORMAT)
+# Payload bytes before base64. Large enough for screenshots and pasted
+# documents, small enough that a runaway selection cannot exhaust memory.
+MAX_PAYLOAD_BYTES = 16 * 1024 * 1024
+MAX_LINE_BYTES = MAX_PAYLOAD_BYTES * 4 // 3 + 4096
+TEXT_TYPES = ("text/plain;charset=utf-8", "text/plain", "UTF8_STRING", "TEXT", "STRING")
+
+
+def log(message: str) -> None:
+    print(f"omarchy-native-clipboard-bridge: {message}", file=sys.stderr, flush=True)
+
+
+def fingerprint(mime: str, payload: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(mime.encode())
+    digest.update(b"\0")
+    digest.update(payload)
+    return digest.hexdigest()
+
+
+def encode_message(mime: str, payload: bytes) -> bytes:
+    message = {
+        "type": "clipboard",
+        "format": mime,
+        "data": base64.b64encode(payload).decode("ascii"),
+    }
+    return json.dumps(message, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+
+
+def decode_message(line: bytes) -> tuple[str, bytes] | None:
+    """Return (mime, payload) for a host clipboard line, or None to ignore."""
+    message = json.loads(line)
+    if not isinstance(message, dict) or message.get("type") != "clipboard":
+        raise ValueError("host sent an invalid clipboard message")
+    if set(message) != {"type", "format", "data"}:
+        raise ValueError("host clipboard message has an unexpected schema")
+    mime = message["format"]
+    data = message["data"]
+    if mime not in FORMATS or not isinstance(data, str):
+        return None
+    try:
+        payload = base64.b64decode(data, validate=True)
+    except ValueError as error:
+        raise ValueError("host clipboard payload is not base64") from error
+    if not payload or len(payload) > MAX_PAYLOAD_BYTES:
+        return None
+    if mime == TEXT_FORMAT:
+        try:
+            payload.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    return mime, payload
+
+
+class ClipboardSync:
+    """Echo-safe two-way state shared by the tests and the live agent."""
+
+    def __init__(self, send: Any, copy: Any) -> None:
+        self.send = send
+        self.copy = copy
+        self.last_from_host: str | None = None
+        self.last_from_guest: str | None = None
+
+    def guest_changed(self, mime: str, payload: bytes) -> bool:
+        """Forward a new guest selection to the host. Returns True if sent."""
+        if mime not in FORMATS or not payload or len(payload) > MAX_PAYLOAD_BYTES:
+            return False
+        key = fingerprint(mime, payload)
+        # wl-copy re-announces whatever the host just wrote; only that echo
+        # is dropped. A repeat of earlier guest content is a real change.
+        if key == self.last_from_host:
+            return False
+        self.last_from_guest = key
+        self.send(encode_message(mime, payload))
+        return True
+
+    def host_changed(self, mime: str, payload: bytes) -> bool:
+        """Apply a host pasteboard update to the guest. Returns True if applied."""
+        key = fingerprint(mime, payload)
+        if key == self.last_from_guest:
+            return False
+        self.last_from_host = key
+        self.copy(mime, payload)
+        return True
+
+
+def wl_paste_selection() -> tuple[str, bytes] | None:
+    """Read the current Wayland selection as (mime, payload)."""
+    listing = subprocess.run(
+        ["wl-paste", "--list-types"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    if listing.returncode != 0:
+        return None
+    offered = listing.stdout.split()
+    if any(kind in offered for kind in TEXT_TYPES):
+        requested = next(kind for kind in TEXT_TYPES if kind in offered)
+        mime = TEXT_FORMAT
+    elif PNG_FORMAT in offered:
+        requested = PNG_FORMAT
+        mime = PNG_FORMAT
+    else:
+        return None
+    content = subprocess.run(
+        ["wl-paste", "--no-newline", "--type", requested],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+        check=False,
+    )
+    if content.returncode != 0 or not content.stdout:
+        return None
+    payload = content.stdout
+    if mime == TEXT_FORMAT:
+        try:
+            payload.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    return mime, payload
+
+
+def emit_selection() -> int:
+    """`wl-paste --watch` callback: print the selection as one text line."""
+    selection = wl_paste_selection()
+    if selection is None:
+        return 0
+    mime, payload = selection
+    sys.stdout.write(f"{mime}\t{base64.b64encode(payload).decode('ascii')}\n")
+    sys.stdout.flush()
+    return 0
+
+
+def wl_copy(mime: str, payload: bytes) -> None:
+    # wl-copy forks a background owner that serves the selection until the
+    # next change, so the agent does not need to keep the process around.
+    subprocess.run(
+        ["wl-copy", "--type", mime],
+        input=payload,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+        check=False,
+    )
+
+
+def open_port() -> int:
+    while True:
+        try:
+            return os.open(PORT, os.O_RDWR | os.O_CLOEXEC | os.O_NOCTTY)
+        except FileNotFoundError:
+            time.sleep(1)
+
+
+def parse_watch_line(line: bytes) -> tuple[str, bytes] | None:
+    mime, separator, encoded = line.partition(b"\t")
+    if not separator:
+        return None
+    try:
+        payload = base64.b64decode(encoded, validate=True)
+    except ValueError:
+        return None
+    decoded_mime = mime.decode("ascii", "replace")
+    if decoded_mime not in FORMATS or not payload:
+        return None
+    return decoded_mime, payload
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--emit":
+        return emit_selection()
+
+    if not os.environ.get("WAYLAND_DISPLAY"):
+        log("no Wayland display; waiting for the graphical session")
+        return 1
+    for tool in ("wl-paste", "wl-copy"):
+        if shutil.which(tool) is None:
+            log(f"{tool} is unavailable")
+            return 1
+
+    descriptor = open_port()
+
+    def send(payload: bytes) -> None:
+        offset = 0
+        while offset < len(payload):
+            offset += os.write(descriptor, payload[offset:])
+
+    sync = ClipboardSync(send, wl_copy)
+    watcher = subprocess.Popen(
+        ["wl-paste", "--watch", os.path.realpath(sys.argv[0]), "--emit"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    assert watcher.stdout is not None
+    watch_fd = watcher.stdout.fileno()
+    os.set_blocking(watch_fd, False)
+
+    port_buffer = bytearray()
+    watch_buffer = bytearray()
+    send(json.dumps({"type": "sync"}, separators=(",", ":")).encode() + b"\n")
+    try:
+        while True:
+            ready, _, _ = select.select([descriptor, watch_fd], [], [], 1.0)
+            if watcher.poll() is not None:
+                raise RuntimeError("wl-paste watcher exited")
+            if descriptor in ready:
+                chunk = os.read(descriptor, 65536)
+                if not chunk:
+                    return 0
+                port_buffer.extend(chunk)
+                if len(port_buffer) > MAX_LINE_BYTES:
+                    raise RuntimeError("host clipboard message exceeds the size limit")
+                while b"\n" in port_buffer:
+                    line, _, remainder = port_buffer.partition(b"\n")
+                    port_buffer = bytearray(remainder)
+                    decoded = decode_message(line)
+                    if decoded is not None:
+                        sync.host_changed(*decoded)
+            if watch_fd in ready:
+                try:
+                    chunk = os.read(watch_fd, 65536)
+                except BlockingIOError:
+                    chunk = b""
+                if chunk:
+                    watch_buffer.extend(chunk)
+                    if len(watch_buffer) > MAX_LINE_BYTES:
+                        log("guest selection exceeds the size limit; skipping")
+                        watch_buffer = bytearray()
+                    while b"\n" in watch_buffer:
+                        line, _, remainder = watch_buffer.partition(b"\n")
+                        watch_buffer = bytearray(remainder)
+                        parsed = parse_watch_line(line)
+                        if parsed is not None:
+                            sync.guest_changed(*parsed)
+    finally:
+        if watcher.poll() is None:
+            watcher.terminate()
+            try:
+                watcher.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                watcher.kill()
+        os.close(descriptor)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as error:
+        log(str(error))
+        raise SystemExit(1)

--- a/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-clipboard-bridge
@@ -34,6 +34,9 @@ FORMATS = (TEXT_FORMAT, PNG_FORMAT)
 # documents, small enough that a runaway selection cannot exhaust memory.
 MAX_PAYLOAD_BYTES = 16 * 1024 * 1024
 MAX_LINE_BYTES = MAX_PAYLOAD_BYTES * 4 // 3 + 4096
+# An echo follows its write within milliseconds; a marker older than this
+# no longer protects anything and must not swallow a genuine repeat.
+ECHO_WINDOW_SECONDS = 2.0
 TEXT_TYPES = ("text/plain;charset=utf-8", "text/plain", "UTF8_STRING", "TEXT", "STRING")
 
 
@@ -84,35 +87,73 @@ def decode_message(line: bytes) -> tuple[str, bytes] | None:
 
 
 class ClipboardSync:
-    """Echo-safe two-way state shared by the tests and the live agent."""
+    """Echo-safe two-way state shared by the tests and the live agent.
 
-    def __init__(self, send: Any, copy: Any) -> None:
+    Each direction remembers the fingerprint of its last write for a short
+    window. Without the expiry a marker would outlive the content it
+    protects: guest copies B, Mac copies A, Mac copies B again, and the final
+    B would be mistaken for the original echo and lost.
+    """
+
+    def __init__(self, send: Any, copy: Any, clock: Any = time.monotonic) -> None:
         self.send = send
         self.copy = copy
-        self.last_from_host: str | None = None
-        self.last_from_guest: str | None = None
+        self.clock = clock
+        self.last_from_host: tuple[str, float] | None = None
+        self.last_from_guest: tuple[str, float] | None = None
+
+    @staticmethod
+    def _is_echo(marker: tuple[str, float] | None, key: str, now: float) -> bool:
+        return marker is not None and marker[0] == key and now - marker[1] <= ECHO_WINDOW_SECONDS
 
     def guest_changed(self, mime: str, payload: bytes) -> bool:
         """Forward a new guest selection to the host. Returns True if sent."""
         if mime not in FORMATS or not payload or len(payload) > MAX_PAYLOAD_BYTES:
             return False
         key = fingerprint(mime, payload)
+        now = self.clock()
         # wl-copy re-announces whatever the host just wrote; only that echo
         # is dropped. A repeat of earlier guest content is a real change.
-        if key == self.last_from_host:
+        if self._is_echo(self.last_from_host, key, now):
             return False
-        self.last_from_guest = key
+        self.last_from_guest = (key, now)
         self.send(encode_message(mime, payload))
         return True
 
     def host_changed(self, mime: str, payload: bytes) -> bool:
         """Apply a host pasteboard update to the guest. Returns True if applied."""
         key = fingerprint(mime, payload)
-        if key == self.last_from_guest:
+        now = self.clock()
+        if self._is_echo(self.last_from_guest, key, now):
             return False
-        self.last_from_host = key
+        self.last_from_host = (key, now)
         self.copy(mime, payload)
         return True
+
+
+def read_bounded(descriptor: int, limit: int, timeout: float) -> bytes | None:
+    """Read a pipe until EOF in bounded chunks.
+
+    Returns None once more than `limit` bytes arrive or `timeout` seconds
+    pass, so an enormous selection is never held in memory in full.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        ready, _, _ = select.select([descriptor], [], [], remaining)
+        if not ready:
+            return None
+        chunk = os.read(descriptor, min(65536, limit + 1 - total))
+        if not chunk:
+            return b"".join(chunks)
+        total += len(chunk)
+        if total > limit:
+            return None
+        chunks.append(chunk)
 
 
 def wl_paste_selection() -> tuple[str, bytes] | None:
@@ -137,17 +178,27 @@ def wl_paste_selection() -> tuple[str, bytes] | None:
         mime = PNG_FORMAT
     else:
         return None
-    content = subprocess.run(
+    # Stream the selection through a pipe and stop as soon as it passes the
+    # payload limit, before base64 or JSON ever see it.
+    with subprocess.Popen(
         ["wl-paste", "--no-newline", "--type", requested],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
-        timeout=15,
-        check=False,
-    )
-    if content.returncode != 0 or not content.stdout:
+    ) as content:
+        assert content.stdout is not None
+        payload = None
+        try:
+            payload = read_bounded(content.stdout.fileno(), MAX_PAYLOAD_BYTES, 15)
+        finally:
+            if payload is None:
+                content.kill()
+        content.wait()
+    if payload is None:
+        log("guest selection is too large or too slow; skipping")
         return None
-    payload = content.stdout
+    if content.returncode != 0 or not payload:
+        return None
     if mime == TEXT_FORMAT:
         try:
             payload.decode("utf-8")
@@ -243,7 +294,10 @@ def main() -> int:
             if descriptor in ready:
                 chunk = os.read(descriptor, 65536)
                 if not chunk:
-                    return 0
+                    # QEMU reports EOF when the Mac side of the port goes away.
+                    # Exit non-zero so systemd restarts this agent and it can
+                    # re-sync once the launcher brings the host bridge back.
+                    raise RuntimeError("host clipboard bridge disconnected")
                 port_buffer.extend(chunk)
                 if len(port_buffer) > MAX_LINE_BYTES:
                     raise RuntimeError("host clipboard message exceeds the size limit")

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -66,10 +66,12 @@ install -m 0755 "$guest_dir/compat/ttfx-arm64" "$root/usr/local/bin/ttfx"
 # also carries one deliberate command replacement for safe PipeWire input
 # switching. The display fragment selects Cocoa's host-composited cursor path
 # and keeps the guest mode synchronized when QEMU changes the virtual EDID.
+# The clipboard bridge mirrors the Mac pasteboard into the Wayland session.
 cp -a "$guest_dir/native-overlay/." "$root/"
 chmod 0755 \
   "$root/usr/bin/omarchy-audio-input-set-default" \
   "$root/usr/local/bin/omarchy-native-audio-bridge" \
+  "$root/usr/local/bin/omarchy-native-clipboard-bridge" \
   "$root/usr/local/bin/omarchy-native-display-sync"
 audio_helper_source_digest=$(sha256sum \
   "$guest_dir/native-overlay/usr/bin/omarchy-audio-input-set-default")
@@ -79,9 +81,14 @@ audio_helper_installed_digest=$(sha256sum \
 audio_helper_installed_digest=${audio_helper_installed_digest%% *}
 [[ $audio_helper_installed_digest == "$audio_helper_source_digest" ]] || \
   fail "native audio input helper did not replace the upstream command"
-mkdir -p "$root/etc/systemd/user/default.target.wants"
+mkdir -p "$root/etc/systemd/user/default.target.wants" \
+  "$root/etc/systemd/user/graphical-session.target.wants"
 ln -sfn /usr/lib/systemd/user/omarchy-native-audio-bridge.service \
   "$root/etc/systemd/user/default.target.wants/omarchy-native-audio-bridge.service"
+# The clipboard agent needs the Wayland socket, so it follows the uwsm-managed
+# graphical session rather than the plain user manager.
+ln -sfn /usr/lib/systemd/user/omarchy-native-clipboard-bridge.service \
+  "$root/etc/systemd/user/graphical-session.target.wants/omarchy-native-clipboard-bridge.service"
 cat "$guest_dir/fragments/hypr-monitors-arm-qemu.append.lua" >>"$root/etc/skel/.config/hypr/monitors.lua"
 
 hostname=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["guest"]["hostname"])' "$spec")

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -130,6 +130,14 @@
       "fallback": "full-copy",
       "expandedSizeMiB": 24576
     },
+    "clipboard": {
+      "device": "virtserialport",
+      "port": "dev.tryomarchy.clipboard",
+      "formats": [
+        "text/plain;charset=utf-8",
+        "image/png"
+      ]
+    },
     "devices": [
       "virtio-blk-pci",
       "virtio-gpu-gl-pci",

--- a/guest/tests/test_native_clipboard_bridge.py
+++ b/guest/tests/test_native_clipboard_bridge.py
@@ -111,22 +111,35 @@ class ClipboardSyncTests(unittest.TestCase):
         self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"from mac"))
         self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"from mac"))
 
+    def test_opposite_change_clears_the_echo_marker(self) -> None:
+        clock = [0.0]
+        recorder = Recorder()
+        sync = bridge.ClipboardSync(recorder.send, recorder.copy, clock=lambda: clock[0])
+
+        # Guest copies B, the Mac copies A, then the Mac copies B right away.
+        # The final B is new content, not an echo of the guest's write.
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"A"))
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"B"))
+        self.assertEqual([payload for _, payload in recorder.copied], [b"A", b"B"])
+
+        # Mirror image: Mac copies C, guest copies D, guest copies C again.
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"C"))
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"C"))  # the wl-copy echo
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"D"))
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"C"))
+        self.assertEqual(len(recorder.sent), 3)
+
     def test_echo_markers_expire(self) -> None:
         clock = [0.0]
         recorder = Recorder()
         sync = bridge.ClipboardSync(recorder.send, recorder.copy, clock=lambda: clock[0])
 
-        # Guest copies B, the Mac copies A, then the Mac copies B again well
-        # after the guest's write. The final B is new content, not an echo.
-        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
-        clock[0] += bridge.ECHO_WINDOW_SECONDS + 1
-        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"A"))
         self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"B"))
-        self.assertEqual([payload for _, payload in recorder.copied], [b"A", b"B"])
-
-        # Inside the window the mirrored write is still recognized as an echo.
+        # Inside the window the mirrored write is recognized as an echo.
         clock[0] += 0.1
         self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
+        # Long after, the same content from the guest is a real change.
         clock[0] += bridge.ECHO_WINDOW_SECONDS + 1
         self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
 

--- a/guest/tests/test_native_clipboard_bridge.py
+++ b/guest/tests/test_native_clipboard_bridge.py
@@ -7,6 +7,7 @@ import base64
 import importlib.util
 from importlib.machinery import SourceFileLoader
 import json
+import os
 from pathlib import Path
 import unittest
 
@@ -110,6 +111,25 @@ class ClipboardSyncTests(unittest.TestCase):
         self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"from mac"))
         self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"from mac"))
 
+    def test_echo_markers_expire(self) -> None:
+        clock = [0.0]
+        recorder = Recorder()
+        sync = bridge.ClipboardSync(recorder.send, recorder.copy, clock=lambda: clock[0])
+
+        # Guest copies B, the Mac copies A, then the Mac copies B again well
+        # after the guest's write. The final B is new content, not an echo.
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
+        clock[0] += bridge.ECHO_WINDOW_SECONDS + 1
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"A"))
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"B"))
+        self.assertEqual([payload for _, payload in recorder.copied], [b"A", b"B"])
+
+        # Inside the window the mirrored write is still recognized as an echo.
+        clock[0] += 0.1
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
+        clock[0] += bridge.ECHO_WINDOW_SECONDS + 1
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"B"))
+
     def test_unsupported_or_oversized_guest_selections_are_dropped(self) -> None:
         recorder = Recorder()
         sync = bridge.ClipboardSync(recorder.send, recorder.copy)
@@ -117,6 +137,32 @@ class ClipboardSyncTests(unittest.TestCase):
         self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b""))
         self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"x" * (bridge.MAX_PAYLOAD_BYTES + 1)))
         self.assertEqual(recorder.sent, [])
+
+
+class BoundedReadTests(unittest.TestCase):
+    def read_pipe(self, payload: bytes, limit: int) -> bytes | None:
+        reader, writer = os.pipe()
+        try:
+            with os.fdopen(writer, "wb") as sink:
+                sink.write(payload)
+            return bridge.read_bounded(reader, limit, 5)
+        finally:
+            os.close(reader)
+
+    def test_reads_selection_within_limit(self) -> None:
+        self.assertEqual(self.read_pipe(b"x" * 1000, 1000), b"x" * 1000)
+        self.assertEqual(self.read_pipe(b"", 1000), b"")
+
+    def test_rejects_oversized_selection_without_buffering_it(self) -> None:
+        self.assertIsNone(self.read_pipe(b"x" * 1001, 1000))
+
+    def test_gives_up_on_a_silent_writer(self) -> None:
+        reader, writer = os.pipe()
+        try:
+            self.assertIsNone(bridge.read_bounded(reader, 1000, 0.05))
+        finally:
+            os.close(reader)
+            os.close(writer)
 
 
 if __name__ == "__main__":

--- a/guest/tests/test_native_clipboard_bridge.py
+++ b/guest/tests/test_native_clipboard_bridge.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Behavior tests for the guest side of macOS clipboard sharing."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+from importlib.machinery import SourceFileLoader
+import json
+from pathlib import Path
+import unittest
+
+
+BRIDGE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "native-overlay/usr/local/bin/omarchy-native-clipboard-bridge"
+)
+LOADER = SourceFileLoader("omarchy_native_clipboard_bridge", str(BRIDGE_PATH))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot import {BRIDGE_PATH}")
+bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bridge)
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.copied: list[tuple[str, bytes]] = []
+
+    def send(self, payload: bytes) -> None:
+        self.sent.append(payload)
+
+    def copy(self, mime: str, payload: bytes) -> None:
+        self.copied.append((mime, payload))
+
+
+class MessageCodingTests(unittest.TestCase):
+    def test_encode_matches_host_schema(self) -> None:
+        line = bridge.encode_message(bridge.TEXT_FORMAT, "héllo\n".encode())
+        self.assertTrue(line.endswith(b"\n"))
+        self.assertEqual(
+            json.loads(line),
+            {"type": "clipboard", "format": "text/plain;charset=utf-8", "data": "aMOpbGxvCg=="},
+        )
+        self.assertEqual(
+            line,
+            b'{"data":"aMOpbGxvCg==","format":"text/plain;charset=utf-8","type":"clipboard"}\n',
+        )
+
+    def test_decode_accepts_supported_formats_only(self) -> None:
+        png = b"\x89PNG\r\n"
+        line = json.dumps(
+            {"type": "clipboard", "format": "image/png", "data": base64.b64encode(png).decode()}
+        ).encode()
+        self.assertEqual(bridge.decode_message(line), ("image/png", png))
+        html = json.dumps({"type": "clipboard", "format": "text/html", "data": "AAAA"}).encode()
+        self.assertIsNone(bridge.decode_message(html))
+        empty = json.dumps({"type": "clipboard", "format": "image/png", "data": ""}).encode()
+        self.assertIsNone(bridge.decode_message(empty))
+        bad_utf8 = json.dumps(
+            {"type": "clipboard", "format": bridge.TEXT_FORMAT, "data": base64.b64encode(b"\xff\xfe").decode()}
+        ).encode()
+        self.assertIsNone(bridge.decode_message(bad_utf8))
+
+    def test_decode_rejects_malformed_messages(self) -> None:
+        for line in (
+            b'{"type":"catalog"}',
+            b'{"type":"clipboard","format":"image/png"}',
+            b'{"type":"clipboard","format":"image/png","data":"%%%"}',
+            b'{"type":"clipboard","format":"image/png","data":"AAAA","extra":1}',
+            b"[]",
+        ):
+            with self.assertRaises(ValueError):
+                bridge.decode_message(line)
+
+    def test_watch_lines_parse_format_and_payload(self) -> None:
+        encoded = base64.b64encode(b"copied").decode()
+        self.assertEqual(
+            bridge.parse_watch_line(f"{bridge.TEXT_FORMAT}\t{encoded}".encode()),
+            (bridge.TEXT_FORMAT, b"copied"),
+        )
+        self.assertIsNone(bridge.parse_watch_line(b"no separator"))
+        self.assertIsNone(bridge.parse_watch_line(f"text/html\t{encoded}".encode()))
+        self.assertIsNone(bridge.parse_watch_line(f"{bridge.TEXT_FORMAT}\t".encode()))
+
+
+class ClipboardSyncTests(unittest.TestCase):
+    def test_echoes_are_suppressed_in_both_directions(self) -> None:
+        recorder = Recorder()
+        sync = bridge.ClipboardSync(recorder.send, recorder.copy)
+
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"from mac"))
+        self.assertEqual(recorder.copied, [(bridge.TEXT_FORMAT, b"from mac")])
+        # wl-copy re-announces the selection through wl-paste --watch.
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"from mac"))
+        self.assertEqual(recorder.sent, [])
+
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"from guest"))
+        self.assertEqual(json.loads(recorder.sent[-1])["data"], base64.b64encode(b"from guest").decode())
+        # The host applies it to the pasteboard and must not send it back.
+        self.assertFalse(sync.host_changed(bridge.TEXT_FORMAT, b"from guest"))
+        self.assertEqual(len(recorder.copied), 1)
+
+        self.assertTrue(sync.host_changed(bridge.PNG_FORMAT, b"\x89PNG"))
+        self.assertEqual(recorder.copied[-1], (bridge.PNG_FORMAT, b"\x89PNG"))
+        self.assertFalse(sync.guest_changed(bridge.PNG_FORMAT, b"\x89PNG"))
+        # Copying earlier guest content again is a real change once the host moved on.
+        self.assertTrue(sync.guest_changed(bridge.TEXT_FORMAT, b"from guest"))
+        self.assertTrue(sync.host_changed(bridge.TEXT_FORMAT, b"from mac"))
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"from mac"))
+
+    def test_unsupported_or_oversized_guest_selections_are_dropped(self) -> None:
+        recorder = Recorder()
+        sync = bridge.ClipboardSync(recorder.send, recorder.copy)
+        self.assertFalse(sync.guest_changed("text/html", b"<b>x</b>"))
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b""))
+        self.assertFalse(sync.guest_changed(bridge.TEXT_FORMAT, b"x" * (bridge.MAX_PAYLOAD_BYTES + 1)))
+        self.assertEqual(recorder.sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -70,6 +70,14 @@ def main() -> None:
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")
     check("omarchy-native-audio-bridge" in configure, "guest installs native host-audio integration")
+    check(
+        "graphical-session.target.wants/omarchy-native-clipboard-bridge.service" in configure,
+        "guest starts clipboard sharing with the graphical session",
+    )
+    check(
+        spec["runtime"]["clipboard"]["port"] == "dev.tryomarchy.clipboard",
+        "clipboard contract names the virtio port",
+    )
     zram_override = read(
         GUEST
         / "factory-overlay/etc/systemd/zram-generator.conf.d/99-try-omarchy.conf"
@@ -99,6 +107,23 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as temporary:
         py_compile.compile(str(audio_bridge), cfile=str(Path(temporary) / "audio.pyc"), doraise=True)
     check(True, "native audio bridge compiles")
+
+    clipboard_bridge = GUEST / "native-overlay/usr/local/bin/omarchy-native-clipboard-bridge"
+    check(clipboard_bridge.stat().st_mode & stat.S_IXUSR != 0, "native clipboard bridge is executable")
+    with tempfile.TemporaryDirectory() as temporary:
+        py_compile.compile(str(clipboard_bridge), cfile=str(Path(temporary) / "clipboard.pyc"), doraise=True)
+    check(True, "native clipboard bridge compiles")
+    clipboard_unit = read(GUEST / "native-overlay/usr/lib/systemd/user/omarchy-native-clipboard-bridge.service")
+    check(
+        "PartOf=graphical-session.target" in clipboard_unit
+        and "ConditionPathExists=/dev/virtio-ports/dev.tryomarchy.clipboard" in clipboard_unit,
+        "clipboard bridge follows the graphical session and its virtio port",
+    )
+    clipboard_rule = read(GUEST / "native-overlay/etc/udev/rules.d/92-omarchy-native-clipboard.rules")
+    check(
+        'ATTR{name}=="dev.tryomarchy.clipboard"' in clipboard_rule and 'GROUP="users"' in clipboard_rule,
+        "clipboard port is readable by the provisioned users group",
+    )
 
     audio_input_helper = GUEST / "native-overlay/usr/bin/omarchy-audio-input-set-default"
     check(audio_input_helper.stat().st_mode & stat.S_IXUSR != 0, "native audio input helper is executable")

--- a/macos/README.md
+++ b/macos/README.md
@@ -4,7 +4,7 @@ This directory contains the Apple Silicon application layer:
 
 - a Swift/AppKit lifecycle and permission helper;
 - a pinned, patched QEMU ARM64 runtime using HVF and Cocoa/VirGL;
-- persistent-disk, input, audio-device, signing, and DMG tooling.
+- persistent-disk, input, audio-device, clipboard, signing, and DMG tooling.
 
 Use the root Makefile for normal development:
 

--- a/macos/Sources/OmarchyVMHelper/NativeAudioBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeAudioBridge.swift
@@ -186,7 +186,7 @@ final class NativeAudioBridge {
               processIdentity.isQEMUSystemProcess else {
             throw HelperError.io("native audio bridge target is not a QEMU system process")
         }
-        descriptor = try Self.connectSecureSocket(path: socketPath)
+        descriptor = try NativeBridgeSocket.connectSecure(path: socketPath, label: "audio bridge")
         self.deviceProvider = deviceProvider
         self.preferenceStore = preferenceStore
         routeStore = try NativeAudioRouteFileStore(directoryPath: routeDirectoryPath)
@@ -309,75 +309,7 @@ final class NativeAudioBridge {
             preferences: preferenceStore.load()
         )
         try writeQueue.sync {
-            try data.withUnsafeBytes { buffer in
-                guard let base = buffer.baseAddress else { return }
-                var offset = 0
-                while offset < buffer.count {
-                    let count = Darwin.write(descriptor, base.advanced(by: offset), buffer.count - offset)
-                    if count > 0 {
-                        offset += count
-                    } else if count < 0 && errno == EINTR {
-                        continue
-                    } else {
-                        throw HelperError.io("cannot write the guest audio channel")
-                    }
-                }
-            }
+            try NativeBridgeSocket.writeAll(data, to: descriptor, label: "audio")
         }
-    }
-
-    private static func connectSecureSocket(path: String) throws -> Int32 {
-        guard path.hasPrefix("/"), !path.utf8.contains(0) else {
-            throw HelperError.io("audio bridge socket path must be an absolute pathname")
-        }
-        let url = URL(fileURLWithPath: path).standardizedFileURL
-        guard url.path == path else {
-            throw HelperError.io("audio bridge socket path must already be standardized")
-        }
-        let parent = url.deletingLastPathComponent()
-        var parentInfo = stat()
-        var socketInfo = stat()
-        guard lstat(parent.path, &parentInfo) == 0,
-              (parentInfo.st_mode & S_IFMT) == S_IFDIR,
-              parentInfo.st_uid == getuid(),
-              (parentInfo.st_mode & 0o077) == 0,
-              lstat(path, &socketInfo) == 0,
-              (socketInfo.st_mode & S_IFMT) == S_IFSOCK,
-              socketInfo.st_uid == getuid() else {
-            throw HelperError.io("audio bridge endpoint must be a private owned Unix socket")
-        }
-
-        let pathBytes = Array(path.utf8)
-        var address = sockaddr_un()
-        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
-            throw HelperError.io("audio bridge socket path is too long")
-        }
-        address.sun_family = sa_family_t(AF_UNIX)
-        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
-            buffer.initializeMemory(as: UInt8.self, repeating: 0)
-            buffer.copyBytes(from: pathBytes)
-        }
-        let socketDescriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
-        guard socketDescriptor >= 0 else { throw HelperError.io("cannot create audio bridge socket") }
-        var noSignal: Int32 = 1
-        guard withUnsafePointer(to: &noSignal, {
-            setsockopt(socketDescriptor, SOL_SOCKET, SO_NOSIGPIPE, $0, socklen_t(MemoryLayout<Int32>.size))
-        }) == 0 else {
-            Darwin.close(socketDescriptor)
-            throw HelperError.io("cannot configure audio bridge socket")
-        }
-        let offset = MemoryLayout.offset(of: \sockaddr_un.sun_path) ?? 0
-        let length = socklen_t(offset + pathBytes.count + 1)
-        let result = withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                Darwin.connect(socketDescriptor, $0, length)
-            }
-        }
-        guard result == 0 else {
-            let detail = String(cString: strerror(errno))
-            Darwin.close(socketDescriptor)
-            throw HelperError.io("cannot connect to audio bridge socket: \(detail)")
-        }
-        return socketDescriptor
     }
 }

--- a/macos/Sources/OmarchyVMHelper/NativeBridgeSocket.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeBridgeSocket.swift
@@ -1,0 +1,80 @@
+import Darwin
+import Foundation
+
+/// Connects the helper to one of QEMU's private virtio-serial chardev sockets.
+/// The socket must already exist inside the launcher's owned, mode-0700 run
+/// directory so another local user cannot pre-create or swap the endpoint.
+enum NativeBridgeSocket {
+    static func connectSecure(path: String, label: String) throws -> Int32 {
+        guard path.hasPrefix("/"), !path.utf8.contains(0) else {
+            throw HelperError.io("\(label) socket path must be an absolute pathname")
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard url.path == path else {
+            throw HelperError.io("\(label) socket path must already be standardized")
+        }
+        let parent = url.deletingLastPathComponent()
+        var parentInfo = stat()
+        var socketInfo = stat()
+        guard lstat(parent.path, &parentInfo) == 0,
+              (parentInfo.st_mode & S_IFMT) == S_IFDIR,
+              parentInfo.st_uid == getuid(),
+              (parentInfo.st_mode & 0o077) == 0,
+              lstat(path, &socketInfo) == 0,
+              (socketInfo.st_mode & S_IFMT) == S_IFSOCK,
+              socketInfo.st_uid == getuid() else {
+            throw HelperError.io("\(label) endpoint must be a private owned Unix socket")
+        }
+
+        let pathBytes = Array(path.utf8)
+        var address = sockaddr_un()
+        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+            throw HelperError.io("\(label) socket path is too long")
+        }
+        address.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: UInt8.self, repeating: 0)
+            buffer.copyBytes(from: pathBytes)
+        }
+        let socketDescriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard socketDescriptor >= 0 else { throw HelperError.io("cannot create \(label) socket") }
+        var noSignal: Int32 = 1
+        guard withUnsafePointer(to: &noSignal, {
+            setsockopt(socketDescriptor, SOL_SOCKET, SO_NOSIGPIPE, $0, socklen_t(MemoryLayout<Int32>.size))
+        }) == 0 else {
+            Darwin.close(socketDescriptor)
+            throw HelperError.io("cannot configure \(label) socket")
+        }
+        let offset = MemoryLayout.offset(of: \sockaddr_un.sun_path) ?? 0
+        let length = socklen_t(offset + pathBytes.count + 1)
+        let result = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(socketDescriptor, $0, length)
+            }
+        }
+        guard result == 0 else {
+            let detail = String(cString: strerror(errno))
+            Darwin.close(socketDescriptor)
+            throw HelperError.io("cannot connect to \(label) socket: \(detail)")
+        }
+        return socketDescriptor
+    }
+
+    /// Writes every byte, retrying on EINTR, or throws.
+    static func writeAll(_ data: Data, to descriptor: Int32, label: String) throws {
+        try data.withUnsafeBytes { buffer in
+            guard let base = buffer.baseAddress else { return }
+            var offset = 0
+            while offset < buffer.count {
+                let count = Darwin.write(descriptor, base.advanced(by: offset), buffer.count - offset)
+                if count > 0 {
+                    offset += count
+                } else if count < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw HelperError.io("cannot write the guest \(label) channel")
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
@@ -98,25 +98,52 @@ struct ClipboardMessage: Equatable {
 /// Applying the guest's selection to the Mac pasteboard bumps the pasteboard
 /// change count, and writing the Mac pasteboard into the guest triggers the
 /// guest watcher; both are recognized by fingerprint and dropped.
+///
+/// An echo follows its write within milliseconds, so each marker is only
+/// honored for a short window. Without the expiry a marker would outlive
+/// the content it protects: guest copies B, Mac copies A, Mac copies B again,
+/// and the final B would be mistaken for the original echo and lost.
 struct ClipboardSyncState: Equatable {
-    private(set) var lastFromHost: String?
-    private(set) var lastFromGuest: String?
+    /// How long a write may be mirrored back before it counts as new content.
+    static let echoWindow: TimeInterval = 2
+
+    private struct Marker: Equatable {
+        let fingerprint: String
+        let at: TimeInterval
+    }
+
+    private var fromHost: Marker?
+    private var fromGuest: Marker?
+
+    var lastFromHost: String? { fromHost?.fingerprint }
+    var lastFromGuest: String? { fromGuest?.fingerprint }
+
+    private static func isEcho(_ marker: Marker?, _ key: String, at now: TimeInterval) -> Bool {
+        guard let marker, marker.fingerprint == key else { return false }
+        return now - marker.at <= echoWindow
+    }
 
     /// Returns true when the host update should be forwarded to the guest.
-    mutating func hostChanged(_ message: ClipboardMessage) -> Bool {
+    mutating func hostChanged(
+        _ message: ClipboardMessage,
+        at now: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
         let key = message.fingerprint
         // Applying a guest selection bumps the pasteboard change count; only
         // that echo is dropped. A repeat of earlier Mac content is a change.
-        guard key != lastFromGuest else { return false }
-        lastFromHost = key
+        guard !Self.isEcho(fromGuest, key, at: now) else { return false }
+        fromHost = Marker(fingerprint: key, at: now)
         return true
     }
 
     /// Returns true when the guest update should be applied to the pasteboard.
-    mutating func guestChanged(_ message: ClipboardMessage) -> Bool {
+    mutating func guestChanged(
+        _ message: ClipboardMessage,
+        at now: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Bool {
         let key = message.fingerprint
-        guard key != lastFromHost else { return false }
-        lastFromGuest = key
+        guard !Self.isEcho(fromHost, key, at: now) else { return false }
+        fromGuest = Marker(fingerprint: key, at: now)
         return true
     }
 }
@@ -197,18 +224,20 @@ final class NativeClipboardBridge {
     func run() throws {
         startPolling()
         var line = Data()
+        var chunk = [UInt8](repeating: 0, count: 64 * 1024)
         while true {
-            var byte: UInt8 = 0
-            let count = Darwin.read(descriptor, &byte, 1)
-            if count == 1 {
-                if byte == 0x0A {
+            let count = chunk.withUnsafeMutableBytes { Darwin.read(descriptor, $0.baseAddress, $0.count) }
+            if count > 0 {
+                var start = 0
+                for index in 0..<count where chunk[index] == 0x0A {
+                    line.append(contentsOf: chunk[start..<index])
                     try handle(line)
                     line.removeAll(keepingCapacity: true)
-                } else if byte != 0x0D {
-                    guard line.count < ClipboardMessage.maximumLineBytes else {
-                        throw HelperError.io("guest clipboard message exceeds the size limit")
-                    }
-                    line.append(byte)
+                    start = index + 1
+                }
+                line.append(contentsOf: chunk[start..<count])
+                guard line.count <= ClipboardMessage.maximumLineBytes else {
+                    throw HelperError.io("guest clipboard message exceeds the size limit")
                 }
             } else if count == 0 {
                 return

--- a/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
@@ -99,10 +99,13 @@ struct ClipboardMessage: Equatable {
 /// change count, and writing the Mac pasteboard into the guest triggers the
 /// guest watcher; both are recognized by fingerprint and dropped.
 ///
-/// An echo follows its write within milliseconds, so each marker is only
-/// honored for a short window. Without the expiry a marker would outlive
-/// the content it protects: guest copies B, Mac copies A, Mac copies B again,
-/// and the final B would be mistaken for the original echo and lost.
+/// A marker only protects content that is still on the other side's
+/// clipboard. Accepting a new change in one direction therefore clears the
+/// other direction's marker: after guest copies B and Mac copies A, the
+/// pasteboard no longer holds B, so a later Mac copy of B is new content and
+/// must not be mistaken for the original echo. Echoes are delivered in order
+/// before any later user copy, so clearing cannot let one through. A short
+/// expiry backs this up for markers that never see an opposite change.
 struct ClipboardSyncState: Equatable {
     /// How long a write may be mirrored back before it counts as new content.
     static let echoWindow: TimeInterval = 2
@@ -133,6 +136,7 @@ struct ClipboardSyncState: Equatable {
         // that echo is dropped. A repeat of earlier Mac content is a change.
         guard !Self.isEcho(fromGuest, key, at: now) else { return false }
         fromHost = Marker(fingerprint: key, at: now)
+        fromGuest = nil
         return true
     }
 
@@ -144,6 +148,7 @@ struct ClipboardSyncState: Equatable {
         let key = message.fingerprint
         guard !Self.isEcho(fromHost, key, at: now) else { return false }
         fromGuest = Marker(fingerprint: key, at: now)
+        fromHost = nil
         return true
     }
 }

--- a/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeClipboardBridge.swift
@@ -1,0 +1,293 @@
+import AppKit
+import CryptoKit
+import Darwin
+import Foundation
+
+/// One clipboard payload crossing the virtio channel in either direction.
+struct ClipboardMessage: Equatable {
+    enum Format: String, CaseIterable, Equatable {
+        case text = "text/plain;charset=utf-8"
+        case png = "image/png"
+    }
+
+    /// Raw payload bytes before base64. Large enough for screenshots and
+    /// pasted documents; bounded so a runaway selection cannot exhaust memory.
+    static let maximumPayloadBytes = 16 * 1024 * 1024
+    static let maximumLineBytes = maximumPayloadBytes * 4 / 3 + 4096
+
+    let format: Format
+    let payload: Data
+
+    init?(format: Format, payload: Data) {
+        guard !payload.isEmpty, payload.count <= Self.maximumPayloadBytes else { return nil }
+        if format == .text, String(data: payload, encoding: .utf8) == nil {
+            return nil
+        }
+        self.format = format
+        self.payload = payload
+    }
+
+    var text: String? {
+        guard format == .text else { return nil }
+        return String(data: payload, encoding: .utf8)
+    }
+
+    /// Stable identity used to suppress echoes between the two sides.
+    var fingerprint: String {
+        var hasher = SHA256()
+        hasher.update(data: Data(format.rawValue.utf8))
+        hasher.update(data: Data([0]))
+        hasher.update(data: payload)
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    func encode() throws -> Data {
+        let object: [String: Any] = [
+            "type": "clipboard",
+            "format": format.rawValue,
+            "data": payload.base64EncodedString(),
+        ]
+        var data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys, .withoutEscapingSlashes]
+        )
+        data.append(0x0A)
+        return data
+    }
+
+    enum GuestLine: Equatable {
+        case clipboard(ClipboardMessage)
+        case sync
+        case ignored
+    }
+
+    /// Decodes one guest line. Unknown formats are ignored rather than fatal
+    /// so a newer guest agent cannot take the whole bridge down.
+    static func decode(_ data: Data) throws -> GuestLine {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = object["type"] as? String else {
+            throw HelperError.io("guest sent an invalid clipboard message")
+        }
+        switch type {
+        case "sync":
+            guard object.keys.sorted() == ["type"] else {
+                throw HelperError.io("guest clipboard sync has an unexpected schema")
+            }
+            return .sync
+        case "clipboard":
+            guard object.keys.sorted() == ["data", "format", "type"],
+                  let rawFormat = object["format"] as? String,
+                  let encoded = object["data"] as? String else {
+                throw HelperError.io("guest clipboard message has an unexpected schema")
+            }
+            guard let format = Format(rawValue: rawFormat) else { return .ignored }
+            guard let payload = Data(base64Encoded: encoded) else {
+                throw HelperError.io("guest clipboard payload is not base64")
+            }
+            guard let message = ClipboardMessage(format: format, payload: payload) else {
+                return .ignored
+            }
+            return .clipboard(message)
+        default:
+            throw HelperError.io("guest sent an unknown clipboard message type")
+        }
+    }
+}
+
+/// Echo-safe two-way bookkeeping shared by the tests and the live bridge.
+/// Applying the guest's selection to the Mac pasteboard bumps the pasteboard
+/// change count, and writing the Mac pasteboard into the guest triggers the
+/// guest watcher; both are recognized by fingerprint and dropped.
+struct ClipboardSyncState: Equatable {
+    private(set) var lastFromHost: String?
+    private(set) var lastFromGuest: String?
+
+    /// Returns true when the host update should be forwarded to the guest.
+    mutating func hostChanged(_ message: ClipboardMessage) -> Bool {
+        let key = message.fingerprint
+        // Applying a guest selection bumps the pasteboard change count; only
+        // that echo is dropped. A repeat of earlier Mac content is a change.
+        guard key != lastFromGuest else { return false }
+        lastFromHost = key
+        return true
+    }
+
+    /// Returns true when the guest update should be applied to the pasteboard.
+    mutating func guestChanged(_ message: ClipboardMessage) -> Bool {
+        let key = message.fingerprint
+        guard key != lastFromHost else { return false }
+        lastFromGuest = key
+        return true
+    }
+}
+
+protocol HostPasteboardProviding: AnyObject {
+    var changeCount: Int { get }
+    func read() -> ClipboardMessage?
+    func write(_ message: ClipboardMessage)
+}
+
+/// NSPasteboard adapter. Text wins over images when both are offered because
+/// rich text copies usually carry a preview image alongside the string.
+final class GeneralPasteboard: HostPasteboardProviding {
+    private let pasteboard = NSPasteboard.general
+
+    var changeCount: Int { pasteboard.changeCount }
+
+    func read() -> ClipboardMessage? {
+        if let text = pasteboard.string(forType: .string),
+           let message = ClipboardMessage(format: .text, payload: Data(text.utf8)) {
+            return message
+        }
+        if let png = pasteboard.data(forType: .png),
+           let message = ClipboardMessage(format: .png, payload: png) {
+            return message
+        }
+        if let tiff = pasteboard.data(forType: .tiff),
+           let bitmap = NSBitmapImageRep(data: tiff),
+           let png = bitmap.representation(using: .png, properties: [:]),
+           let message = ClipboardMessage(format: .png, payload: png) {
+            return message
+        }
+        return nil
+    }
+
+    func write(_ message: ClipboardMessage) {
+        pasteboard.clearContents()
+        switch message.format {
+        case .text:
+            if let text = message.text {
+                pasteboard.setString(text, forType: .string)
+            }
+        case .png:
+            pasteboard.setData(message.payload, forType: .png)
+        }
+    }
+}
+
+final class NativeClipboardBridge {
+    private let descriptor: Int32
+    private let pasteboard: HostPasteboardProviding
+    private let stateQueue = DispatchQueue(label: "dev.tryomarchy.native.clipboard-bridge-state")
+    private let writeQueue = DispatchQueue(label: "dev.tryomarchy.native.clipboard-bridge-writes")
+    private let stopLock = NSLock()
+    private var state = ClipboardSyncState()
+    private var observedChangeCount: Int
+    private var poller: DispatchSourceTimer?
+    private var stopped = false
+
+    init(
+        targetPID: pid_t,
+        socketPath: String,
+        pasteboard: HostPasteboardProviding = GeneralPasteboard()
+    ) throws {
+        guard let processIdentity = KernelProcessIdentity.capture(processIdentifier: targetPID),
+              processIdentity.isQEMUSystemProcess else {
+            throw HelperError.io("native clipboard bridge target is not a QEMU system process")
+        }
+        descriptor = try NativeBridgeSocket.connectSecure(path: socketPath, label: "clipboard bridge")
+        self.pasteboard = pasteboard
+        observedChangeCount = pasteboard.changeCount
+    }
+
+    deinit {
+        stop()
+    }
+
+    func run() throws {
+        startPolling()
+        var line = Data()
+        while true {
+            var byte: UInt8 = 0
+            let count = Darwin.read(descriptor, &byte, 1)
+            if count == 1 {
+                if byte == 0x0A {
+                    try handle(line)
+                    line.removeAll(keepingCapacity: true)
+                } else if byte != 0x0D {
+                    guard line.count < ClipboardMessage.maximumLineBytes else {
+                        throw HelperError.io("guest clipboard message exceeds the size limit")
+                    }
+                    line.append(byte)
+                }
+            } else if count == 0 {
+                return
+            } else if errno != EINTR {
+                throw HelperError.io("cannot read the guest clipboard channel")
+            }
+        }
+    }
+
+    func stop() {
+        stopLock.lock()
+        guard !stopped else {
+            stopLock.unlock()
+            return
+        }
+        stopped = true
+        stopLock.unlock()
+        poller?.cancel()
+        poller = nil
+        Darwin.shutdown(descriptor, SHUT_RDWR)
+        Darwin.close(descriptor)
+    }
+
+    private func hasStopped() -> Bool {
+        stopLock.lock()
+        defer { stopLock.unlock() }
+        return stopped
+    }
+
+    /// NSPasteboard has no change notification; a quarter-second poll of the
+    /// integer change count is the documented approach and costs nothing
+    /// until something is actually copied.
+    private func startPolling() {
+        let timer = DispatchSource.makeTimerSource(queue: stateQueue)
+        timer.schedule(deadline: .now() + 0.25, repeating: 0.25, leeway: .milliseconds(50))
+        timer.setEventHandler { [weak self] in
+            guard let self, !self.hasStopped() else { return }
+            self.pollPasteboard()
+        }
+        timer.resume()
+        poller = timer
+    }
+
+    private func pollPasteboard() {
+        let current = pasteboard.changeCount
+        guard current != observedChangeCount else { return }
+        observedChangeCount = current
+        guard let message = pasteboard.read(), state.hostChanged(message) else { return }
+        do {
+            try send(message.encode())
+        } catch {
+            fputs("[clipboard-bridge] \(error.localizedDescription)\n", stderr)
+            stop()
+        }
+    }
+
+    private func handle(_ data: Data) throws {
+        try stateQueue.sync {
+            switch try ClipboardMessage.decode(data) {
+            case .sync:
+                guard let message = pasteboard.read() else { return }
+                // A fresh guest session asks for the current Mac clipboard.
+                // Reset the host marker so the same text can be re-sent.
+                state = ClipboardSyncState()
+                guard state.hostChanged(message) else { return }
+                try send(message.encode())
+            case .clipboard(let message):
+                guard state.guestChanged(message) else { return }
+                pasteboard.write(message)
+                observedChangeCount = pasteboard.changeCount
+            case .ignored:
+                return
+            }
+        }
+    }
+
+    private func send(_ data: Data) throws {
+        try writeQueue.sync {
+            try NativeBridgeSocket.writeAll(data, to: descriptor, label: "clipboard")
+        }
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/main.swift
+++ b/macos/Sources/OmarchyVMHelper/main.swift
@@ -5,7 +5,7 @@ import Foundation
 private var terminationSignalSources: [DispatchSourceSignal] = []
 
 private func usage() -> Never {
-    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY\n", stderr)
+    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY | --bridge-native-clipboard QEMU_PID SOCKET\n", stderr)
     exit(64)
 }
 
@@ -41,6 +41,29 @@ do {
             terminationSignalSources.append(source)
         }
         fputs("[audio-bridge] Host audio devices are available inside Omarchy.\n", stderr)
+        try bridge.run()
+        exit(0)
+    }
+
+    if arguments.first == "--bridge-native-clipboard" {
+        guard arguments.count == 3,
+              let processIdentifier = Int32(arguments[1]),
+              processIdentifier > 1 else { usage() }
+        let bridge = try NativeClipboardBridge(
+            targetPID: processIdentifier,
+            socketPath: arguments[2]
+        )
+        for signalNumber in [SIGINT, SIGTERM] {
+            Darwin.signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(
+                signal: signalNumber,
+                queue: .global(qos: .userInitiated)
+            )
+            source.setEventHandler { bridge.stop() }
+            source.resume()
+            terminationSignalSources.append(source)
+        }
+        fputs("[clipboard-bridge] The Mac clipboard is shared with Omarchy.\n", stderr)
         try bridge.run()
         exit(0)
     }

--- a/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
@@ -70,23 +70,41 @@ struct NativeClipboardBridgeTests {
         #expect(!guest(fromMac))
     }
 
-    @Test("echo markers expire so a genuine repeat of guest content is not lost")
+    @Test("an opposite change clears the echo marker so a repeat is not lost")
+    func oppositeChangeClearsEchoMarker() throws {
+        var state = ClipboardSyncState()
+        func host(_ message: ClipboardMessage) -> Bool { state.hostChanged(message, at: 0) }
+        func guest(_ message: ClipboardMessage) -> Bool { state.guestChanged(message, at: 0) }
+        let a = try #require(ClipboardMessage(format: .text, payload: Data("A".utf8)))
+        let b = try #require(ClipboardMessage(format: .text, payload: Data("B".utf8)))
+        let c = try #require(ClipboardMessage(format: .text, payload: Data("C".utf8)))
+        let d = try #require(ClipboardMessage(format: .text, payload: Data("D".utf8)))
+
+        // Guest copies B, the Mac copies A, then the Mac copies B right away.
+        // The final B is new content, not an echo of the guest's write.
+        #expect(guest(b))
+        #expect(host(a))
+        #expect(host(b))
+
+        // Mirror image: Mac copies C, guest copies D, guest copies C again.
+        #expect(host(c))
+        #expect(!guest(c)) // the wl-copy echo
+        #expect(guest(d))
+        #expect(guest(c))
+    }
+
+    @Test("echo markers expire so a genuine repeat of the same content is not lost")
     func echoMarkersExpire() throws {
         var state = ClipboardSyncState()
         func host(_ message: ClipboardMessage, at time: TimeInterval) -> Bool { state.hostChanged(message, at: time) }
         func guest(_ message: ClipboardMessage, at time: TimeInterval) -> Bool { state.guestChanged(message, at: time) }
-        let a = try #require(ClipboardMessage(format: .text, payload: Data("A".utf8)))
         let b = try #require(ClipboardMessage(format: .text, payload: Data("B".utf8)))
         let window = ClipboardSyncState.echoWindow
 
-        // Guest copies B, the Mac copies A, then the Mac copies B again well
-        // after the guest's write. The final B is new content, not an echo.
-        #expect(guest(b, at: 0))
-        #expect(host(a, at: window + 1))
-        #expect(host(b, at: window + 2))
-
-        // Inside the window the mirrored write is still recognized as an echo.
-        #expect(!guest(b, at: window + 2.1))
-        #expect(guest(b, at: window * 2 + 3))
+        #expect(host(b, at: 0))
+        // Inside the window the mirrored write is recognized as an echo.
+        #expect(!guest(b, at: 0.1))
+        // Long after, the same content from the guest is a real change.
+        #expect(guest(b, at: window + 1))
     }
 }

--- a/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Native clipboard bridge")
+struct NativeClipboardBridgeTests {
+    @Test("clipboard messages round-trip through the newline-delimited JSON schema")
+    func roundTrip() throws {
+        let message = try #require(ClipboardMessage(format: .text, payload: Data("héllo\n".utf8)))
+        let encoded = try message.encode()
+        #expect(encoded.last == 0x0A)
+        #expect(
+            String(decoding: encoded, as: UTF8.self)
+                == #"{"data":"aMOpbGxvCg==","format":"text/plain;charset=utf-8","type":"clipboard"}"# + "\n"
+        )
+        #expect(try ClipboardMessage.decode(encoded.dropLast()) == .clipboard(message))
+        #expect(try ClipboardMessage.decode(Data(#"{"type":"sync"}"#.utf8)) == .sync)
+    }
+
+    @Test("unknown formats are ignored while malformed lines are rejected")
+    func decodeValidation() throws {
+        #expect(
+            try ClipboardMessage.decode(
+                Data(#"{"data":"AAAA","format":"text/html","type":"clipboard"}"#.utf8)
+            ) == .ignored
+        )
+        #expect(
+            try ClipboardMessage.decode(
+                Data(#"{"data":"","format":"image/png","type":"clipboard"}"#.utf8)
+            ) == .ignored
+        )
+        for line in [
+            "not json",
+            #"{"type":"clipboard"}"#,
+            #"{"type":"sync","extra":1}"#,
+            #"{"data":"%%%","format":"image/png","type":"clipboard"}"#,
+            #"{"data":"AAAA","format":"image/png","type":"clipboard","more":true}"#,
+            #"{"type":"select"}"#,
+        ] {
+            #expect(throws: HelperError.self) {
+                try ClipboardMessage.decode(Data(line.utf8))
+            }
+        }
+        #expect(ClipboardMessage(format: .text, payload: Data([0xFF, 0xFE])) == nil)
+        #expect(ClipboardMessage(format: .png, payload: Data()) == nil)
+    }
+
+    @Test("echoes are suppressed in both directions and new content still flows")
+    func echoSuppression() throws {
+        var state = ClipboardSyncState()
+        func host(_ message: ClipboardMessage) -> Bool { state.hostChanged(message) }
+        func guest(_ message: ClipboardMessage) -> Bool { state.guestChanged(message) }
+        let fromMac = try #require(ClipboardMessage(format: .text, payload: Data("from mac".utf8)))
+        let fromGuest = try #require(ClipboardMessage(format: .text, payload: Data("from guest".utf8)))
+        let image = try #require(ClipboardMessage(format: .png, payload: Data([0x89, 0x50, 0x4E, 0x47])))
+
+        #expect(host(fromMac))
+        // wl-copy in the guest re-announces the same selection; do not bounce it back.
+        #expect(!guest(fromMac))
+
+        #expect(guest(fromGuest))
+        // Writing the pasteboard bumps its change count; the poller must not re-send.
+        #expect(!host(fromGuest))
+
+        #expect(host(image))
+        #expect(!guest(image))
+        // Copying earlier guest content again is a real change once the host moved on.
+        #expect(guest(fromGuest))
+        #expect(host(fromMac))
+        #expect(!guest(fromMac))
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeClipboardBridgeTests.swift
@@ -69,4 +69,24 @@ struct NativeClipboardBridgeTests {
         #expect(host(fromMac))
         #expect(!guest(fromMac))
     }
+
+    @Test("echo markers expire so a genuine repeat of guest content is not lost")
+    func echoMarkersExpire() throws {
+        var state = ClipboardSyncState()
+        func host(_ message: ClipboardMessage, at time: TimeInterval) -> Bool { state.hostChanged(message, at: time) }
+        func guest(_ message: ClipboardMessage, at time: TimeInterval) -> Bool { state.guestChanged(message, at: time) }
+        let a = try #require(ClipboardMessage(format: .text, payload: Data("A".utf8)))
+        let b = try #require(ClipboardMessage(format: .text, payload: Data("B".utf8)))
+        let window = ClipboardSyncState.echoWindow
+
+        // Guest copies B, the Mac copies A, then the Mac copies B again well
+        // after the guest's write. The final B is new content, not an echo.
+        #expect(guest(b, at: 0))
+        #expect(host(a, at: window + 1))
+        #expect(host(b, at: window + 2))
+
+        // Inside the window the mirrored write is still recognized as an echo.
+        #expect(!guest(b, at: window + 2.1))
+        #expect(guest(b, at: window * 2 + 3))
+    }
 }

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -336,6 +336,7 @@ runtime = exact_keys(
     spec.get("runtime"),
     {
         "audio",
+        "clipboard",
         "compressedDisk",
         "devices",
         "disk",
@@ -369,6 +370,11 @@ expected_devices = [
     "intel-hda",
     "hda-micro",
 ]
+clipboard = {
+    "device": "virtserialport",
+    "port": "dev.tryomarchy.clipboard",
+    "formats": ["text/plain;charset=utf-8", "image/png"],
+}
 graphics = {
     "device": "virtio-gpu-gl-pci",
     "display": "cocoa",
@@ -407,6 +413,7 @@ if (
     or runtime.get("network") != network
     or runtime.get("audio") != audio
     or runtime.get("storage") != storage
+    or runtime.get("clipboard") != clipboard
     or runtime.get("devices") != expected_devices
     or runtime.get("minimumMemoryMiB") != 2048
     or runtime.get("recommendedMemoryMiB") != 4096
@@ -601,6 +608,7 @@ owner_marker=""
 owner_token=""
 qemu_pid=""
 audio_bridge_pid=""
+clipboard_bridge_pid=""
 
 terminate_child() {
   local pid=$1
@@ -630,6 +638,9 @@ cleanup() {
   fi
   if [[ $audio_bridge_pid =~ ^[0-9]+$ ]]; then
     terminate_child "$audio_bridge_pid" 20
+  fi
+  if [[ $clipboard_bridge_pid =~ ^[0-9]+$ ]]; then
+    terminate_child "$clipboard_bridge_pid" 20
   fi
   qemu_persistent_storage_release_lock
   if [[ -n $work_dir && -n $owner_marker && -n $owner_token ]]; then
@@ -721,6 +732,7 @@ chmod 600 "$owner_marker"
 # for cleanup, but expose the runtime sockets through that standardized alias.
 qmp_socket="/tmp/${work_dir##*/}/qmp.sock"
 audio_bridge_socket="/tmp/${work_dir##*/}/audio.sock"
+clipboard_bridge_socket="/tmp/${work_dir##*/}/clipboard.sock"
 audio_route_dir="/tmp/${work_dir##*/}/audio-routes"
 mkdir -m 700 "$work_dir/audio-routes"
 
@@ -800,6 +812,8 @@ qemu_args=(
   -device 'virtconsole,bus=omarchy-serial.0,nr=0,chardev=omarchy-hvc0'
   -chardev "socket,id=omarchy-audio-bridge,path=$audio_bridge_socket,server=on,wait=off"
   -device 'virtserialport,bus=omarchy-serial.0,nr=1,chardev=omarchy-audio-bridge,name=dev.tryomarchy.audio'
+  -chardev "socket,id=omarchy-clipboard-bridge,path=$clipboard_bridge_socket,server=on,wait=off"
+  -device 'virtserialport,bus=omarchy-serial.0,nr=2,chardev=omarchy-clipboard-bridge,name=dev.tryomarchy.clipboard'
 )
 
 # SDL2 has one legacy process-wide override that would collapse input and
@@ -819,6 +833,8 @@ if [[ ${OMARCHY_QEMU_GPU_DRY_RUN:-0} == 1 ]]; then
   printf ' %q' "$qemu_bin" "${qemu_args[@]}" >&2
   printf '\n[qemu-gpu] audio bridge command: %q --bridge-native-audio QEMU_PID %q %q' \
     "$native_bridge" "$audio_bridge_socket" "$audio_route_dir" >&2
+  printf '\n[qemu-gpu] clipboard bridge command: %q --bridge-native-clipboard QEMU_PID %q' \
+    "$native_bridge" "$clipboard_bridge_socket" >&2
   printf '\n' >&2
   exit 0
 fi
@@ -838,12 +854,13 @@ printf '%s\n' "$qemu_pid" >"$work_dir/.qemu.pid"
 chmod 600 "$work_dir/.qemu.pid"
 
 for ((attempt = 0; attempt < 100; attempt++)); do
-  [[ -S $qmp_socket && -S $audio_bridge_socket ]] && break
+  [[ -S $qmp_socket && -S $audio_bridge_socket && -S $clipboard_bridge_socket ]] && break
   kill -0 "$qemu_pid" 2>/dev/null || fail "QEMU exited before creating its private QMP socket"
   sleep 0.05
 done
 [[ -S $qmp_socket ]] || fail "QEMU did not create its private QMP socket"
 [[ -S $audio_bridge_socket ]] || fail "QEMU did not create its private audio bridge socket"
+[[ -S $clipboard_bridge_socket ]] || fail "QEMU did not create its private clipboard bridge socket"
 echo "[qemu-gpu] Ready." >&2
 
 # FD 9 deliberately remains open only in QEMU. Letting the sibling audio
@@ -851,6 +868,14 @@ echo "[qemu-gpu] Ready." >&2
 "$native_bridge" --bridge-native-audio \
   "$qemu_pid" "$audio_bridge_socket" "$audio_route_dir" 9>&- &
 audio_bridge_pid=$!
+
+start_clipboard_bridge() {
+  "$native_bridge" --bridge-native-clipboard \
+    "$qemu_pid" "$clipboard_bridge_socket" 9>&- &
+  clipboard_bridge_pid=$!
+}
+start_clipboard_bridge
+clipboard_bridge_restarts=0
 
 # Bash 3.2 has no `wait -n`. The native-audio bridge is required for the guest
 # transport, so watch it alongside QEMU and fail if it exits unexpectedly.
@@ -867,6 +892,28 @@ while true; do
     fi
     audio_bridge_pid=""
     fail "native audio bridge exited while QEMU was running (status $audio_bridge_status)"
+  fi
+
+  # Clipboard sharing is a convenience, not a transport the guest depends on.
+  # Restart it a few times rather than stopping the whole virtual machine.
+  if [[ $clipboard_bridge_pid =~ ^[0-9]+$ ]]; then
+    clipboard_bridge_state=$(ps -p "$clipboard_bridge_pid" -o state= 2>/dev/null || true)
+    if [[ -z $clipboard_bridge_state || $clipboard_bridge_state == *Z* ]]; then
+      if wait "$clipboard_bridge_pid"; then
+        clipboard_bridge_status=0
+      else
+        clipboard_bridge_status=$?
+      fi
+      clipboard_bridge_pid=""
+      if (( clipboard_bridge_restarts < 5 )); then
+        clipboard_bridge_restarts=$((clipboard_bridge_restarts + 1))
+        echo "[qemu-gpu] clipboard bridge exited (status $clipboard_bridge_status); restarting ($clipboard_bridge_restarts/5)" >&2
+        sleep 1
+        start_clipboard_bridge
+      else
+        echo "[qemu-gpu] clipboard sharing is unavailable for the rest of this session" >&2
+      fi
+    fi
   fi
   sleep 0.1
 done
@@ -890,4 +937,8 @@ else
   wait "$audio_bridge_pid" 2>/dev/null || true
 fi
 audio_bridge_pid=""
+if [[ $clipboard_bridge_pid =~ ^[0-9]+$ ]]; then
+  terminate_child "$clipboard_bridge_pid" 20
+fi
+clipboard_bridge_pid=""
 exit "$qemu_status"


### PR DESCRIPTION
Closes #10

## Summary

- Two-way clipboard sharing for text and PNG images between macOS and the Omarchy desktop.
- Host side follows the existing native audio-bridge pattern: a new virtserialport `dev.tryomarchy.clipboard` backed by a private socket, served by `omarchy-vm-helper --bridge-native-clipboard`, which polls `NSPasteboard.changeCount`. The bridge is supervised non-fatally (restarted up to 5×) so a clipboard hiccup never stops the VM. The socket connect/write code shared with the audio bridge moves to `NativeBridgeSocket.swift`.
- Guest side: `omarchy-native-clipboard-bridge` (Python, uses the already-shipped `wl-clipboard`, whose data-control support works on Hyprland without focus) runs as a user unit bound to `graphical-session.target`; a udev rule grants the `users` group the port.
- Both sides fingerprint what they last wrote so nothing echoes back; the guest asks for the current Mac clipboard on login. Payloads are capped at 16 MiB. Unknown formats are ignored rather than fatal so the protocol can grow.
- Runtime contract (`spec.json`), launcher validator, and `guest/tests/verify.py` cover the port, unit, rule, and message schema.

No new host or guest dependencies; no QEMU changes.

## Test plan

- [x] `swift test` (48 tests) and `guest/test` pass
- [x] Copy text on the Mac → paste in Omarchy; copy in Omarchy → `pbpaste` on the Mac
- [ ] Screenshot copied on the Mac pastes as PNG in the guest (implemented and unit-tested; not yet exercised by hand)
- [x] Verified on a full `make build` + first-boot provisioning on Apple Silicon

Note: building on current Homebrew (sdl2-compat/SDL3) needs #6 first; this PR does not touch those pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GopAGVNHBeeDUwEQ21Qotf


