### PR TITLE
Share one Mac folder with Omarchy over virtio-9p

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ into its home under the same name (`~/Work` on the Mac becomes `~/Work` in
 Omarchy) with full read and write access, so choose a folder you intend Linux
 software to modify. The whole home folder, `~/Library`, and system directories
 cannot be shared. **Turn Off** keeps the choice but stops exporting it on the
-next launch. The share belongs to the first Omarchy account created during
+next launch; Omarchy then removes the link and gives back any standard folder
+such as `~/Documents` that the link had taken over. The share belongs to the
+first Omarchy account created during
 provisioning; additional guest accounts see it read-only.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Try Omarchy is not official or affiliated with Omarchy.
 - Resizable native window with automatic guest resolution and HiDPI scale updates
 - Mac audio input/output selection inside Omarchy, with live routing and system-default fallback
 - Two-way clipboard sharing for text and PNG images between macOS and Omarchy
+- One optional shared Mac folder, available inside Omarchy under the same name (`~/Work` stays `~/Work`)
 
 > **Current limitation:** Video decoding is CPU-only, so playback can be slow, especially at high resolutions. An improved video path is in development.
 
@@ -31,6 +32,17 @@ Copy and paste work in both directions as soon as you sign in to Omarchy: text
 and PNG images copied on the Mac appear in the Omarchy clipboard, and content
 copied in Omarchy lands on the Mac pasteboard. Nothing is transferred until
 something is copied.
+
+## Sharing a folder with the Mac
+
+Folder sharing is off until you pick a folder. Use **Choose…** next to
+**Shared folder** on the start menu to select one Mac folder; Omarchy links it
+into its home under the same name (`~/Work` on the Mac becomes `~/Work` in
+Omarchy) with full read and write access, so choose a folder you intend Linux
+software to modify. The whole home folder, `~/Library`, and system directories
+cannot be shared. **Turn Off** keeps the choice but stops exporting it on the
+next launch. The share belongs to the first Omarchy account created during
+provisioning; additional guest accounts see it read-only.
 
 ## Requirements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,16 @@ fingerprint of what it last wrote so the immediate echo is dropped. The marker
 is cleared as soon as the other side moves on to new content, and expires after
 a couple of seconds regardless, so a genuine repeat of the same content still flows.
 
+When a folder is chosen on the start menu, QEMU exports it over virtio-9p with
+`security_model=none`, so every host file operation runs as the Mac user and
+the Mac keeps real modes and ownership. A small QEMU patch adds
+`guest_owner_uid`/`guest_owner_gid` fsdev options that report the Mac user's
+files as the first Omarchy account (uid/gid 1000), which makes the guest
+kernel's permission checks agree with what the host will actually allow. The
+guest mounts the tag at `/mnt/mac` before the display manager starts, and a
+user unit links `~/<folder name>` to it at login; the name travels on the
+kernel command line as `omarchy.shared_folder_name=<base64url>`.
+
 ## The ARM64 image
 
 The guest image is built by this project; it is not an official prebuilt image
@@ -58,7 +68,7 @@ creates the account on first boot.
 - The Swift code is a separate macOS launcher and helper.
 - A few QEMU C and Objective-C files are patched before QEMU is compiled. These
   patches cover the Cocoa app identity, display behavior, graphics integration,
-  and host audio-device routing.
+  host audio-device routing, and shared-folder ownership mapping.
 - The pinned Omarchy runtime trees are copied from upstream. Guest overlays add
   the QEMU and ARM64 integration around them.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,8 +35,8 @@ make release \
 1. Confirm `main` is clean and all pinned inputs have reviewable provenance.
 2. Run all tests and perform a first-boot provisioning test on a clean Mac user.
 3. Verify networking, display scaling, keyboard/mouse, microphone permission,
-   audio-device changes, clipboard sharing in both directions, persistence,
-   reset, and ephemeral mode.
+   audio-device changes, clipboard sharing in both directions, a shared folder
+   read and written from both sides, persistence, reset, and ephemeral mode.
 4. Verify the app and DMG signatures with Apple's tools and confirm notarization.
 5. Audit `THIRD_PARTY_NOTICES.md`, the bundle's license material, the guest
    package lock, and QEMU corresponding-source obligations.

--- a/guest/native-overlay/usr/lib/systemd/system/omarchy-native-mac-share.service
+++ b/guest/native-overlay/usr/lib/systemd/system/omarchy-native-mac-share.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Mount the Mac folder shared by Try Omarchy
+After=local-fs.target systemd-modules-load.service
+Before=sddm.service display-manager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/omarchy-native-mac-share --mount
+ExecStop=/usr/local/bin/omarchy-native-mac-share --unmount
+
+[Install]
+WantedBy=multi-user.target

--- a/guest/native-overlay/usr/lib/systemd/user/omarchy-native-mac-share-link.service
+++ b/guest/native-overlay/usr/lib/systemd/user/omarchy-native-mac-share-link.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Link the shared Mac folder into the home directory
-ConditionPathIsMountPoint=/mnt/mac
+# Runs whether or not /mnt/mac is mounted: without a mount it removes links
+# left by an earlier share and restores a displaced xdg folder.
 
 [Service]
 Type=oneshot

--- a/guest/native-overlay/usr/lib/systemd/user/omarchy-native-mac-share-link.service
+++ b/guest/native-overlay/usr/lib/systemd/user/omarchy-native-mac-share-link.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Link the shared Mac folder into the home directory
+ConditionPathIsMountPoint=/mnt/mac
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/omarchy-native-mac-share --link
+
+[Install]
+WantedBy=default.target

