### PR TITLE
Make make make better builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+__pycache__/
+.pytest_cache/
 *.pem
 .env*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,5 +24,10 @@ Generated files in `dist/` and build caches in `macos/.build/` and
 artifacts and caches. `make clean-all` additionally destroys persistent local
 VM data and should only be used when a complete reset is intended.
 
+Component builds use content-hashed state under `.build/state/`. A state file is
+published only after the build succeeds and its output passes validation. Use
+`FORCE=1` when reviewing reproducibility or when an intentionally unchanged
+input must be rebuilt; do not work around the cache by editing generated state.
+
 By contributing, you agree that your contribution is licensed under the MIT
 License in this repository.

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ override DIST := $(ROOT)/dist
 override GUEST_DIST := $(DIST)/guest
 override APP := $(DIST)/Try Omarchy.app
 override DMG := $(DIST)/Try Omarchy.dmg
+override BUILD_CACHE := $(ROOT)/scripts/build-cache.py
+override BUILD_STATE := $(ROOT)/.build/state
 RELEASE_SIGN_IDENTITY ?= Developer ID Application: Eduardo Martinez (RZC79MPD34)
 RELEASE_NOTARY_PROFILE ?= try-omarchy
+FORCE ?= 0
 
 .DEFAULT_GOAL := help
-.PHONY: help doctor test guest runtime app build run run-ephemeral reset package release clean clean-all clean-guest
+.PHONY: help doctor test guest runtime app build run run-ephemeral reset package release release-preflight clean clean-all clean-guest
 
 help:
 	@printf '%s\n' \
@@ -17,15 +20,16 @@ help:
 	  '' \
 	  '  make doctor         Check the local toolchain' \
 	  '  make test           Run native and guest contract tests' \
-	  '  make build          Build guest, runtime, and app' \
+	  '  make build          Build only changed guest, runtime, and app inputs' \
+	  '  make build FORCE=1  Rebuild every component' \
 	  '  make run            Build the app from existing artifacts and open it' \
 	  '  make package        Create an ad-hoc DMG for local testing' \
 	  '  make release        Create a signed and notarized distribution DMG' \
 	  '' \
 	  'Component builds:' \
-	  '  make guest          Build dist/guest in Docker' \
-	  '  make runtime        Build macos/.build/qemu-gpu-runtime' \
-	  '  make app            Build dist/Try Omarchy.app from both artifacts' \
+	  '  make guest          Ensure dist/guest is current (Docker)' \
+	  '  make runtime        Ensure macos/.build/qemu-gpu-runtime is current' \
+	  '  make app            Ensure both artifacts and the app are current' \
 	  '' \
 	  'Storage:' \
 	  '  make run-ephemeral  Run without retaining VM changes' \
@@ -42,21 +46,28 @@ doctor:
 	@printf 'Toolchain ready: %s (%s)\n' "$$(sw_vers -productVersion)" "$$(uname -m)"
 
 test:
+	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/tests/test-build-cache.py"
 	@$(ROOT)/guest/test
 	@mkdir -p $(ROOT)/macos/.build/module-cache/swift $(ROOT)/macos/.build/module-cache/clang
 	@cd $(ROOT)/macos && SWIFT_MODULECACHE_PATH=$(ROOT)/macos/.build/module-cache/swift CLANG_MODULE_CACHE_PATH=$(ROOT)/macos/.build/module-cache/clang swift test --disable-sandbox
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
 
 guest:
-	@$(ROOT)/guest/build-container.sh --output $(GUEST_DIST)
+	@OMARCHY_FORCE_BUILD="$(FORCE)" "$(BUILD_CACHE)" \
+	  --root "$(ROOT)" --state-dir "$(BUILD_STATE)" guest -- \
+	  "$(ROOT)/guest/build-container.sh" --output "$(GUEST_DIST)"
 
 runtime:
-	@$(ROOT)/macos/build-qemu-gpu-runtime.sh
+	@OMARCHY_FORCE_BUILD="$(FORCE)" "$(BUILD_CACHE)" \
+	  --root "$(ROOT)" --state-dir "$(BUILD_STATE)" runtime -- \
+	  "$(ROOT)/macos/build-qemu-gpu-runtime.sh"
 
-app:
-	@$(ROOT)/macos/build-app.sh --guest-dir $(GUEST_DIST)
+app: guest runtime
+	@OMARCHY_FORCE_BUILD="$(FORCE)" "$(BUILD_CACHE)" \
+	  --root "$(ROOT)" --state-dir "$(BUILD_STATE)" app -- \
+	  "$(ROOT)/macos/build-app.sh" --guest-dir "$(GUEST_DIST)"
 
