### PR TITLE
Fix Start Menu UI alignment

### DIFF
--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -311,20 +311,22 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         launchButton.controlSize = .large
         launchButton.font = launchButtonFont
         launchButton.isEnabled = !launchInProgress && !resetInProgress && !microphoneRequestInFlight
-        if !launchButton.isEnabled {
-            launchButton.title = ""
-            let disabledTitle = MouseIgnoringTextField(labelWithString: launchButtonTitle)
-            disabledTitle.font = launchButtonFont
-            disabledTitle.textColor = .controlTextColor
-            disabledTitle.alignment = .center
-            disabledTitle.setAccessibilityElement(false)
-            disabledTitle.translatesAutoresizingMaskIntoConstraints = false
-            launchButton.addSubview(disabledTitle)
-            NSLayoutConstraint.activate([
-                disabledTitle.centerXAnchor.constraint(equalTo: launchButton.centerXAnchor),
-                disabledTitle.centerYAnchor.constraint(equalTo: launchButton.centerYAnchor),
-            ])
-        }
+        launchButton.title = ""
+        launchButton.identifier = NSUserInterfaceItemIdentifier("launch-button")
+        let launchButtonLabel = MouseIgnoringTextField(labelWithString: launchButtonTitle)
+        launchButtonLabel.font = launchButtonFont
+        launchButtonLabel.textColor = launchButton.isEnabled
+            ? .alternateSelectedControlTextColor
+            : .controlTextColor
+        launchButtonLabel.alignment = .center
+        launchButtonLabel.setAccessibilityElement(false)
+        launchButtonLabel.identifier = NSUserInterfaceItemIdentifier("launch-button-label")
+        launchButtonLabel.translatesAutoresizingMaskIntoConstraints = false
+        launchButton.addSubview(launchButtonLabel)
+        NSLayoutConstraint.activate([
+            launchButtonLabel.centerXAnchor.constraint(equalTo: launchButton.centerXAnchor),
+            launchButtonLabel.centerYAnchor.constraint(equalTo: launchButton.centerYAnchor),
+        ])
         launchButton.translatesAutoresizingMaskIntoConstraints = false
         launchButton.setAccessibilityLabel(launchInProgress ? "Launching Omarchy" : "Launch Omarchy")
         if launchInProgress {
@@ -466,6 +468,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             let button = NSButton(title: actionTitle, target: self, action: action)
             button.controlSize = .small
             button.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
+            button.identifier = NSUserInterfaceItemIdentifier("permission-action-\(symbolName)")
             trailingViews.append(button)
         }
         let trailing = NSStackView(views: trailingViews)
@@ -482,6 +485,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             row.heightAnchor.constraint(greaterThanOrEqualToConstant: 76),
             trailing.widthAnchor.constraint(equalToConstant: 112),
         ])
+        if let button = trailingViews.last as? NSButton {
+            button.widthAnchor.constraint(equalTo: trailing.widthAnchor).isActive = true
+        }
         labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
         labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         trailing.setContentHuggingPriority(.required, for: .horizontal)

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Start menu layout")
+@MainActor
+struct StartMenuWindowTests {
+    @Test("missing-permission actions share one aligned column and launch text is centered")
+    func permissionActionsAndLaunchTitleStayAligned() throws {
+        _ = NSApplication.shared
+        let menu = StartMenuWindow(
+            accessibilityStatus: { false },
+            microphoneStatus: { .notDetermined },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(false) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            launch: {}
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let content = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })?.contentView
+        )
+        content.layoutSubtreeIfNeeded()
+
+        let accessibilityAction = try #require(
+            descendant(withIdentifier: "permission-action-accessibility", in: content)
+        )
+        let microphoneAction = try #require(
+            descendant(withIdentifier: "permission-action-mic", in: content)
+        )
+        let accessibilityFrame = accessibilityAction.convert(accessibilityAction.bounds, to: content)
+        let microphoneFrame = microphoneAction.convert(microphoneAction.bounds, to: content)
+        #expect(abs(accessibilityFrame.minX - microphoneFrame.minX) < 0.5)
+        #expect(abs(accessibilityFrame.width - microphoneFrame.width) < 0.5)
+
+        let launchButton = try #require(
+            descendant(withIdentifier: "launch-button", in: content)
+        )
+        let launchLabel = try #require(
+            descendant(withIdentifier: "launch-button-label", in: launchButton)
+        )
+        let labelFrame = launchLabel.convert(launchLabel.bounds, to: launchButton)
+        #expect(abs(labelFrame.midX - launchButton.bounds.midX) <= 0.5)
+        #expect(abs(labelFrame.midY - launchButton.bounds.midY) <= 0.5)
+    }
+
+    private func descendant(withIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.identifier?.rawValue == identifier {
+            return view
+        }
+        for subview in view.subviews {
+            if let match = descendant(withIdentifier: identifier, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary
- Align permission action buttons to a consistent column width
- Center the launch button label in enabled and disabled states
- Add accessibility identifiers for start menu controls
- Add unit coverage for action alignment and launch label centering

## Testing
- Added and ran Swift Testing coverage for start menu layout alignment