--- a/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Mount the Mac folder that Try Omarchy exports over virtio-9p. The host
+# publishes the share with mount tag "mac" only when the user enabled one, so
+# a missing tag simply means nothing to do. QEMU already reports the Mac
+# user's files as the Omarchy owner account (uid/gid 1000), which is why no
+# uid remapping happens here. At login, --link places ~/<name> in the user's
+# home, where <name> is the Mac folder's own name carried on the kernel
+# command line, so a shared ~/Work shows up as ~/Work.
+
+set -euo pipefail
+
+mount_tag=${OMARCHY_MAC_SHARE_TAG:-mac}
+mount_point=${OMARCHY_MAC_SHARE_MOUNT_POINT:-/mnt/mac}
+virtio_root=${OMARCHY_MAC_SHARE_VIRTIO_ROOT:-/sys/bus/virtio/drivers/9pnet_virtio}
+kernel_cmdline=${OMARCHY_MAC_SHARE_CMDLINE:-/proc/cmdline}
+name_parameter=omarchy.shared_folder_name
+fallback_name=Mac
+
+log() {
+  echo "omarchy-native-mac-share: $*" >&2
+}
+
+find_share_device() {
+  local device
+  shopt -s nullglob
+  for device in "$virtio_root"/virtio*; do
+    [[ -r $device/mount_tag ]] || continue
+    if [[ $(tr -d '\0' <"$device/mount_tag") == "$mount_tag" ]]; then
+      echo "${device##*/}"
+      shopt -u nullglob
+      return 0
+    fi
+  done
+  shopt -u nullglob
+  return 1
+}
+
+mount_share() {
+  local attempt
+  modprobe 9pnet_virtio 2>/dev/null || true
+  modprobe 9p 2>/dev/null || true
+  for ((attempt = 0; attempt < 10; attempt++)); do
+    if find_share_device >/dev/null; then
+      break
+    fi
+    sleep 0.5
+  done
+  if ! find_share_device >/dev/null; then
+    log "no Mac folder is shared with this session"
+    return 0
+  fi
+  install -d -m 0755 "$mount_point"
+  if mountpoint -q "$mount_point"; then
+    log "$mount_point is already mounted"
+    return 0
+  fi
+  # cache=mmap keeps reads and directory listings coherent with changes made
+  # on the Mac while still allowing mmap-based readers. msize raises the 9p
+  # transfer unit for large copies.
+  mount -t 9p -o "trans=virtio,version=9p2000.L,msize=1048576,cache=mmap" \
+    "$mount_tag" "$mount_point"
+  log "mounted the shared Mac folder at $mount_point"
+}
+
+shared_folder_name() {
+  local argument
+  local encoded=""
+  local decoded
+  for argument in $(<"$kernel_cmdline"); do
+    [[ $argument == "$name_parameter="* ]] || continue
+    encoded=${argument#*=}
+  done
+  if [[ -z $encoded || ! $encoded =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "$fallback_name"
+    return 0
+  fi
+  local padded=$encoded
+  while (( ${#padded} % 4 )); do padded+="="; done
+  decoded=$(printf '%s' "$padded" | tr -- '-_' '+/' | base64 -d 2>/dev/null | tr -d '\0') || decoded=""
+  if [[ -z $decoded || $decoded == */* || $decoded == . || $decoded == .. || $decoded == *$'\n'* ]]; then
+    echo "$fallback_name"
+    return 0
+  fi
+  echo "$decoded"
+}
+
+link_share() {
+  local home=${HOME:-}
+  local name
+  local target
+  local existing
+  [[ -n $home && -d $home ]] || { log "no home directory to link into"; return 0; }
+  if [[ ${OMARCHY_MAC_SHARE_ASSUME_MOUNTED:-0} != 1 ]] && ! mountpoint -q "$mount_point"; then
+    log "no Mac folder is mounted; nothing to link"
+    return 0
+  fi
+  name=$(shared_folder_name)
+  target="$home/$name"
+  # Drop links from an earlier share name so only the current one remains.
+  for existing in "$home"/* "$home"/.[!.]*; do
+    [[ -L $existing && $(readlink "$existing") == "$mount_point" && $existing != "$target" ]] || continue
+    rm -f "$existing"
+  done
+  if [[ -L $target ]]; then
+    [[ $(readlink "$target") == "$mount_point" ]] && return 0
+    log "$target is a link elsewhere; using ~/$fallback_name instead"
+    target="$home/$fallback_name"
+  elif [[ -d $target ]]; then
+    # xdg-user-dirs pre-creates folders such as Documents. Replace only an
+    # empty one; keep real content and fall back to the generic name.
+    if ! rmdir "$target" 2>/dev/null; then
+      log "$target already has content; using ~/$fallback_name instead"
+      target="$home/$fallback_name"
+    fi
+  elif [[ -e $target ]]; then
+    log "$target exists; using ~/$fallback_name instead"
+    target="$home/$fallback_name"
+  fi
+  if [[ -e $target || -L $target ]]; then
+    [[ -L $target && $(readlink "$target") == "$mount_point" ]] && return 0
+    log "cannot place the shared folder link at $target"
+    return 0
+  fi
+  ln -s "$mount_point" "$target"
+  log "linked $target to the shared Mac folder"
+}
+
+unmount_share() {
+  if mountpoint -q "$mount_point"; then
+    umount "$mount_point" || umount -l "$mount_point" || true
+  fi
+}
+
+case ${1:-} in
+  --mount) mount_share ;;
+  --unmount) unmount_share ;;
+  --link) link_share ;;
+  --find-device) find_share_device ;;
+  --name) shared_folder_name ;;
+  *)
+    echo "Usage: omarchy-native-mac-share --mount | --unmount | --link | --find-device | --name" >&2
+    exit 64
+    ;;
+esac

--- a/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
@@ -6,7 +6,9 @@
 # user's files as the Omarchy owner account (uid/gid 1000), which is why no
 # uid remapping happens here. At login, --link places ~/<name> in the user's
 # home, where <name> is the Mac folder's own name carried on the kernel
-# command line, so a shared ~/Work shows up as ~/Work.
+# command line, so a shared ~/Work shows up as ~/Work. When nothing is shared,
+# --link removes links left behind by an earlier share and restores any xdg
+# folder (Documents, Downloads, ...) that such a link had displaced.
 
 set -euo pipefail
 
@@ -36,8 +38,30 @@ find_share_device() {
   return 1
 }
 
+# The launcher puts the folder name on the kernel command line only when a
+# share is enabled, so its absence means there is no device to wait for.
+share_enabled() {
+  local argument
+  for argument in $(<"$kernel_cmdline"); do
+    [[ $argument == "$name_parameter="* ]] && return 0
+  done
+  return 1
+}
+
+share_mounted() {
+  case ${OMARCHY_MAC_SHARE_ASSUME_MOUNTED:-} in
+    1) return 0 ;;
+    0) return 1 ;;
+  esac
+  mountpoint -q "$mount_point"
+}
+
 mount_share() {
   local attempt
+  if ! share_enabled; then
+    log "sharing is off; nothing to mount"
+    return 0
+  fi
   modprobe 9pnet_virtio 2>/dev/null || true
   modprobe 9p 2>/dev/null || true
   for ((attempt = 0; attempt < 10; attempt++)); do
@@ -85,23 +109,62 @@ shared_folder_name() {
   echo "$decoded"
 }
 
+# Folders that xdg-user-dirs manages for this user, one absolute path per
+# line. Falls back to the stock names when the session has no config yet.
+xdg_user_dirs() {
+  local home=$1
+  local config=${XDG_CONFIG_HOME:-$home/.config}/user-dirs.dirs
+  local line value
+  if [[ -r $config ]]; then
+    while IFS= read -r line; do
+      [[ $line =~ ^XDG_[A-Z_]+_DIR=\"?([^\"]*)\"?$ ]] || continue
+      value=${BASH_REMATCH[1]}
+      value=${value//\$HOME/$home}
+      [[ $value == /* ]] && echo "$value"
+    done <"$config"
+    return 0
+  fi
+  local name
+  for name in Desktop Documents Downloads Music Pictures Public Templates Videos; do
+    echo "$home/$name"
+  done
+}
+
+# Remove a link to the share. A link that replaced an empty xdg folder gives
+# that folder back so file pickers and downloads keep working.
+remove_share_link() {
+  local link=$1
+  local home=$2
+  local xdg_dir
+  rm -f "$link"
+  while IFS= read -r xdg_dir; do
+    [[ $xdg_dir == "$link" ]] || continue
+    mkdir -p "$link" && log "restored $link after removing the shared folder link"
+    break
+  done < <(xdg_user_dirs "$home")
+}
+
 link_share() {
   local home=${HOME:-}
   local name
-  local target
+  local target=""
   local existing
   [[ -n $home && -d $home ]] || { log "no home directory to link into"; return 0; }
-  if [[ ${OMARCHY_MAC_SHARE_ASSUME_MOUNTED:-0} != 1 ]] && ! mountpoint -q "$mount_point"; then
+  if share_mounted; then
+    name=$(shared_folder_name)
+    target="$home/$name"
+  fi
+  # Drop links from an earlier share so only the current one remains. This
+  # runs even without a mount, otherwise turning sharing off would leave
+  # ~/<old name> pointing at an empty, root-owned mount point.
+  for existing in "$home"/* "$home"/.[!.]*; do
+    [[ -L $existing && $(readlink "$existing") == "$mount_point" && $existing != "$target" ]] || continue
+    remove_share_link "$existing" "$home"
+  done
+  if [[ -z $target ]]; then
     log "no Mac folder is mounted; nothing to link"
     return 0
   fi
-  name=$(shared_folder_name)
-  target="$home/$name"
-  # Drop links from an earlier share name so only the current one remains.
-  for existing in "$home"/* "$home"/.[!.]*; do
-    [[ -L $existing && $(readlink "$existing") == "$mount_point" && $existing != "$target" ]] || continue
-    rm -f "$existing"
-  done
   if [[ -L $target ]]; then
     [[ $(readlink "$target") == "$mount_point" ]] && return 0
     log "$target is a link elsewhere; using ~/$fallback_name instead"
@@ -138,8 +201,9 @@ case ${1:-} in
   --link) link_share ;;
   --find-device) find_share_device ;;
   --name) shared_folder_name ;;
+  --enabled) share_enabled ;;
   *)
-    echo "Usage: omarchy-native-mac-share --mount | --unmount | --link | --find-device | --name" >&2
+    echo "Usage: omarchy-native-mac-share --mount | --unmount | --link | --find-device | --name | --enabled" >&2
     exit 64
     ;;
 esac

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -66,13 +66,15 @@ install -m 0755 "$guest_dir/compat/ttfx-arm64" "$root/usr/local/bin/ttfx"
 # also carries one deliberate command replacement for safe PipeWire input
 # switching. The display fragment selects Cocoa's host-composited cursor path
 # and keeps the guest mode synchronized when QEMU changes the virtual EDID.
-# The clipboard bridge mirrors the Mac pasteboard into the Wayland session.
+# The clipboard bridge mirrors the Mac pasteboard into the Wayland session,
+# and the Mac folder mount completes the host integration.
 cp -a "$guest_dir/native-overlay/." "$root/"
 chmod 0755 \
   "$root/usr/bin/omarchy-audio-input-set-default" \
   "$root/usr/local/bin/omarchy-native-audio-bridge" \
   "$root/usr/local/bin/omarchy-native-clipboard-bridge" \
-  "$root/usr/local/bin/omarchy-native-display-sync"
+  "$root/usr/local/bin/omarchy-native-display-sync" \
+  "$root/usr/local/bin/omarchy-native-mac-share"
 audio_helper_source_digest=$(sha256sum \
   "$guest_dir/native-overlay/usr/bin/omarchy-audio-input-set-default")
 audio_helper_source_digest=${audio_helper_source_digest%% *}
@@ -89,6 +91,14 @@ ln -sfn /usr/lib/systemd/user/omarchy-native-audio-bridge.service \
 # graphical session rather than the plain user manager.
 ln -sfn /usr/lib/systemd/user/omarchy-native-clipboard-bridge.service \
   "$root/etc/systemd/user/graphical-session.target.wants/omarchy-native-clipboard-bridge.service"
+
+# The shared Mac folder mounts system-wide at the spec's mount point; at login
+# each account links ~/<Mac folder name> to it. QEMU maps the Mac user's files
+# to the Omarchy owner account (uid 1000, the first provisioned user).
+shared_folder_mount_point=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["runtime"]["sharedFolder"]["guestMountPoint"])' "$spec")
+[[ $shared_folder_mount_point == /mnt/mac ]] || fail "shared folder mount point must match the link unit"
+ln -sfn /usr/lib/systemd/user/omarchy-native-mac-share-link.service \
+  "$root/etc/systemd/user/default.target.wants/omarchy-native-mac-share-link.service"
 cat "$guest_dir/fragments/hypr-monitors-arm-qemu.append.lua" >>"$root/etc/skel/.config/hypr/monitors.lua"
 
 hostname=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["guest"]["hostname"])' "$spec")

--- a/guest/scripts/finalize-rootfs.sh
+++ b/guest/scripts/finalize-rootfs.sh
@@ -37,6 +37,7 @@ expected_mise=$(read_spec '["supplyChain"]["mise"]["reportedVersion"]')
 [[ $(/usr/bin/mise --version) == "$expected_mise" ]] || { echo "Pinned mise identity mismatch" >&2; exit 1; }
 systemctl enable omarchy-provision-owner.service
 systemctl enable sddm.service
+systemctl enable omarchy-native-mac-share.service
 
 # The app expands only the writable APFS clone to 24 GiB. Grow ext4 online so
 # Omarchy's update-safety check sees that working capacity.

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -138,6 +138,16 @@
         "image/png"
       ]
     },
+    "sharedFolder": {
+      "device": "virtio-9p-pci",
+      "fsdriver": "local",
+      "securityModel": "none",
+      "mountTag": "mac",
+      "guestOwnerUid": 1000,
+      "guestOwnerGid": 1000,
+      "guestMountPoint": "/mnt/mac",
+      "guestLinkNameParameter": "omarchy.shared_folder_name"
+    },
     "devices": [
       "virtio-blk-pci",
       "virtio-gpu-gl-pci",
@@ -150,7 +160,8 @@
       "virtio-rng-pci",
       "virtio-balloon-pci",
       "intel-hda",
-      "hda-micro"
+      "hda-micro",
+      "virtio-9p-pci"
     ]
   }
 }

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -11,6 +11,7 @@ import py_compile
 import stat
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 
@@ -216,11 +217,60 @@ def main() -> None:
             subprocess.run([str(mac_share), "--name"], text=True, env=environment, capture_output=True, check=True).stdout == "Mac\n",
             "Mac share link name falls back to Mac without a launcher parameter",
         )
+
+        # Sharing turned off: the link service still runs, drops every link to
+        # the mount point, and gives back an xdg folder that a link displaced.
+        (home / "Documents" / "keep.txt").unlink()
+        (home / "Documents").rmdir()
+        (home / "Documents").symlink_to("/mnt/mac")
+        (home / ".config").mkdir()
+        (home / ".config" / "user-dirs.dirs").write_text(
+            'XDG_DESKTOP_DIR="$HOME/Desktop"\nXDG_DOCUMENTS_DIR="$HOME/Documents"\n'
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "0"
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(
+            not (home / "Mac").is_symlink()
+            and not (home / "Mac").exists()
+            and (home / "Documents").is_dir()
+            and not (home / "Documents").is_symlink(),
+            "Mac share link cleanup runs without a mount and restores a displaced xdg folder",
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "1"
+
+        # Sharing turned off: --mount returns at once instead of polling for
+        # a device that will never appear.
+        environment["OMARCHY_MAC_SHARE_TAG"] = "mac"
+        started = time.monotonic()
+        skipped = subprocess.run(
+            [str(mac_share), "--mount"], text=True, env=environment, capture_output=True, check=False
+        )
+        check(
+            skipped.returncode == 0
+            and "sharing is off" in skipped.stderr
+            and time.monotonic() - started < 2,
+            "Mac share mount returns immediately when the launcher shares nothing",
+        )
+        check(
+            subprocess.run([str(mac_share), "--enabled"], env=environment, check=False).returncode == 1,
+            "Mac share reports sharing off without a launcher parameter",
+        )
+        cmdline.write_text("root=/dev/vda rw omarchy.shared_folder_name=RG9jdW1lbnRz\n")
+        check(
+            subprocess.run([str(mac_share), "--enabled"], env=environment, check=False).returncode == 0,
+            "Mac share reports sharing on with a launcher parameter",
+        )
     share_unit = read(GUEST / "native-overlay/usr/lib/systemd/system/omarchy-native-mac-share.service")
     check(
         "ExecStart=/usr/local/bin/omarchy-native-mac-share --mount" in share_unit
         and "Before=sddm.service" in share_unit,
         "Mac share mounts before the display manager",
+    )
+    link_unit = read(GUEST / "native-overlay/usr/lib/systemd/user/omarchy-native-mac-share-link.service")
+    check(
+        "ExecStart=/usr/local/bin/omarchy-native-mac-share --link" in link_unit
+        and "ConditionPathIsMountPoint" not in link_unit,
+        "Mac share link service runs at login even when nothing is mounted",
     )
 
     audio_input_helper = GUEST / "native-overlay/usr/bin/omarchy-audio-input-set-default"

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -86,6 +86,23 @@ def main() -> None:
         spec["runtime"]["clipboard"]["port"] == "dev.tryomarchy.clipboard",
         "clipboard contract names the virtio port",
     )
+    check(
+        '"$root/usr/local/bin/omarchy-native-mac-share"' in configure
+        and "default.target.wants/omarchy-native-mac-share-link.service" in configure,
+        "guest links the shared Mac folder into each home at login",
+    )
+    shared_folder = spec["runtime"]["sharedFolder"]
+    check(
+        shared_folder["device"] == "virtio-9p-pci"
+        and shared_folder["securityModel"] == "none"
+        and shared_folder["guestOwnerUid"] == 1000
+        and shared_folder["guestOwnerGid"] == 1000
+        and shared_folder["mountTag"] == "mac"
+        and shared_folder["guestMountPoint"] == "/mnt/mac"
+        and shared_folder["guestLinkNameParameter"] == "omarchy.shared_folder_name"
+        and "virtio-9p-pci" in spec["runtime"]["devices"],
+        "shared folder contract maps Mac files to the first Omarchy user over virtio-9p",
+    )
     zram_override = read(
         GUEST
         / "factory-overlay/etc/systemd/zram-generator.conf.d/99-try-omarchy.conf"
@@ -106,6 +123,7 @@ def main() -> None:
     finalizer = read(GUEST / "scripts/finalize-rootfs.sh")
     check("factory" in finalizer and "aarch64" in finalizer, "finalizer enforces the native factory contract")
     check("systemd-growfs-root.service" in finalizer, "factory disk grows on first boot")
+    check("systemctl enable omarchy-native-mac-share.service" in finalizer, "shared Mac folder mounts at boot")
 
     manifest_writer = read(GUEST / "scripts/write-guest-manifest.py")
     check('"kind": "try-omarchy-guest-artifacts"' in manifest_writer, "new artifacts use the native manifest identity")
@@ -131,6 +149,78 @@ def main() -> None:
     check(
         'ATTR{name}=="dev.tryomarchy.clipboard"' in clipboard_rule and 'GROUP="users"' in clipboard_rule,
         "clipboard port is readable by the provisioned users group",
+    )
+    mac_share = GUEST / "native-overlay/usr/local/bin/omarchy-native-mac-share"
+    check(mac_share.stat().st_mode & stat.S_IXUSR != 0, "native Mac share mounter is executable")
+    with tempfile.TemporaryDirectory() as temporary:
+        temporary_path = Path(temporary)
+        virtio_root = temporary_path / "9pnet_virtio"
+        other = virtio_root / "virtio2"
+        other.mkdir(parents=True)
+        (other / "mount_tag").write_bytes(b"other\0")
+        share = virtio_root / "virtio3"
+        share.mkdir()
+        (share / "mount_tag").write_bytes(b"mac\0")
+        environment = os.environ.copy()
+        environment["OMARCHY_MAC_SHARE_VIRTIO_ROOT"] = str(virtio_root)
+        found = subprocess.run(
+            [str(mac_share), "--find-device"],
+            text=True,
+            env=environment,
+            capture_output=True,
+            check=True,
+        )
+        check(found.stdout.strip() == "virtio3", "Mac share mounter finds the virtio-9p device by mount tag")
+        environment["OMARCHY_MAC_SHARE_TAG"] = "absent"
+        missing = subprocess.run(
+            [str(mac_share), "--find-device"],
+            text=True,
+            env=environment,
+            capture_output=True,
+            check=False,
+        )
+        check(missing.returncode == 1 and missing.stdout == "", "Mac share mounter reports an absent share")
+
+        cmdline = temporary_path / "cmdline"
+        # "Wörk Files" as URL-safe base64 without padding, as the launcher emits it.
+        cmdline.write_text("root=/dev/vda rw omarchy.qemu_virgl=1 omarchy.shared_folder_name=V8O2cmsgRmlsZXM\n")
+        home = temporary_path / "home"
+        (home / "Documents").mkdir(parents=True)
+        (home / "OldName").symlink_to("/mnt/mac")
+        environment["OMARCHY_MAC_SHARE_CMDLINE"] = str(cmdline)
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "1"
+        environment["HOME"] = str(home)
+        name = subprocess.run([str(mac_share), "--name"], text=True, env=environment, capture_output=True, check=True)
+        check(name.stdout == "Wörk Files\n", "Mac share link name decodes from the kernel command line")
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(
+            os.readlink(home / "Wörk Files") == "/mnt/mac" and not (home / "OldName").exists(),
+            "Mac share link uses the Mac folder name and drops stale links",
+        )
+        cmdline.write_text("root=/dev/vda rw omarchy.shared_folder_name=RG9jdW1lbnRz\n")
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(
+            os.readlink(home / "Documents") == "/mnt/mac" and not (home / "Wörk Files").exists(),
+            "Mac share link replaces an empty xdg folder of the same name",
+        )
+        (home / "Documents").unlink()
+        (home / "Documents").mkdir()
+        (home / "Documents" / "keep.txt").write_text("keep")
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(
+            (home / "Documents" / "keep.txt").exists() and os.readlink(home / "Mac") == "/mnt/mac",
+            "Mac share link keeps a populated folder and falls back to ~/Mac",
+        )
+        cmdline.write_text("root=/dev/vda rw\n")
+        check(
+            subprocess.run([str(mac_share), "--name"], text=True, env=environment, capture_output=True, check=True).stdout == "Mac\n",
+            "Mac share link name falls back to Mac without a launcher parameter",
+        )
+    share_unit = read(GUEST / "native-overlay/usr/lib/systemd/system/omarchy-native-mac-share.service")
+    check(
+        "ExecStart=/usr/local/bin/omarchy-native-mac-share --mount" in share_unit
+        and "Before=sddm.service" in share_unit,
+        "Mac share mounts before the display manager",
     )
 
     audio_input_helper = GUEST / "native-overlay/usr/bin/omarchy-audio-input-set-default"
@@ -232,6 +322,7 @@ HOTPLUG=1
     shell_files = [
         GUEST / "test",
         display_sync,
+        mac_share,
         *GUEST.glob("*.sh"),
         *GUEST.glob("scripts/*.sh"),
     ]

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -32,6 +32,12 @@
   <string>15.0</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSDesktopFolderUsageDescription</key>
+  <string>Try Omarchy reads and writes this folder only if you choose to share it with Omarchy.</string>
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>Try Omarchy reads and writes this folder only if you choose to share it with Omarchy.</string>
+  <key>NSDownloadsFolderUsageDescription</key>
+  <string>Try Omarchy reads and writes this folder only if you choose to share it with Omarchy.</string>
   <key>NSMicrophoneUsageDescription</key>
   <string>Try Omarchy uses the Mac microphone only when software inside the virtual machine records audio.</string>
   <key>NSPrincipalClass</key>

--- a/macos/README.md
+++ b/macos/README.md
@@ -4,7 +4,7 @@ This directory contains the Apple Silicon application layer:
 
 - a Swift/AppKit lifecycle and permission helper;
 - a pinned, patched QEMU ARM64 runtime using HVF and Cocoa/VirGL;
-- persistent-disk, input, audio-device, clipboard, signing, and DMG tooling.
+- persistent-disk, input, audio-device, clipboard, shared-folder, signing, and DMG tooling.
 
 Use the root Makefile for normal development:
 

--- a/macos/Sources/OmarchyVMHelper/SharedFolder.swift
+++ b/macos/Sources/OmarchyVMHelper/SharedFolder.swift
@@ -1,0 +1,211 @@
+import Darwin
+import Foundation
+
+/// The single Mac folder that the guest may read and write under its own name.
+struct SharedFolderPreference: Equatable {
+    var path: String?
+    var isEnabled: Bool
+
+    static let disabled = Self(path: nil, isEnabled: false)
+
+    /// The folder the launcher exports, or nil when sharing is off.
+    var activePath: String? {
+        guard isEnabled, let path, !path.isEmpty else { return nil }
+        return path
+    }
+}
+
+struct SharedFolderPreferenceStore {
+    static let key = "sharedFolderPreferences"
+    static let schemaVersion = 1
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> SharedFolderPreference {
+        guard let data = defaults.data(forKey: Self.key),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              payload.schemaVersion == Self.schemaVersion else {
+            return .disabled
+        }
+        if let path = payload.path, path.isEmpty || !path.hasPrefix("/") {
+            return .disabled
+        }
+        return SharedFolderPreference(path: payload.path, isEnabled: payload.isEnabled && payload.path != nil)
+    }
+
+    func save(_ preference: SharedFolderPreference) {
+        let payload = Payload(
+            schemaVersion: Self.schemaVersion,
+            path: preference.path,
+            isEnabled: preference.isEnabled
+        )
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+
+    private struct Payload: Codable {
+        let schemaVersion: Int
+        let path: String?
+        let isEnabled: Bool
+    }
+}
+
+enum SharedFolderPolicyError: LocalizedError, Equatable {
+    case notAbsolute
+    case unsupportedCharacter
+    case missing(String)
+    case symbolicLink(String)
+    case notOwned(String)
+    case systemDirectory(String)
+    case homeDirectory
+    case libraryDirectory
+
+    var errorDescription: String? {
+        switch self {
+        case .notAbsolute: "The shared folder must be an absolute path."
+        case .unsupportedCharacter: "The shared folder path contains a character QEMU cannot pass through."
+        case .missing(let path): "The shared folder no longer exists: \(path)"
+        case .symbolicLink(let path): "The shared folder cannot be a symbolic link: \(path)"
+        case .notOwned(let path): "The shared folder must belong to you: \(path)"
+        case .systemDirectory(let path): "System folders cannot be shared: \(path)"
+        case .homeDirectory: "Choose a folder inside your home folder rather than the whole home folder."
+        case .libraryDirectory: "The Library folder cannot be shared."
+        }
+    }
+}
+
+/// Mirrors the launcher script's own checks so the start menu can explain a
+/// rejected folder before QEMU ever sees it. The guest gains full read/write
+/// access as the Mac user, so whole-home and system trees stay off limits.
+enum SharedFolderPolicy {
+    static let environmentKey = "OMARCHY_QEMU_GPU_SHARED_FOLDER"
+    static let systemDirectories: Set<String> = [
+        "/", "/Users", "/private", "/private/tmp", "/tmp", "/System", "/Library", "/Applications", "/Volumes",
+    ]
+
+    /// Returns the canonical, symlink-resolved path for a valid folder.
+    static func validate(
+        _ path: String,
+        homeDirectory: String,
+        fileManager: FileManager = .default
+    ) throws -> String {
+        guard path.hasPrefix("/") else { throw SharedFolderPolicyError.notAbsolute }
+        guard !path.contains("\n"), !path.contains("\r"), !path.contains(","), !path.utf8.contains(0) else {
+            throw SharedFolderPolicyError.unsupportedCharacter
+        }
+        let standardized = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        var information = stat()
+        guard Darwin.lstat(standardized.path, &information) == 0 else {
+            throw SharedFolderPolicyError.missing(standardized.path)
+        }
+        guard (information.st_mode & S_IFMT) != S_IFLNK else {
+            throw SharedFolderPolicyError.symbolicLink(standardized.path)
+        }
+        guard (information.st_mode & S_IFMT) == S_IFDIR else {
+            throw SharedFolderPolicyError.missing(standardized.path)
+        }
+        let canonical = standardized.resolvingSymlinksInPath().path
+        guard !canonical.contains(",") else { throw SharedFolderPolicyError.unsupportedCharacter }
+        guard !systemDirectories.contains(canonical) else {
+            throw SharedFolderPolicyError.systemDirectory(canonical)
+        }
+        guard information.st_uid == getuid() else {
+            throw SharedFolderPolicyError.notOwned(canonical)
+        }
+        let home = URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        guard canonical != home else { throw SharedFolderPolicyError.homeDirectory }
+        let library = home + "/Library"
+        guard canonical != library, !canonical.hasPrefix(library + "/") else {
+            throw SharedFolderPolicyError.libraryDirectory
+        }
+        return canonical
+    }
+
+    /// The name the guest links inside its home directory.
+    static func guestLinkName(_ path: String) -> String {
+        let name = URL(fileURLWithPath: path, isDirectory: true).lastPathComponent
+        return name.isEmpty || name == "/" ? "Mac" : name
+    }
+
+    static func displayPath(_ path: String, homeDirectory: String) -> String {
+        if path == homeDirectory {
+            return "~"
+        }
+        if path.hasPrefix(homeDirectory + "/") {
+            return "~" + path.dropFirst(homeDirectory.count)
+        }
+        return path
+    }
+}
+
+struct SharedFolderLaunchConfiguration: Equatable {
+    let sharedFolder: String?
+    let environment: [String: String]
+
+    /// Publishes the validated folder to the launcher script, or removes any
+    /// inherited value so an environment leak can never share a folder the
+    /// user did not pick in this app.
+    static func make(
+        baseEnvironment: [String: String],
+        preference: SharedFolderPreference,
+        homeDirectory: String,
+        fileManager: FileManager = .default
+    ) -> Self {
+        var environment = baseEnvironment
+        environment.removeValue(forKey: SharedFolderPolicy.environmentKey)
+        guard let path = preference.activePath else {
+            return Self(sharedFolder: nil, environment: environment)
+        }
+        do {
+            let canonical = try SharedFolderPolicy.validate(
+                path,
+                homeDirectory: homeDirectory,
+                fileManager: fileManager
+            )
+            environment[SharedFolderPolicy.environmentKey] = canonical
+            return Self(sharedFolder: canonical, environment: environment)
+        } catch {
+            fputs("[shared-folder] \(error.localizedDescription); sharing is off for this launch\n", stderr)
+            return Self(sharedFolder: nil, environment: environment)
+        }
+    }
+}
+
+/// What the start menu shows for the share row.
+struct SharedFolderMenuState: Equatable {
+    let path: String?
+    let displayPath: String?
+    let isEnabled: Bool
+    let problem: String?
+
+    static let disabled = Self(path: nil, displayPath: nil, isEnabled: false, problem: nil)
+
+    static func make(
+        preference: SharedFolderPreference,
+        homeDirectory: String,
+        fileManager: FileManager = .default
+    ) -> Self {
+        guard let path = preference.path else { return .disabled }
+        var problem: String?
+        if preference.isEnabled {
+            do {
+                _ = try SharedFolderPolicy.validate(path, homeDirectory: homeDirectory, fileManager: fileManager)
+            } catch {
+                problem = error.localizedDescription
+            }
+        }
+        return Self(
+            path: path,
+            displayPath: SharedFolderPolicy.displayPath(path, homeDirectory: homeDirectory),
+            isEnabled: preference.isEnabled,
+            problem: problem
+        )
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -48,6 +48,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private let requestMicrophone: (@escaping (Bool) -> Void) -> Void
     private let storageSpaceEstimate: () -> String?
     private let resetStorage: () -> Void
+    private let sharedFolderStatus: () -> SharedFolderMenuState
+    private let chooseSharedFolder: (String) -> String?
+    private let setSharedFolderEnabled: (Bool) -> Void
     private let launch: () -> Void
     private let canResetStorage: Bool
     private let storageLocation: String?
@@ -68,6 +71,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         storageLocationURL: URL?,
         storageSpaceEstimate: @escaping () -> String?,
         resetStorage: @escaping () -> Void,
+        sharedFolderStatus: @escaping () -> SharedFolderMenuState,
+        chooseSharedFolder: @escaping (String) -> String?,
+        setSharedFolderEnabled: @escaping (Bool) -> Void,
         launch: @escaping () -> Void
     ) {
         self.accessibilityStatus = accessibilityStatus
@@ -79,10 +85,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         self.storageLocationURL = storageLocationURL
         self.storageSpaceEstimate = storageSpaceEstimate
         self.resetStorage = resetStorage
+        self.sharedFolderStatus = sharedFolderStatus
+        self.chooseSharedFolder = chooseSharedFolder
+        self.setSharedFolderEnabled = setSharedFolderEnabled
         self.launch = launch
 
         window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 510),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 590),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -220,7 +229,37 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
                 : #selector(beginMicrophoneRequest)
         )
 
-        let permissionRows = NSStackView(views: [accessibilityRow, separator(), microphoneRow])
+        let sharedFolder = sharedFolderStatus()
+        let sharedFolderDetail: String
+        var sharedFolderActions: [(String, Selector)] = [("Choose…", #selector(beginSharedFolderSelection))]
+        if let problem = sharedFolder.problem {
+            sharedFolderDetail = problem
+        } else if let displayPath = sharedFolder.displayPath, sharedFolder.isEnabled {
+            sharedFolderDetail = "Omarchy can read and write “\(displayPath)” as ~/\(SharedFolderPolicy.guestLinkName(sharedFolder.path ?? displayPath))."
+        } else if let displayPath = sharedFolder.displayPath {
+            sharedFolderDetail = "Off. “\(displayPath)” stays private to this Mac until turned on."
+        } else {
+            sharedFolderDetail = "Optional. Pick a Mac folder to use inside Omarchy under the same name."
+        }
+        if sharedFolder.path != nil {
+            sharedFolderActions.append(
+                sharedFolder.isEnabled
+                    ? ("Turn Off", #selector(disableSharedFolder))
+                    : ("Turn On", #selector(enableSharedFolder))
+            )
+        }
+        let sharedFolderRow = permissionRow(
+            symbolName: "folder",
+            title: "Shared folder",
+            detail: sharedFolderDetail,
+            granted: sharedFolder.isEnabled && sharedFolder.problem == nil,
+            statusLabels: ("●  On", "○  Off"),
+            actions: sharedFolderActions
+        )
+
+        let permissionRows = NSStackView(
+            views: [accessibilityRow, separator(), microphoneRow, separator(), sharedFolderRow]
+        )
         permissionRows.orientation = .vertical
         permissionRows.alignment = .width
         permissionRows.spacing = 0
@@ -416,6 +455,24 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         actionTitle: String?,
         action: Selector
     ) -> NSView {
+        permissionRow(
+            symbolName: symbolName,
+            title: title,
+            detail: detail,
+            granted: granted,
+            statusLabels: ("●  Yes", "○  No"),
+            actions: actionTitle.map { [($0, action)] } ?? []
+        )
+    }
+
+    private func permissionRow(
+        symbolName: String,
+        title: String,
+        detail: String,
+        granted: Bool,
+        statusLabels: (granted: String, denied: String),
+        actions: [(String, Selector)]
+    ) -> NSView {
         let symbol = NSImageView()
         symbol.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
         symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
@@ -439,7 +496,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         labels.alignment = .leading
         labels.spacing = 3
 
-        let statusText = granted ? "●  Yes" : "○  No"
+        let statusText = granted ? statusLabels.granted : statusLabels.denied
         let statusFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
         let status = NSTextField(labelWithString: statusText)
         status.font = statusFont
@@ -464,7 +521,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         status.setContentHuggingPriority(.required, for: .horizontal)
 
         var trailingViews: [NSView] = [status]
-        if let actionTitle {
+        for (actionTitle, action) in actions {
             let button = NSButton(title: actionTitle, target: self, action: action)
             button.controlSize = .small
             button.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
@@ -556,6 +613,44 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
 
     @objc private func resetOmarchy() {
         confirmReset()
+    }
+
+    @objc private func beginSharedFolderSelection() {
+        guard !launchInProgress, !resetInProgress else { return }
+        let panel = NSOpenPanel()
+        panel.title = "Choose a folder to share with Omarchy"
+        panel.message = "Omarchy will be able to read and change everything inside this folder, linked as ~/<folder name>."
+        panel.prompt = "Share"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.resolvesAliases = true
+        if let current = sharedFolderStatus().path {
+            panel.directoryURL = URL(fileURLWithPath: current, isDirectory: true)
+        } else {
+            panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        if let problem = chooseSharedFolder(url.path) {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "That folder can’t be shared"
+            alert.informativeText = problem
+            alert.addButton(withTitle: "OK")
+            alert.beginSheetModal(for: window)
+        }
+        render()
+    }
+
+    @objc private func enableSharedFolder() {
+        setSharedFolderEnabled(true)
+        render()
+    }
+
+    @objc private func disableSharedFolder() {
+        setSharedFolderEnabled(false)
+        render()
     }
 
     private func confirmReset() {

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -10,6 +10,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let baseEnvironment: [String: String]
     private let supervisor: QEMUGPUProcessSupervisor
     private let preferenceStore: AudioRoutingPreferenceStore
+    private let sharedFolderStore: SharedFolderPreferenceStore
     private let deviceProvider: HostAudioDeviceProviding
     private var startMenuWindow: StartMenuWindow?
 
@@ -26,6 +27,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         supervisor: QEMUGPUProcessSupervisor = QEMUGPUProcessSupervisor(),
         preferenceStore: AudioRoutingPreferenceStore = AudioRoutingPreferenceStore(),
+        sharedFolderStore: SharedFolderPreferenceStore = SharedFolderPreferenceStore(),
         deviceProvider: HostAudioDeviceProviding = CoreAudioHostAudioDeviceProvider()
     ) {
         self.launcherURL = launcherURL
@@ -33,6 +35,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         self.baseEnvironment = baseEnvironment
         self.supervisor = supervisor
         self.preferenceStore = preferenceStore
+        self.sharedFolderStore = sharedFolderStore
         self.deviceProvider = deviceProvider
     }
 
@@ -79,6 +82,15 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             },
             resetStorage: { [weak self] in
                 self?.resetVirtualMachine()
+            },
+            sharedFolderStatus: { [weak self] in
+                self?.sharedFolderMenuState() ?? SharedFolderMenuState.disabled
+            },
+            chooseSharedFolder: { [weak self] path in
+                self?.chooseSharedFolder(path)
+            },
+            setSharedFolderEnabled: { [weak self] enabled in
+                self?.setSharedFolderEnabled(enabled)
             },
             launch: { [weak self] in
                 self?.startVirtualMachine()
@@ -195,11 +207,16 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             preferences: preferences,
             catalog: catalog
         )
+        let sharing = SharedFolderLaunchConfiguration.make(
+            baseEnvironment: configuration.environment,
+            preference: sharedFolderStore.load(),
+            homeDirectory: Self.homeDirectory
+        )
 
         try supervisor.start(
             executableURL: launcherURL,
             arguments: arguments,
-            environment: configuration.environment,
+            environment: sharing.environment,
             launchEvent: { [weak self] event in
                 if event == .virtualMachineReady {
                     self?.virtualMachineDidStart()
@@ -215,6 +232,36 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         virtualMachineReachedStart = true
         startMenuWindow?.dismiss()
         startMenuWindow = nil
+    }
+
+    private static var homeDirectory: String {
+        FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+    }
+
+    private func sharedFolderMenuState() -> SharedFolderMenuState {
+        SharedFolderMenuState.make(
+            preference: sharedFolderStore.load(),
+            homeDirectory: Self.homeDirectory
+        )
+    }
+
+    /// Returns an error message when the folder is rejected; otherwise saves
+    /// it as the enabled share.
+    private func chooseSharedFolder(_ path: String) -> String? {
+        do {
+            let canonical = try SharedFolderPolicy.validate(path, homeDirectory: Self.homeDirectory)
+            sharedFolderStore.save(SharedFolderPreference(path: canonical, isEnabled: true))
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    private func setSharedFolderEnabled(_ enabled: Bool) {
+        var preference = sharedFolderStore.load()
+        guard preference.path != nil else { return }
+        preference.isEnabled = enabled
+        sharedFolderStore.save(preference)
     }
 
     private func requestOptionalAccessibilityPermission() {

--- a/macos/Tests/OmarchyVMHelperTests/SharedFolderTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/SharedFolderTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Shared folder policy")
+struct SharedFolderPolicyTests {
+    private func temporaryHome() throws -> URL {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("omarchy-share-home-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        return home.standardizedFileURL
+    }
+
+    @Test("accepts an owned folder inside the home directory and canonicalizes it")
+    func acceptsOwnedFolder() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let shared = home.appendingPathComponent("Public", isDirectory: true)
+        try FileManager.default.createDirectory(at: shared, withIntermediateDirectories: true)
+        let messy = home.path + "/./Public/"
+
+        let canonical = try SharedFolderPolicy.validate(messy, homeDirectory: home.path)
+        #expect(canonical == shared.resolvingSymlinksInPath().path)
+    }
+
+    @Test("rejects the home folder, Library, system roots, symlinks, and missing paths")
+    func rejectsUnsafeFolders() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let library = home.appendingPathComponent("Library/Application Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: library, withIntermediateDirectories: true)
+        let real = home.appendingPathComponent("Real", isDirectory: true)
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        let link = home.appendingPathComponent("Link", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        #expect(throws: SharedFolderPolicyError.homeDirectory) {
+            try SharedFolderPolicy.validate(home.path, homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.libraryDirectory) {
+            try SharedFolderPolicy.validate(library.path, homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.systemDirectory("/")) {
+            try SharedFolderPolicy.validate("/", homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.notAbsolute) {
+            try SharedFolderPolicy.validate("relative/folder", homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.unsupportedCharacter) {
+            try SharedFolderPolicy.validate(real.path + ",id=evil", homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.symbolicLink(link.path)) {
+            try SharedFolderPolicy.validate(link.path, homeDirectory: home.path)
+        }
+        #expect(throws: SharedFolderPolicyError.missing(home.path + "/Nope")) {
+            try SharedFolderPolicy.validate(home.path + "/Nope", homeDirectory: home.path)
+        }
+    }
+
+    @Test("launch environment publishes only a valid enabled folder and strips inherited values")
+    func launchEnvironment() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let shared = home.appendingPathComponent("Shared", isDirectory: true)
+        try FileManager.default.createDirectory(at: shared, withIntermediateDirectories: true)
+        let base = [
+            "KEEP_ME": "yes",
+            SharedFolderPolicy.environmentKey: "/leaked",
+        ]
+
+        let enabled = SharedFolderLaunchConfiguration.make(
+            baseEnvironment: base,
+            preference: SharedFolderPreference(path: shared.path, isEnabled: true),
+            homeDirectory: home.path
+        )
+        #expect(enabled.sharedFolder == shared.resolvingSymlinksInPath().path)
+        #expect(enabled.environment[SharedFolderPolicy.environmentKey] == shared.resolvingSymlinksInPath().path)
+        #expect(enabled.environment["KEEP_ME"] == "yes")
+
+        let disabled = SharedFolderLaunchConfiguration.make(
+            baseEnvironment: base,
+            preference: SharedFolderPreference(path: shared.path, isEnabled: false),
+            homeDirectory: home.path
+        )
+        #expect(disabled.sharedFolder == nil)
+        #expect(disabled.environment == ["KEEP_ME": "yes"])
+
+        let invalid = SharedFolderLaunchConfiguration.make(
+            baseEnvironment: base,
+            preference: SharedFolderPreference(path: home.path, isEnabled: true),
+            homeDirectory: home.path
+        )
+        #expect(invalid.sharedFolder == nil)
+        #expect(invalid.environment[SharedFolderPolicy.environmentKey] == nil)
+    }
+
+    @Test("menu state reports a remembered folder, its switch, and a stale-path problem")
+    func menuState() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let shared = home.appendingPathComponent("Docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: shared, withIntermediateDirectories: true)
+
+        let on = SharedFolderMenuState.make(
+            preference: SharedFolderPreference(path: shared.path, isEnabled: true),
+            homeDirectory: home.path
+        )
+        #expect(on == SharedFolderMenuState(path: shared.path, displayPath: "~/Docs", isEnabled: true, problem: nil))
+
+        let stale = SharedFolderMenuState.make(
+            preference: SharedFolderPreference(path: home.path + "/Gone", isEnabled: true),
+            homeDirectory: home.path
+        )
+        #expect(stale.isEnabled)
+        #expect(stale.problem != nil)
+
+        #expect(SharedFolderMenuState.make(preference: .disabled, homeDirectory: home.path) == .disabled)
+    }
+}
+
+@Suite("Shared folder guest link name")
+struct SharedFolderGuestLinkNameTests {
+    @Test("the guest link takes the Mac folder's own name")
+    func usesBasename() {
+        #expect(SharedFolderPolicy.guestLinkName("/Users/someone/Work") == "Work")
+        #expect(SharedFolderPolicy.guestLinkName("/Users/someone/Wörk Files/") == "Wörk Files")
+        #expect(SharedFolderPolicy.guestLinkName("/") == "Mac")
+    }
+}
+
+@Suite("Shared folder preferences")
+struct SharedFolderPreferenceStoreTests {
+    @Test("a chosen folder and its switch survive a relaunch")
+    func persistsSelection() {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+
+        #expect(fixture.store.load() == .disabled)
+        fixture.store.save(SharedFolderPreference(path: "/Users/me/Public", isEnabled: true))
+        #expect(SharedFolderPreferenceStore(defaults: fixture.defaults).load()
+            == SharedFolderPreference(path: "/Users/me/Public", isEnabled: true))
+        fixture.store.save(SharedFolderPreference(path: "/Users/me/Public", isEnabled: false))
+        #expect(fixture.store.load() == SharedFolderPreference(path: "/Users/me/Public", isEnabled: false))
+        #expect(fixture.store.load().activePath == nil)
+    }
+
+    @Test("corrupt, relative, or future-schema values fall back to disabled")
+    func rejectsCorruptValues() {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+
+        fixture.defaults.set(Data("junk".utf8), forKey: SharedFolderPreferenceStore.key)
+        #expect(fixture.store.load() == .disabled)
+        fixture.defaults.set(
+            Data(#"{"schemaVersion":99,"path":"/x","isEnabled":true}"#.utf8),
+            forKey: SharedFolderPreferenceStore.key
+        )
+        #expect(fixture.store.load() == .disabled)
+        fixture.defaults.set(
+            Data(#"{"schemaVersion":1,"path":"relative","isEnabled":true}"#.utf8),
+            forKey: SharedFolderPreferenceStore.key
+        )
+        #expect(fixture.store.load() == .disabled)
+        fixture.defaults.set(
+            Data(#"{"schemaVersion":1,"path":null,"isEnabled":true}"#.utf8),
+            forKey: SharedFolderPreferenceStore.key
+        )
+        #expect(fixture.store.load() == .disabled)
+    }
+
+    private final class DefaultsFixture {
+        let suiteName = "dev.tryomarchy.native.tests.\(UUID().uuidString)"
+        let defaults: UserDefaults
+        let store: SharedFolderPreferenceStore
+
+        init() {
+            defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            store = SharedFolderPreferenceStore(defaults: defaults)
+        }
+
+        func cleanUp() {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -18,6 +18,9 @@ struct StartMenuWindowTests {
             storageLocationURL: nil,
             storageSpaceEstimate: { nil },
             resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
             launch: {}
         )
         menu.show()

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -12,7 +12,7 @@ atomically stage it at:
   macos/.build/qemu-gpu-runtime
 
 The build is Apple-Silicon/HVF-only. It enables Cocoa+VirGL, SLIRP user
-networking, and SDL duplex audio. All downloaded source archives and wheels are
+networking, SDL duplex audio, and virtio-9p folder sharing. All downloaded source archives and wheels are
 immutable and checksum-pinned; scratch sources are removed on every exit.
 
 With --archive-dir, reuse already-downloaded pinned archives from DIR. Every
@@ -44,6 +44,7 @@ native_dir=$(cd "$(dirname "$0")" && pwd -P)
 identity_patch="$native_dir/patches/qemu-cocoa-product-identity.patch"
 display_patch="$native_dir/patches/qemu-cocoa-dynamic-display.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
+shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 prepare_runtime="$native_dir/prepare-qemu-gpu-runtime.sh"
 
 qemu_commit=cf3e71d8fc8ba681266759bb6cb2e45a45983e3e
@@ -62,6 +63,7 @@ gpu_fix_patch_sha256=2b0a589d5821fbbfaa65177c97395ec50382373373e5c6860821279f07d
 identity_patch_sha256=5c9358c2858a74d6a678eacaae550a021f3e616c98c4e4e98c0e50bd869a0666
 display_patch_sha256=19392fe5723829edea348b82a6b0a74f874724af243ed0fb9101007a22fa5bbb
 audio_device_patch_sha256=20469691f4cdabcd6b9513d6bf00fab9f66983e17b1e8477cc2e5ac47416feed
+shared_folder_patch_sha256=585a5ed40cc7e4a155ca799d731e15354db9e75d4f517d0689be60200750f3e3
 
 keycodemap_commit=f5772a62ec52591ff6870b7e8ef32482371f22c6
 keycodemap_root="keycodemapdb-$keycodemap_commit"
@@ -123,6 +125,8 @@ macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
   die "missing dynamic-display patch: $display_patch"
 [[ -f $audio_device_patch && ! -L $audio_device_patch ]] || \
   die "missing SDL audio-device patch: $audio_device_patch"
+[[ -f $shared_folder_patch && ! -L $shared_folder_patch ]] || \
+  die "missing 9p shared-folder patch: $shared_folder_patch"
 [[ -x $prepare_runtime && ! -L $prepare_runtime ]] || \
   die "missing runtime preparation script: $prepare_runtime"
 if [[ -n $archive_cache ]]; then
@@ -302,13 +306,16 @@ verify_file_sha "Try Omarchy Cocoa product-identity patch" \
 verify_file_sha "Try Omarchy dynamic-display patch" "$display_patch" "$display_patch_sha256"
 verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
+verify_file_sha "Try Omarchy 9p shared-folder patch" \
+  "$shared_folder_patch" "$shared_folder_patch_sha256"
 
-log "Applying the exact render, product-identity, dynamic-display, and audio-device patches"
+log "Applying the exact render, product-identity, dynamic-display, audio-device, and shared-folder patches"
 patch -d "$source_dir" -p1 -f -i "$texture_patch"
 patch -d "$source_dir" -p1 -f -i "$gpu_fix_patch"
 patch -d "$source_dir" -p1 -f -i "$identity_patch"
 patch -d "$source_dir" -p1 -f -i "$display_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
+patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 
 virgl_root="$dependency_root/virglrenderer/$virgl_version"
 angle_root="$dependency_root/angle/$angle_version"
@@ -339,7 +346,7 @@ fallback_libraries="$virgl_root/lib:$epoxy_root/lib:$angle_root/lib"
 
 build_dir="$source_dir/build"
 mkdir "$build_dir"
-log "Configuring QEMU 10.2.50 (HVF-only, Cocoa/VirGL, SLIRP, SDL audio)"
+log "Configuring QEMU 10.2.50 (HVF-only, Cocoa/VirGL, SLIRP, SDL audio, virtio-9p)"
 (
   cd "$build_dir"
   env PKG_CONFIG_PATH="$pkg_config_path" \
@@ -359,6 +366,7 @@ log "Configuring QEMU 10.2.50 (HVF-only, Cocoa/VirGL, SLIRP, SDL audio)"
       --enable-fdt=internal \
       --enable-sdl \
       --audio-drv-list=sdl \
+      --enable-virtfs \
       --disable-debug-info \
       --disable-werror \
       --disable-download \

--- a/macos/patches/qemu-9p-guest-owner.patch
+++ b/macos/patches/qemu-9p-guest-owner.patch
@@ -1,0 +1,154 @@
+diff --git a/fsdev/file-op-9p.h b/fsdev/file-op-9p.h
+--- a/fsdev/file-op-9p.h
++++ b/fsdev/file-op-9p.h
+@@ -96,6 +96,12 @@
+     FsThrottle fst;
+     mode_t fmode;
+     mode_t dmode;
++    /*
++     * Try Omarchy: present the exporting host user's files to the guest as
++     * these credentials (security_model=none only). -1 disables the remap.
++     */
++    uid_t guest_owner_uid;
++    gid_t guest_owner_gid;
+ } FsDriverEntry;
+ 
+ struct FsContext {
+@@ -109,6 +115,8 @@
+     void *private;
+     mode_t fmode;
+     mode_t dmode;
++    uid_t guest_owner_uid;
++    gid_t guest_owner_gid;
+ };
+ 
+ struct V9fsPath {
+diff --git a/fsdev/qemu-fsdev-opts.c b/fsdev/qemu-fsdev-opts.c
+--- a/fsdev/qemu-fsdev-opts.c
++++ b/fsdev/qemu-fsdev-opts.c
+@@ -46,6 +46,12 @@
+         }, {
+             .name = "dmode",
+             .type = QEMU_OPT_NUMBER,
++        }, {
++            .name = "guest_owner_uid",
++            .type = QEMU_OPT_NUMBER,
++        }, {
++            .name = "guest_owner_gid",
++            .type = QEMU_OPT_NUMBER,
+         },
+ 
+         THROTTLE_OPTS,
+@@ -91,6 +97,12 @@
+             .type = QEMU_OPT_NUMBER,
+         }, {
+             .name = "dmode",
++            .type = QEMU_OPT_NUMBER,
++        }, {
++            .name = "guest_owner_uid",
++            .type = QEMU_OPT_NUMBER,
++        }, {
++            .name = "guest_owner_gid",
+             .type = QEMU_OPT_NUMBER,
+         },
+ 
+diff --git a/fsdev/qemu-fsdev.c b/fsdev/qemu-fsdev.c
+--- a/fsdev/qemu-fsdev.c
++++ b/fsdev/qemu-fsdev.c
+@@ -59,6 +59,8 @@
+             "fmode",
+             "dmode",
+             "multidevs",
++            "guest_owner_uid",
++            "guest_owner_gid",
+             "throttling.bps-total",
+             "throttling.bps-read",
+             "throttling.bps-write",
+diff --git a/hw/9pfs/9p-local.c b/hw/9pfs/9p-local.c
+--- a/hw/9pfs/9p-local.c
++++ b/hw/9pfs/9p-local.c
+@@ -182,6 +182,25 @@
+     fclose(fp);
+ }
+ 
++/*
++ * Try Omarchy: with security_model=none every host operation runs as the
++ * QEMU process user, so files that user owns are the ones the guest can
++ * actually modify. Report them as owned by the configured guest account so
++ * the guest kernel's permission checks agree with the host's.
++ */
++static void local_remap_guest_owner(FsContext *fs_ctx, struct stat *stbuf)
++{
++    if (!(fs_ctx->export_flags & V9FS_SM_NONE)) {
++        return;
++    }
++    if (fs_ctx->guest_owner_uid != (uid_t)-1 && stbuf->st_uid == geteuid()) {
++        stbuf->st_uid = fs_ctx->guest_owner_uid;
++    }
++    if (fs_ctx->guest_owner_gid != (gid_t)-1 && stbuf->st_gid == getegid()) {
++        stbuf->st_gid = fs_ctx->guest_owner_gid;
++    }
++}
++
+ static int local_lstat(FsContext *fs_ctx, V9fsPath *fs_path, struct stat *stbuf)
+ {
+     int err = -1;
+@@ -224,6 +243,7 @@
+     } else if (fs_ctx->export_flags & V9FS_SM_MAPPED_FILE) {
+         local_mapped_file_attr(dirfd, name, stbuf);
+     }
++    local_remap_guest_owner(fs_ctx, stbuf);
+ 
+ err_out:
+     close_preserve_errno(dirfd);
+@@ -811,6 +831,7 @@
+         errno = EOPNOTSUPP;
+         return -1;
+     }
++    local_remap_guest_owner(fs_ctx, stbuf);
+     return err;
+ }
+ 
+@@ -1581,6 +1602,30 @@
+             error_setg(errp, "dmode is only valid for mapped security modes");
+             return -1;
+         }
++    }
++
++    fse->guest_owner_uid = (uid_t)-1;
++    fse->guest_owner_gid = (gid_t)-1;
++    if (qemu_opt_find(opts, "guest_owner_uid") ||
++        qemu_opt_find(opts, "guest_owner_gid")) {
++        uint64_t owner_uid = qemu_opt_get_number(opts, "guest_owner_uid",
++                                                 (uint64_t)-1);
++        uint64_t owner_gid = qemu_opt_get_number(opts, "guest_owner_gid",
++                                                 (uint64_t)-1);
++
++        if (!(fse->export_flags & V9FS_SM_NONE)) {
++            error_setg(errp, "guest_owner_uid and guest_owner_gid are only "
++                       "valid for security_model=none");
++            return -1;
++        }
++        if (owner_uid == (uint64_t)-1 || owner_gid == (uint64_t)-1 ||
++            owner_uid >= (uid_t)-1 || owner_gid >= (gid_t)-1) {
++            error_setg(errp, "guest_owner_uid and guest_owner_gid must both "
++                       "be set to valid ids");
++            return -1;
++        }
++        fse->guest_owner_uid = (uid_t)owner_uid;
++        fse->guest_owner_gid = (gid_t)owner_gid;
+     }
+ 
+     fse->path = g_strdup(path);
+diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
+--- a/hw/9pfs/9p.c
++++ b/hw/9pfs/9p.c
+@@ -4329,6 +4329,8 @@
+ 
+     s->ctx.fmode = fse->fmode;
+     s->ctx.dmode = fse->dmode;
++    s->ctx.guest_owner_uid = fse->guest_owner_uid;
++    s->ctx.guest_owner_gid = fse->guest_owner_gid;
+ 
+     s->fids = g_hash_table_new(NULL, NULL);
+     qemu_co_rwlock_init(&s->rename_lock);

--- a/macos/prepare-qemu-gpu-runtime.sh
+++ b/macos/prepare-qemu-gpu-runtime.sh
@@ -573,6 +573,12 @@ verify_runtime_tree() {
       die "source-built QEMU is missing the duplex hda-micro codec"
     [[ $device_help == *'name "virtio-net-pci"'* ]] || \
       die "source-built QEMU is missing the virtio-net-pci device"
+    [[ $device_help == *'name "virtio-9p-pci"'* ]] || \
+      die "source-built QEMU is missing the virtio-9p-pci shared-folder device"
+    for marker in guest_owner_uid guest_owner_gid; do
+      LC_ALL=C grep -aFq "$marker" "$qemu" || \
+        die "source-built QEMU is missing the $marker shared-folder option"
+    done
   fi
 }
 

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -125,6 +125,7 @@ for device in \
   virtconsole \
   virtserialport \
   virtio-balloon-pci \
+  virtio-9p-pci \
   virtio-blk-pci \
   virtio-gpu-gl-pci \
   virtio-keyboard-pci \
@@ -133,6 +134,11 @@ for device in \
   virtio-serial-pci \
   virtio-tablet-pci; do
   require_qemu_device "$device"
+done
+for marker in guest_owner_uid guest_owner_gid; do
+  LC_ALL=C grep -aFq "$marker" "$qemu_bin" || {
+    fail "staged QEMU lacks the shared-folder owner mapping; run make runtime"
+  }
 done
 
 qemu_entitlements=$(codesign -d --entitlements - "$qemu_bin" 2>&1) || {
@@ -351,6 +357,7 @@ runtime = exact_keys(
         "minimumMemoryMiB",
         "network",
         "recommendedMemoryMiB",
+        "sharedFolder",
         "storage",
         "virtualMachineMonitor",
     },
@@ -369,11 +376,22 @@ expected_devices = [
     "virtio-balloon-pci",
     "intel-hda",
     "hda-micro",
+    "virtio-9p-pci",
 ]
 clipboard = {
     "device": "virtserialport",
     "port": "dev.tryomarchy.clipboard",
     "formats": ["text/plain;charset=utf-8", "image/png"],
+}
+shared_folder = {
+    "device": "virtio-9p-pci",
+    "fsdriver": "local",
+    "securityModel": "none",
+    "mountTag": "mac",
+    "guestOwnerUid": 1000,
+    "guestOwnerGid": 1000,
+    "guestMountPoint": "/mnt/mac",
+    "guestLinkNameParameter": "omarchy.shared_folder_name",
 }
 graphics = {
     "device": "virtio-gpu-gl-pci",
@@ -414,6 +432,7 @@ if (
     or runtime.get("audio") != audio
     or runtime.get("storage") != storage
     or runtime.get("clipboard") != clipboard
+    or runtime.get("sharedFolder") != shared_folder
     or runtime.get("devices") != expected_devices
     or runtime.get("minimumMemoryMiB") != 2048
     or runtime.get("recommendedMemoryMiB") != 4096
@@ -478,6 +497,8 @@ for required in ("root=/dev/vda", "rw", "rootwait", "console=tty0", "console=hvc
         fail(f"kernel command line must contain exactly one {required}")
 if any(argument.startswith("omarchy.qemu_virgl=") for argument in arguments):
     fail("kernel command line already contains a QEMU VirGL role")
+if any(argument.startswith("omarchy.shared_folder_name=") for argument in arguments):
+    fail("kernel command line already contains a shared folder name")
 
 records = manifest.get("artifacts")
 if not isinstance(records, list) or len(records) != len(expected_artifacts):
@@ -602,6 +623,50 @@ if (( host_cpu_count < vcpu_count )); then
   vcpu_count=$host_cpu_count
 fi
 (( vcpu_count >= 4 )) || fail "the ARM guest requires at least four host CPUs"
+
+# The launcher publishes one optional Mac folder for the guest. The Swift app
+# canonicalizes and validates the selection first; re-check here so a stray
+# environment value can never export an unsafe tree. Empty means disabled.
+shared_folder=${OMARCHY_QEMU_GPU_SHARED_FOLDER:-}
+shared_folder_mount_tag=mac
+shared_folder_guest_owner_uid=1000
+shared_folder_guest_owner_gid=1000
+shared_folder_kernel_argument=""
+if [[ -n $shared_folder ]]; then
+  [[ $shared_folder == /* ]] || fail "shared folder must be an absolute path"
+  [[ $shared_folder != *$'\n'* && $shared_folder != *$'\r'* && $shared_folder != *,* ]] || {
+    fail "shared folder path contains an unsupported character"
+  }
+  [[ -d $shared_folder && ! -L $shared_folder ]] || {
+    fail "shared folder is missing or is a symbolic link: $shared_folder"
+  }
+  shared_folder=$(cd "$shared_folder" && pwd -P) || fail "cannot resolve the shared folder"
+  [[ $(stat -f '%u' "$shared_folder") == $(id -u) ]] || {
+    fail "shared folder must be owned by this user: $shared_folder"
+  }
+  home_dir=$(cd "$HOME" 2>/dev/null && pwd -P || true)
+  case "$shared_folder" in
+    /|/Users|/private|/private/tmp|/tmp|/System|/Library|/Applications|/Volumes)
+      fail "refusing to share a system directory: $shared_folder"
+      ;;
+  esac
+  if [[ -n $home_dir ]]; then
+    [[ $shared_folder != "$home_dir" ]] || fail "refusing to share the whole home folder"
+    [[ $shared_folder != "$home_dir/Library" && $shared_folder != "$home_dir/Library/"* ]] || {
+      fail "refusing to share the Library folder"
+    }
+  fi
+  # The guest links ~/<name> to the mount so a shared ~/Work appears as ~/Work.
+  # The name travels on the kernel command line as URL-safe base64, which keeps
+  # spaces and non-ASCII names intact inside one space-delimited parameter.
+  shared_folder_name=${shared_folder##*/}
+  [[ -n $shared_folder_name && $shared_folder_name != . && $shared_folder_name != .. ]] || {
+    fail "shared folder has no usable name: $shared_folder"
+  }
+  shared_folder_name_encoded=$(printf '%s' "$shared_folder_name" | base64 | tr '+/' '-_' | tr -d '=\n')
+  [[ $shared_folder_name_encoded =~ ^[A-Za-z0-9_-]+$ ]] || fail "cannot encode the shared folder name"
+  shared_folder_kernel_argument=" omarchy.shared_folder_name=$shared_folder_name_encoded"
+fi
 
 work_dir=""
 owner_marker=""
@@ -793,7 +858,7 @@ qemu_args=(
   -qmp "unix:$qmp_socket,server=on,wait=off"
   -kernel "$guest_dir/vmlinuz-linux"
   -initrd "$guest_dir/initramfs-linux.img"
-  -append "$kernel_command_line omarchy.qemu_virgl=1"
+  -append "$kernel_command_line omarchy.qemu_virgl=1$shared_folder_kernel_argument"
   -drive "if=none,id=omarchy-root,file=$working_disk,format=raw,media=disk,cache=writeback"
   -device 'virtio-blk-pci,drive=omarchy-root,serial=omarchy-root'
   -device "$gpu_device"
@@ -816,6 +881,17 @@ qemu_args=(
   -device 'virtserialport,bus=omarchy-serial.0,nr=2,chardev=omarchy-clipboard-bridge,name=dev.tryomarchy.clipboard'
 )
 
+if [[ -n $shared_folder ]]; then
+  # security_model=none performs every host operation as this Mac user and
+  # ignores guest chown requests, so the Mac keeps real modes and ownership.
+  # The patched local driver reports this user's files as the Omarchy owner
+  # account so the guest kernel grants matching read/write access.
+  qemu_args+=(
+    -fsdev "local,id=omarchy-share,path=$shared_folder,security_model=none,multidevs=remap,guest_owner_uid=$shared_folder_guest_owner_uid,guest_owner_gid=$shared_folder_guest_owner_gid"
+    -device "virtio-9p-pci,fsdev=omarchy-share,mount_tag=$shared_folder_mount_tag,romfile="
+  )
+fi
+
 # SDL2 has one legacy process-wide override that would collapse input and
 # output onto the same named device. The patched QEMU backend uses the two
 # direction-specific Omarchy variables instead; unset means live System Default.
@@ -835,6 +911,11 @@ if [[ ${OMARCHY_QEMU_GPU_DRY_RUN:-0} == 1 ]]; then
     "$native_bridge" "$audio_bridge_socket" "$audio_route_dir" >&2
   printf '\n[qemu-gpu] clipboard bridge command: %q --bridge-native-clipboard QEMU_PID %q' \
     "$native_bridge" "$clipboard_bridge_socket" >&2
+  if [[ -n $shared_folder ]]; then
+    printf '\n[qemu-gpu] shared folder: %q' "$shared_folder" >&2
+  else
+    printf '\n[qemu-gpu] shared folder: disabled' >&2
+  fi
   printf '\n' >&2
   exit 0
 fi
@@ -847,6 +928,9 @@ if [[ $QEMU_SELECTED_STORAGE_MODE == persistent ]]; then
   echo "[qemu-gpu] User data: $QEMU_PERSISTENT_STORAGE_DIRECTORY" >&2
 else
   echo "[qemu-gpu] Starting a disposable ARM64 VirGL guest with $vcpu_count vCPUs and 4 GiB RAM." >&2
+fi
+if [[ -n $shared_folder ]]; then
+  echo "[qemu-gpu] Shared folder: $shared_folder (guest ~/$shared_folder_name)" >&2
 fi
 "$qemu_bin" "${qemu_args[@]}" &
 qemu_pid=$!

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -641,6 +641,15 @@ if [[ -n $shared_folder ]]; then
     fail "shared folder is missing or is a symbolic link: $shared_folder"
   }
   shared_folder=$(cd "$shared_folder" && pwd -P) || fail "cannot resolve the shared folder"
+  # A symlink in the middle of the path can resolve to a name that the first
+  # check never saw, so validate the canonical path again before it goes into
+  # QEMU's comma-delimited -fsdev option.
+  [[ $shared_folder == /* && -d $shared_folder && ! -L $shared_folder ]] || {
+    fail "shared folder resolves outside a plain directory: $shared_folder"
+  }
+  [[ $shared_folder != *$'\n'* && $shared_folder != *$'\r'* && $shared_folder != *,* ]] || {
+    fail "shared folder resolves to a path with an unsupported character: $shared_folder"
+  }
   [[ $(stat -f '%u' "$shared_folder") == $(id -u) ]] || {
     fail "shared folder must be owned by this user: $shared_folder"
   }


### PR DESCRIPTION
Closes #11

## Summary

- The start menu gains a **Shared folder** row (Choose…, Turn On/Off). One Mac folder is exported to the guest over virtio-9p and linked into the Omarchy home under its own name, so a shared `~/Work` appears as `~/Work`.
- Ownership: Linux 9p has no idmapped-mount support and `bindfs` is not packaged for Arch Linux ARM, so the mapping lives on the host. A small QEMU patch (`macos/patches/qemu-9p-guest-owner.patch`, applies cleanly to the pinned commit) adds `guest_owner_uid`/`guest_owner_gid` fsdev options for `security_model=none`: host operations still run as the Mac user and the Mac keeps real modes/ownership, but that user's files are reported as the first Omarchy account (uid/gid 1000) so guest permission checks agree with the host. `--enable-virtfs` is added to the runtime build and the device/options are verified at build, prepare, and launch time.
- Policy: the Swift app validates and canonicalizes the choice (no `/`, `/Users`, the whole home, `~/Library`, symlinks, non-owned dirs, or paths containing `,`), persists it in UserDefaults, and passes it via `OMARCHY_QEMU_GPU_SHARED_FOLDER`; `run-qemu-gpu.sh` re-validates before emitting the fsdev/device pair. The folder name reaches the guest as `omarchy.shared_folder_name=<base64url>` on the kernel command line. `Info.plist` gains Desktop/Documents/Downloads usage strings for the TCC prompt.
- Guest: `omarchy-native-mac-share` mounts the `mac` tag at `/mnt/mac` before the display manager; a user unit links `~/<name>` at login, replacing only an empty xdg folder of the same name and falling back to `~/Mac` otherwise. The pinned kernel builds 9p as modules.
- Contract, validator, `verify.py`, and Swift tests cover the device, options, policy, preferences, and link behavior.

Sharing is off until a folder is chosen, so existing users see no change. A guest rebuild changes the factory image identity (reset required), as with any `guest/` change.

## Test plan

- [x] `swift test` (52 tests) and `guest/test` pass
- [x] `make runtime`: virtfs enabled, patch applies, `virtio-9p-pci` present; invalid option combinations are rejected with the intended messages
- [x] Full `make build`, first-boot provisioning, then browsing a shared Mac folder from the guest
- [ ] Files created in the guest show up owned by the Mac user on macOS (expected from security_model=none; not yet checked by hand)

Note: building on current Homebrew (sdl2-compat/SDL3) needs #6 first; this PR does not touch those pins. Independent of the clipboard PR; both touch `run-qemu-gpu.sh`, `spec.json`, `configure-rootfs.sh`, and `verify.py` in adjacent hunks, so whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GopAGVNHBeeDUwEQ21Qotf