-build: doctor guest runtime app
+build: doctor app
 
 run: app
 	@$(ROOT)/macos/open-qemu-gpu.sh
@@ -67,12 +78,15 @@ run-ephemeral: app
 reset: app
 	@$(ROOT)/macos/open-qemu-gpu.sh --reset-storage
 
-package:
+package: guest runtime
 	@$(ROOT)/macos/build-app.sh --dmg --guest-dir $(GUEST_DIST)
 
-release:
+release-preflight:
 	@[[ "$(RELEASE_SIGN_IDENTITY)" == "Developer ID Application:"* ]] || { echo 'error: RELEASE_SIGN_IDENTITY must be a Developer ID Application identity' >&2; exit 1; }
 	@[[ -n "$(strip $(RELEASE_NOTARY_PROFILE))" ]] || { echo 'error: RELEASE_NOTARY_PROFILE must name a notarytool keychain profile' >&2; exit 1; }
+
+release: release-preflight
+	@$(MAKE) --no-print-directory guest runtime
 	@$(ROOT)/macos/build-app.sh \
 	  --dmg \
 	  --guest-dir "$(GUEST_DIST)" \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,18 @@ For a first full build and launch:
 make build run
 ```
 
-The first build downloads pinned sources, assembles a multi-gigabyte guest, and compiles QEMU, so it can take a while. `make build` includes the basic toolchain check. Later native app rebuilds reuse `dist/guest/` and `macos/.build/qemu-gpu-runtime`, so they only need:
+The first build downloads pinned sources, assembles a multi-gigabyte guest, and
+compiles QEMU, so it can take a while. `make build` includes the basic toolchain
+check. Later builds hash the effective inputs and validate the existing outputs,
+then rebuild only the guest, runtime, or app components that changed. To bypass
+that cache deliberately, run `make build FORCE=1` (or add `FORCE=1` to an
+individual component command).
+
+Artifacts created before their `.build/state/` record exists are rebuilt once;
+the cache never adopts an output whose successful inputs it did not observe.
+
+Launching also ensures that the guest, runtime, and native app are current, so
+the normal follow-up command is:
 
 ```sh
 make run

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,8 +19,10 @@ Outputs are written to:
 
 `make package` creates an ad-hoc local build. `make release` uses the maintainer's
 Developer ID Application identity and the `try-omarchy` notarytool keychain
-profile to sign, notarize, and staple the app and DMG. Another maintainer can
-override both defaults:
+profile to sign, notarize, and staple the app and DMG. Both commands first
+ensure the content-hashed guest and runtime artifacts are current; packaging
+and signing themselves always run freshly. Another maintainer can override both
+defaults:
 
 ```sh
 make release \

--- a/scripts/build-cache.py
+++ b/scripts/build-cache.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Run expensive project builds only when their effective inputs changed."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+GUEST_ARTIFACTS = {
+    "LICENSE.omarchy",
+    "build-spec.json",
+    "initramfs-linux.img",
+    "packages.lock.txt",
+    "provenance.json",
+    "rootfs.ext4",
+    "rootfs.ext4.zst",
+    "vmlinuz-linux",
+}
+GUEST_FILES = GUEST_ARTIFACTS | {"guest-manifest.json", "SHA256SUMS"}
+RUNTIME_FILES = {
+    "bin/qemu-system-aarch64",
+    "lib/libEGL.dylib",
+    "lib/libGLESv2.dylib",
+    "lib/libepoxy.0.dylib",
+    "lib/libvirglrenderer.1.dylib",
+}
+
+
+class CacheError(RuntimeError):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def regular_files(
+    root: Path, excluded_directories: set[str] | None = None
+) -> list[Path]:
+    excluded_directories = excluded_directories or set()
+    result: list[Path] = []
+    for current_text, directory_names, file_names in os.walk(root, followlinks=False):
+        current = Path(current_text)
+        kept_directories: list[str] = []
+        for name in sorted(directory_names):
+            path = current / name
+            relative = path.relative_to(root)
+            if relative.parts[0] in excluded_directories:
+                continue
+            if path.is_symlink():
+                result.append(path)
+            else:
+                kept_directories.append(name)
+        directory_names[:] = kept_directories
+        for name in sorted(file_names):
+            path = current / name
+            if path.relative_to(root).parts[0] not in excluded_directories:
+                result.append(path)
+    return sorted(result)
+
+
+def component_files(root: Path, component: str) -> list[Path]:
+    if component == "guest":
+        guest = root / "guest"
+        return [
+            path
+            for path in regular_files(guest, {".work", "tests"})
+            if path.relative_to(guest).as_posix() not in {"README.md", "test"}
+        ]
+
+    if component == "runtime":
+        paths = [
+            root / "macos/build-qemu-gpu-runtime.sh",
+            root / "macos/prepare-qemu-gpu-runtime.sh",
+            root / "macos/qemu-hvf.entitlements",
+        ]
+        paths.extend(regular_files(root / "macos/patches"))
+        return sorted(paths)
+
+    if component == "app":
+        macos = root / "macos"
+        excluded_names = {
+            "README.md",
+            "build-qemu-gpu-runtime.sh",
+            "dmg-layout.applescript",
+            "package-dmg.sh",
+            "prepare-qemu-gpu-runtime.sh",
+        }
+        paths = [
+            path
+            for path in regular_files(macos, {".build", ".swiftpm", "Tests", "patches"})
+            if path.relative_to(macos).as_posix() not in excluded_names
+        ]
+        paths.extend(
+            [
+                root / ".build/state/guest.json",
+                root / ".build/state/runtime.json",
+                root / "dist/guest/guest-manifest.json",
+                root / "dist/guest/SHA256SUMS",
+            ]
+        )
+        return sorted(paths)
+
+    raise CacheError(f"unknown component: {component}")
+
+
+def command_output(argv: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            argv,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return f"<unavailable: {error}>"
+    return f"exit={result.returncode}\n{result.stdout.strip()}"
+
+
+def executable_path(name: str) -> Path | None:
+    result = subprocess.run(
+        ["/usr/bin/which", name],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def macho_dependencies(image: Path) -> list[Path]:
+    result = subprocess.run(
+        ["/usr/bin/otool", "-L", str(image)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    dependencies: list[Path] = []
+    for line in result.stdout.splitlines()[1:]:
+        dependency = line.strip().split(" (", 1)[0]
+        if dependency.startswith(("/System/Library/", "/usr/lib/")):
+            continue
+        if dependency.startswith("/"):
+            dependencies.append(Path(dependency).resolve())
+    return dependencies
+
+
+def app_external_files(root: Path) -> list[Path]:
+    runtime = root / "macos/.build/qemu-gpu-runtime"
+    pending = [runtime / relative for relative in sorted(RUNTIME_FILES)]
+    zstd = executable_path("zstd")
+    if zstd is not None:
+        pending.append(zstd)
+
+    discovered: dict[str, Path] = {}
+    while pending:
+        path = pending.pop()
+        key = str(path)
+        if key in discovered or not path.is_file() or path.is_symlink():
+            continue
+        discovered[key] = path
+        pending.extend(macho_dependencies(path))
+
+        # Homebrew's SDL2 compatibility library loads SDL3 dynamically, so it
+        # does not appear in otool output even though the app bundler copies it.
+        if path.name == "libSDL2-2.0.0.dylib":
+            brew_prefix = command_output(["brew", "--prefix"])
+            if brew_prefix.startswith("exit=0\n"):
+                prefix = Path(brew_prefix.split("\n", 1)[1])
+                pending.append(prefix / "opt/sdl3/lib/libSDL3.0.dylib")
+
+    return [discovered[key] for key in sorted(discovered)]
+
+
+def context(component: str) -> dict[str, str]:
+    values = {
+        "architecture": command_output(["uname", "-m"]),
+        "macOS": command_output(["sw_vers", "-productVersion"]),
+    }
+    if component == "runtime":
+        values.update(
+            {
+                "brew-prefix": command_output(["brew", "--prefix"]),
+                "clang": command_output(["xcrun", "clang", "--version"]),
+                "pkg-config": command_output(
+                    [
+                        "pkg-config",
+                        "--modversion",
+                        "slirp",
+                        "sdl2",
+                        "glib-2.0",
+                        "pixman-1",
+                    ]
+                ),
+                "slirp-prefix": command_output(
+                    ["pkg-config", "--variable=prefix", "slirp"]
+                ),
+                "sdl2-prefix": command_output(
+                    ["pkg-config", "--variable=prefix", "sdl2"]
+                ),
+                "glib-prefix": command_output(
+                    ["pkg-config", "--variable=prefix", "glib-2.0"]
+                ),
+                "pixman-prefix": command_output(
+                    ["pkg-config", "--variable=prefix", "pixman-1"]
+                ),
+            }
+        )
+    elif component == "app":
+        values.update(
+            {
+                "swift": command_output(["swift", "--version"]),
+                "zstd": command_output(["zstd", "--version"]),
+            }
+        )
+    environment_names = {
+        "runtime": {
+            "CC",
+            "CFLAGS",
+            "CPPFLAGS",
+            "DEVELOPER_DIR",
+            "LDFLAGS",
+            "MACOSX_DEPLOYMENT_TARGET",
+            "PKG_CONFIG_PATH",
+            "SDKROOT",
+        },
+        "app": {
+            "DEVELOPER_DIR",
+            "MACOSX_DEPLOYMENT_TARGET",
+            "OMARCHY_CODESIGN_IDENTITY",
+            "SDKROOT",
+            "SWIFTFLAGS",
+        },
+    }
+    for name in sorted(environment_names.get(component, set())):
+        values[f"environment:{name}"] = os.environ.get(name, "")
+    return values
+
+
+def normalized_command(root: Path, command: list[str]) -> list[str]:
+    root_text = str(root)
+    return [argument.replace(root_text, "<ROOT>") for argument in command]
+
+
+def fingerprint(root: Path, component: str, command: list[str]) -> str:
+    digest = hashlib.sha256()
+    digest.update(f"try-omarchy-build-cache-v{SCHEMA_VERSION}\0{component}\0".encode())
+    digest.update(
+        json.dumps(normalized_command(root, command), separators=(",", ":")).encode()
+    )
+    digest.update(
+        json.dumps(context(component), sort_keys=True, separators=(",", ":")).encode()
+    )
+
+    paths = component_files(root, component)
+    if component == "app":
+        paths.extend(app_external_files(root))
+    paths.append(Path(__file__).resolve())
+
+    seen: set[str] = set()
+    for path in sorted(paths, key=lambda item: str(item)):
+        resolved_label = (
+            str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+        )
+        if resolved_label in seen:
+            continue
+        seen.add(resolved_label)
+        if not path.exists() and not path.is_symlink():
+            raise CacheError(f"build input is missing: {resolved_label}")
+        metadata = path.lstat()
+        digest.update(b"input\0" + resolved_label.encode() + b"\0")
+        digest.update(f"{stat.S_IMODE(metadata.st_mode):o}\0".encode())
+        if path.is_symlink():
+            digest.update(b"symlink\0" + os.readlink(path).encode() + b"\0")
+        elif path.is_file():
+            digest.update(b"file\0" + sha256_file(path).encode() + b"\0")
+        else:
+            raise CacheError(
+                f"build input is not a regular file or symlink: {resolved_label}"
+            )
+    return digest.hexdigest()
+
+
+def direct_file_set(directory: Path) -> set[str]:
+    result: set[str] = set()
+    for path in directory.iterdir():
+        if path.is_file() and not path.is_symlink():
+            result.add(path.name)
+        else:
+            raise CacheError(f"unexpected non-file build artifact: {path}")
+    return result
+
+
+def guest_snapshot(directory: Path) -> dict[str, dict[str, int]]:
+    return {
+        name: {
+            "bytes": (directory / name).stat().st_size,
+            "ctimeNs": (directory / name).stat().st_ctime_ns,
+            "mtimeNs": (directory / name).stat().st_mtime_ns,
+        }
+        for name in sorted(GUEST_FILES)
+    }
+
+
+def validate_guest(root: Path, previous: dict[str, Any] | None) -> dict[str, Any]:
+    directory = root / "dist/guest"
+    if not directory.is_dir() or directory.is_symlink():
+        raise CacheError("guest artifact directory is missing or unsafe")
+    if direct_file_set(directory) != GUEST_FILES:
+        raise CacheError("guest artifact directory has a missing or unexpected file")
+
+    manifest_path = directory / "guest-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise CacheError(f"guest manifest is unreadable: {error}") from error
+    if not isinstance(manifest, dict):
+        raise CacheError("guest manifest is not an object")
+    if (
+        manifest.get("schemaVersion") != 1
+        or manifest.get("kind") != "try-omarchy-guest-artifacts"
+    ):
+        raise CacheError("guest manifest identity is invalid")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise CacheError("guest manifest artifacts are invalid")
+
+    manifest_records: dict[str, dict[str, Any]] = {}
+    for record in artifacts:
+        if not isinstance(record, dict) or not isinstance(record.get("path"), str):
+            raise CacheError("guest manifest contains an invalid artifact record")
+        name = record["path"]
+        if name in manifest_records:
+            raise CacheError(f"guest manifest repeats artifact: {name}")
+        manifest_records[name] = record
+    if set(manifest_records) != GUEST_ARTIFACTS:
+        raise CacheError("guest manifest artifact set is incomplete")
+
+    checksums: dict[str, str] = {}
+    try:
+        checksum_lines = (
+            (directory / "SHA256SUMS").read_text(encoding="ascii").splitlines()
+        )
+    except (OSError, UnicodeError) as error:
+        raise CacheError(f"guest SHA256SUMS is unreadable: {error}") from error
+    for line in checksum_lines:
+        fields = line.split(maxsplit=1)
+        if len(fields) != 2 or len(fields[0]) != 64:
+            raise CacheError("guest SHA256SUMS has an invalid record")
+        name = fields[1].lstrip("*")
+        if name in checksums:
+            raise CacheError(f"guest SHA256SUMS repeats artifact: {name}")
+        checksums[name] = fields[0]
+    if set(checksums) != GUEST_ARTIFACTS | {"guest-manifest.json"}:
+        raise CacheError("guest SHA256SUMS artifact set is incomplete")
+    if checksums["guest-manifest.json"] != sha256_file(manifest_path):
+        raise CacheError("guest manifest checksum is stale")
+
+    for name, record in manifest_records.items():
+        path = directory / name
+        if not path.is_file() or path.is_symlink() or path.stat().st_size <= 0:
+            raise CacheError(f"guest artifact is missing or unsafe: {name}")
+        if (
+            record.get("bytes") != path.stat().st_size
+            or record.get("sha256") != checksums[name]
+        ):
+            raise CacheError(f"guest metadata does not match artifact: {name}")
+    if (directory / "build-spec.json").read_bytes() != (
+        root / "guest/spec.json"
+    ).read_bytes():
+        raise CacheError("guest build-spec.json does not match the current spec")
+
+    snapshot = guest_snapshot(directory)
+    if previous is not None and previous.get("outputs") != snapshot:
+        raise CacheError("guest artifact metadata changed since the successful build")
+    return snapshot
+
+
+def runtime_snapshot(directory: Path) -> dict[str, str]:
+    return {name: sha256_file(directory / name) for name in sorted(RUNTIME_FILES)}
+
+
+def validate_runtime(root: Path, previous: dict[str, Any] | None) -> dict[str, Any]:
+    directory = root / "macos/.build/qemu-gpu-runtime"
+    if not directory.is_dir() or directory.is_symlink():
+        raise CacheError("runtime artifact directory is missing or unsafe")
+    actual: set[str] = set()
+    for path in directory.rglob("*"):
+        relative = path.relative_to(directory).as_posix()
+        if path.is_symlink():
+            raise CacheError(f"runtime artifact contains an unsafe symlink: {relative}")
+        if path.is_dir():
+            if relative not in {"bin", "lib"}:
+                raise CacheError(
+                    f"runtime artifact contains an unexpected directory: {relative}"
+                )
+        elif path.is_file():
+            actual.add(relative)
+        else:
+            raise CacheError(f"runtime artifact contains an unsafe entry: {relative}")
+    if actual != RUNTIME_FILES:
+        raise CacheError("runtime artifact directory has a missing or unexpected file")
+    for name in RUNTIME_FILES:
+        path = directory / name
+        if not path.is_file() or path.is_symlink() or path.stat().st_size <= 0:
+            raise CacheError(f"runtime artifact is missing or unsafe: {name}")
+        result = subprocess.run(
+            ["codesign", "--verify", "--strict", str(path)],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            raise CacheError(f"runtime artifact has an invalid code signature: {name}")
+    snapshot = runtime_snapshot(directory)
+    if previous is not None and previous.get("outputs") != snapshot:
+        raise CacheError("runtime artifact content changed since the successful build")
+    return snapshot
+
+
+def validate_app(root: Path, previous: dict[str, Any] | None) -> dict[str, Any]:
+    app = root / "dist/Try Omarchy.app"
+    required = [
+        app / "Contents/MacOS/omarchy-vm-helper",
+        app / "Contents/Resources/runtime/bin/Try Omarchy",
+        app / "Contents/Resources/guest/rootfs.ext4.zst",
+        app / "Contents/Resources/guest/launch.plist",
+    ]
+    if (
+        not app.is_dir()
+        or app.is_symlink()
+        or any(not path.is_file() or path.is_symlink() for path in required)
+    ):
+        raise CacheError("app bundle is missing or unsafe")
+    result = subprocess.run(
+        ["codesign", "--verify", "--deep", "--strict", str(app)],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        raise CacheError("app bundle has an invalid code signature")
+    details = subprocess.run(
+        ["codesign", "--display", "--verbose=4", str(app)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if details.returncode != 0:
+        raise CacheError("app bundle code-signing identity is unreadable")
+    snapshot = {"codeSignature": hashlib.sha256(details.stdout).hexdigest()}
+    if previous is not None and previous.get("outputs") != snapshot:
+        raise CacheError("app bundle identity changed since the successful build")
+    return snapshot
+
+
+def validate_outputs(
+    root: Path, component: str, previous: dict[str, Any] | None
+) -> dict[str, Any]:
+    if component == "guest":
+        return validate_guest(root, previous)
+    if component == "runtime":
+        return validate_runtime(root, previous)
+    if component == "app":
+        return validate_app(root, previous)
+    raise CacheError(f"unknown component: {component}")
+
+
+def read_state(path: Path) -> dict[str, Any] | None:
+    try:
+        state = json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict) or state.get("schemaVersion") != SCHEMA_VERSION:
+        return None
+    return state
+
+
+def write_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(state, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def force_requested(argument: bool) -> bool:
+    value = os.environ.get("OMARCHY_FORCE_BUILD", "0").lower()
+    if value not in {"0", "1", "false", "true", "no", "yes"}:
+        raise CacheError("FORCE must be 0 or 1")
+    return argument or value in {"1", "true", "yes"}
+
+
+def run(
+    root: Path, state_dir: Path, component: str, command: list[str], force: bool
+) -> None:
+    if not command:
+        raise CacheError("a build command is required after --")
+    if state_dir != root / ".build/state":
+        raise CacheError("state directory must be <repository>/.build/state")
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state_path = state_dir / f"{component}.json"
+    lock_path = state_dir / f"{component}.lock"
+
+    with lock_path.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        before = fingerprint(root, component, command)
+        previous = read_state(state_path)
+        if (
+            not force
+            and previous is not None
+            and previous.get("component") == component
+            and previous.get("fingerprint") == before
+        ):
+            try:
+                validate_outputs(root, component, previous)
+            except CacheError as error:
+                print(f"[build-cache] {component} is stale: {error}")
+            else:
+                print(f"[build-cache] {component} is up to date")
+                return
+
+        reason = "forced" if force else "inputs or outputs changed"
+        print(f"[build-cache] rebuilding {component}: {reason}", flush=True)
+        state_path.unlink(missing_ok=True)
+        result = subprocess.run(command, check=False)
+        if result.returncode != 0:
+            raise CacheError(
+                f"{component} build failed with exit status {result.returncode}"
+            )
+
+        after = fingerprint(root, component, command)
+        if after != before:
+            raise CacheError(
+                f"{component} inputs changed while it was building; run it again"
+            )
+        outputs = validate_outputs(root, component, None)
+        write_state(
+            state_path,
+            {
+                "schemaVersion": SCHEMA_VERSION,
+                "component": component,
+                "fingerprint": after,
+                "outputs": outputs,
+            },
+        )
+        print(f"[build-cache] recorded successful {component} build")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--state-dir", required=True, type=Path)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("component", choices=("guest", "runtime", "app"))
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    root = args.root.resolve()
+    state_dir = args.state_dir.resolve()
+    if not root.is_dir():
+        raise CacheError(f"repository root is missing: {root}")
+    run(root, state_dir, args.component, args.command, force_requested(args.force))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except CacheError as error:
+        print(f"build-cache: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/tests/test-build-cache.py
+++ b/tests/test-build-cache.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from contextlib import redirect_stdout
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "try_omarchy_build_cache", REPOSITORY / "scripts/build-cache.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+build_cache = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(build_cache)
+
+
+FAKE_GUEST_BUILDER = textwrap.dedent(
+    r"""
+    import hashlib
+    import json
+    from pathlib import Path
+    import sys
+    import time
+
+    root = Path(sys.argv[1])
+    mode = sys.argv[2]
+    count_path = root / "build-count"
+    count = int(count_path.read_text()) + 1 if count_path.exists() else 1
+    count_path.write_text(f"{count}\n")
+    if mode == "fail":
+        raise SystemExit(23)
+    if mode == "slow":
+        time.sleep(0.2)
+    if mode == "mutate":
+        (root / "guest/build.input").write_text("changed during build\n")
+
+    output = root / "dist/guest"
+    output.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "LICENSE.omarchy",
+        "build-spec.json",
+        "initramfs-linux.img",
+        "packages.lock.txt",
+        "provenance.json",
+        "rootfs.ext4",
+        "rootfs.ext4.zst",
+        "vmlinuz-linux",
+    }
+    spec = (root / "guest/spec.json").read_bytes()
+    records = []
+    checksums = {}
+    for name in sorted(artifacts):
+        contents = spec if name == "build-spec.json" else f"{name} build {count}\n".encode()
+        (output / name).write_bytes(contents)
+        digest = hashlib.sha256(contents).hexdigest()
+        checksums[name] = digest
+        records.append({"path": name, "bytes": len(contents), "sha256": digest})
+    manifest = {
+        "schemaVersion": 1,
+        "kind": "try-omarchy-guest-artifacts",
+        "artifacts": records,
+    }
+    manifest_bytes = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+    (output / "guest-manifest.json").write_bytes(manifest_bytes)
+    checksums["guest-manifest.json"] = hashlib.sha256(manifest_bytes).hexdigest()
+    (output / "SHA256SUMS").write_text(
+        "".join(f"{digest}  {name}\n" for name, digest in sorted(checksums.items()))
+    )
+    """
+)
+
+
+class BuildCacheTests(unittest.TestCase):
+    @staticmethod
+    def prepare_fake_guest(root: Path) -> None:
+        (root / "guest").mkdir()
+        (root / "guest/spec.json").write_text('{"schemaVersion": 1}\n')
+        (root / "guest/build.input").write_text("initial\n")
+
+    def test_make_orders_components_and_propagates_force(self) -> None:
+        dry_run = subprocess.run(
+            ["make", "-n", "build"],
+            cwd=REPOSITORY,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+        guest = dry_run.index(" guest --")
+        runtime = dry_run.index(" runtime --")
+        app = dry_run.index(" app --")
+        self.assertLess(guest, runtime)
+        self.assertLess(runtime, app)
+
+        forced = subprocess.run(
+            ["make", "-n", "build", "FORCE=1"],
+            cwd=REPOSITORY,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        ).stdout
+        self.assertEqual(3, forced.count('OMARCHY_FORCE_BUILD="1"'))
+
+        invalid_release = subprocess.run(
+            ["make", "release", "RELEASE_SIGN_IDENTITY=invalid"],
+            cwd=REPOSITORY,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self.assertNotEqual(0, invalid_release.returncode)
+        self.assertNotIn("build-cache.py", invalid_release.stdout)
+
+    def test_guest_fingerprint_tracks_build_inputs_but_not_documentation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "guest/tests").mkdir(parents=True)
+            (root / "guest/build.sh").write_text("one\n")
+            (root / "guest/README.md").write_text("first docs\n")
+            (root / "guest/tests/example.py").write_text("first test\n")
+            command = [
+                str(root / "guest/build.sh"),
+                "--output",
+                str(root / "dist/guest"),
+            ]
+
+            original = build_cache.fingerprint(root, "guest", command)
+            (root / "guest/README.md").write_text("second docs\n")
+            (root / "guest/tests/example.py").write_text("second test\n")
+            self.assertEqual(original, build_cache.fingerprint(root, "guest", command))
+
+            (root / "guest/build.sh").write_text("two\n")
+            self.assertNotEqual(
+                original, build_cache.fingerprint(root, "guest", command)
+            )
+
+    def test_guest_validation_checks_manifest_and_successful_output_snapshot(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "dist/guest"
+            output.mkdir(parents=True)
+            (root / "guest").mkdir()
+            spec_contents = b'{"schemaVersion": 1}\n'
+            (root / "guest/spec.json").write_bytes(spec_contents)
+
+            records = []
+            checksums: dict[str, str] = {}
+            for name in sorted(build_cache.GUEST_ARTIFACTS):
+                contents = (
+                    spec_contents if name == "build-spec.json" else f"{name}\n".encode()
+                )
+                (output / name).write_bytes(contents)
+                digest = hashlib.sha256(contents).hexdigest()
+                checksums[name] = digest
+                records.append({"path": name, "bytes": len(contents), "sha256": digest})
+            manifest = {
+                "schemaVersion": 1,
+                "kind": "try-omarchy-guest-artifacts",
+                "artifacts": records,
+            }
+            manifest_bytes = (json.dumps(manifest, sort_keys=True) + "\n").encode()
+            (output / "guest-manifest.json").write_bytes(manifest_bytes)
+            checksums["guest-manifest.json"] = hashlib.sha256(
+                manifest_bytes
+            ).hexdigest()
+            (output / "SHA256SUMS").write_text(
+                "".join(
+                    f"{digest}  {name}\n" for name, digest in sorted(checksums.items())
+                )
+            )
+
+            snapshot = build_cache.validate_guest(root, None)
+            self.assertEqual(
+                snapshot, build_cache.validate_guest(root, {"outputs": snapshot})
+            )
+
+            artifact = output / "rootfs.ext4.zst"
+            metadata = artifact.stat()
+            os.utime(artifact, ns=(metadata.st_atime_ns, metadata.st_mtime_ns + 1))
+            with self.assertRaisesRegex(build_cache.CacheError, "metadata changed"):
+                build_cache.validate_guest(root, {"outputs": snapshot})
+
+    def test_state_write_is_readable_and_replaces_old_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            state = Path(temporary) / "state/component.json"
+            first = {"schemaVersion": build_cache.SCHEMA_VERSION, "fingerprint": "one"}
+            second = {"schemaVersion": build_cache.SCHEMA_VERSION, "fingerprint": "two"}
+            build_cache.write_state(state, first)
+            self.assertEqual(first, build_cache.read_state(state))
+            build_cache.write_state(state, second)
+            self.assertEqual(second, build_cache.read_state(state))
+
+    def test_cached_runner_skips_rebuilds_and_never_stamps_bad_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.prepare_fake_guest(root)
+            build_input = root / "guest/build.input"
+            state_dir = root / ".build/state"
+
+            def invoke(mode: str = "good", *, force: bool = False) -> None:
+                command = [sys.executable, "-c", FAKE_GUEST_BUILDER, str(root), mode]
+                with redirect_stdout(io.StringIO()):
+                    build_cache.run(root, state_dir, "guest", command, force)
+
+            invoke()
+            self.assertEqual("1", (root / "build-count").read_text().strip())
+            self.assertTrue((state_dir / "guest.json").is_file())
+
+            invoke()
+            self.assertEqual("1", (root / "build-count").read_text().strip())
+
+            build_input.write_text("edited\n")
+            invoke()
+            self.assertEqual("2", (root / "build-count").read_text().strip())
+
+            invoke(force=True)
+            self.assertEqual("3", (root / "build-count").read_text().strip())
+
+            with (root / "dist/guest/rootfs.ext4.zst").open("ab") as stream:
+                stream.write(b"tampered")
+            invoke()
+            self.assertEqual("4", (root / "build-count").read_text().strip())
+
+            with self.assertRaisesRegex(build_cache.CacheError, "exit status 23"):
+                invoke("fail")
+            self.assertFalse((state_dir / "guest.json").exists())
+
+            invoke()
+            self.assertTrue((state_dir / "guest.json").is_file())
+            with self.assertRaisesRegex(build_cache.CacheError, "inputs changed"):
+                invoke("mutate")
+            self.assertFalse((state_dir / "guest.json").exists())
+
+    def test_concurrent_builds_share_the_component_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self.prepare_fake_guest(root)
+            build_command = [
+                sys.executable,
+                "-c",
+                FAKE_GUEST_BUILDER,
+                str(root),
+                "slow",
+            ]
+            wrapper = [
+                sys.executable,
+                str(REPOSITORY / "scripts/build-cache.py"),
+                "--root",
+                str(root),
+                "--state-dir",
+                str(root / ".build/state"),
+                "guest",
+                "--",
+                *build_command,
+            ]
+            first = subprocess.Popen(
+                wrapper, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            )
+            second = subprocess.Popen(
+                wrapper, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            )
+            first_output, _ = first.communicate(timeout=10)
+            second_output, _ = second.communicate(timeout=10)
+            self.assertEqual(0, first.returncode, first_output)
+            self.assertEqual(0, second.returncode, second_output)
+            self.assertEqual("1", (root / "build-count").read_text().strip())
+            combined = first_output + second_output
+            self.assertEqual(1, combined.count("recorded successful guest build"))
+            self.assertEqual(1, combined.count("guest is up to date"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`make` now tries to figure out what needs to be rebuilt to avoid rebuilding everything everytime.

- Add content-hashed caching for guest, runtime, and app component builds
- Validate existing outputs before reusing cached state, with `FORCE=1` support for deliberate rebuilds
- Ensure packaging and releases refresh required artifacts while keeping signing steps fresh
- Document cache behavior and ignore Python test artifacts

## Testing

- Added and ran unit tests for the build-cache behavior
- Ran the existing guest, Swift, and persistent-storage tests