### PR TITLE
Shared folder fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ cannot be shared. **Turn Off** keeps the choice but stops exporting it on the
 next launch; Omarchy then removes the link and gives back any standard folder
 such as `~/Documents` that the link had taken over. The share belongs to the
 first Omarchy account created during
-provisioning; additional guest accounts see it read-only.
+provisioning. Additional guest accounts can reach the same share, with each
+entry's normal Unix permission bits deciding whether they can modify it.
 
 ## Requirements
 

--- a/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-mac-share
@@ -96,17 +96,17 @@ shared_folder_name() {
     encoded=${argument#*=}
   done
   if [[ -z $encoded || ! $encoded =~ ^[A-Za-z0-9_-]+$ ]]; then
-    echo "$fallback_name"
+    printf '%s\n' "$fallback_name"
     return 0
   fi
   local padded=$encoded
   while (( ${#padded} % 4 )); do padded+="="; done
   decoded=$(printf '%s' "$padded" | tr -- '-_' '+/' | base64 -d 2>/dev/null | tr -d '\0') || decoded=""
   if [[ -z $decoded || $decoded == */* || $decoded == . || $decoded == .. || $decoded == *$'\n'* ]]; then
-    echo "$fallback_name"
+    printf '%s\n' "$fallback_name"
     return 0
   fi
-  echo "$decoded"
+  printf '%s\n' "$decoded"
 }
 
 # Folders that xdg-user-dirs manages for this user, one absolute path per
@@ -130,18 +130,25 @@ xdg_user_dirs() {
   done
 }
 
+is_xdg_user_dir() {
+  local candidate=$1
+  local home=$2
+  local xdg_dir
+  while IFS= read -r xdg_dir; do
+    [[ $xdg_dir == "$candidate" ]] && return 0
+  done < <(xdg_user_dirs "$home")
+  return 1
+}
+
 # Remove a link to the share. A link that replaced an empty xdg folder gives
 # that folder back so file pickers and downloads keep working.
 remove_share_link() {
   local link=$1
   local home=$2
-  local xdg_dir
   rm -f "$link"
-  while IFS= read -r xdg_dir; do
-    [[ $xdg_dir == "$link" ]] || continue
+  if is_xdg_user_dir "$link" "$home"; then
     mkdir -p "$link" && log "restored $link after removing the shared folder link"
-    break
-  done < <(xdg_user_dirs "$home")
+  fi
 }
 
 link_share() {
@@ -157,10 +164,10 @@ link_share() {
   # Drop links from an earlier share so only the current one remains. This
   # runs even without a mount, otherwise turning sharing off would leave
   # ~/<old name> pointing at an empty, root-owned mount point.
-  for existing in "$home"/* "$home"/.[!.]*; do
+  while IFS= read -r -d '' existing; do
     [[ -L $existing && $(readlink "$existing") == "$mount_point" && $existing != "$target" ]] || continue
     remove_share_link "$existing" "$home"
-  done
+  done < <(find "$home" -mindepth 1 -maxdepth 1 -type l -print0)
   if [[ -z $target ]]; then
     log "no Mac folder is mounted; nothing to link"
     return 0
@@ -171,8 +178,11 @@ link_share() {
     target="$home/$fallback_name"
   elif [[ -d $target ]]; then
     # xdg-user-dirs pre-creates folders such as Documents. Replace only an
-    # empty one; keep real content and fall back to the generic name.
-    if ! rmdir "$target" 2>/dev/null; then
+    # empty one; preserve every other directory, even when it is empty.
+    if ! is_xdg_user_dir "$target" "$home"; then
+      log "$target is an existing non-xdg folder; using ~/$fallback_name instead"
+      target="$home/$fallback_name"
+    elif ! rmdir "$target" 2>/dev/null; then
       log "$target already has content; using ~/$fallback_name instead"
       target="$home/$fallback_name"
     fi

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -33,6 +34,10 @@ def json_file(path: Path) -> dict:
     value = json.loads(read(path))
     check(isinstance(value, dict), f"{path.name} contains a JSON object")
     return value
+
+
+def encoded_share_name(name: str) -> str:
+    return base64.urlsafe_b64encode(name.encode()).decode().rstrip("=")
 
 
 def main() -> None:
@@ -193,6 +198,18 @@ def main() -> None:
         environment["HOME"] = str(home)
         name = subprocess.run([str(mac_share), "--name"], text=True, env=environment, capture_output=True, check=True)
         check(name.stdout == "Wörk Files\n", "Mac share link name decodes from the kernel command line")
+        for option_like_name in ("-n", "-e", "-E"):
+            cmdline.write_text(
+                f"root=/dev/vda rw omarchy.shared_folder_name={encoded_share_name(option_like_name)}\n"
+            )
+            decoded = subprocess.run(
+                [str(mac_share), "--name"], text=True, env=environment, capture_output=True, check=True
+            )
+            check(
+                decoded.stdout == f"{option_like_name}\n",
+                f"Mac share link preserves option-like name {option_like_name}",
+            )
+        cmdline.write_text("root=/dev/vda rw omarchy.qemu_virgl=1 omarchy.shared_folder_name=V8O2cmsgRmlsZXM\n")
         subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
         check(
             os.readlink(home / "Wörk Files") == "/mnt/mac" and not (home / "OldName").exists(),
@@ -236,6 +253,40 @@ def main() -> None:
             and not (home / "Documents").is_symlink(),
             "Mac share link cleanup runs without a mount and restores a displaced xdg folder",
         )
+
+        # Existing non-XDG directories belong to the guest, even when empty.
+        # Use ~/Mac as the fallback instead of deleting the existing folder.
+        work = home / "Work"
+        work.mkdir()
+        cmdline.write_text(
+            f"root=/dev/vda rw omarchy.shared_folder_name={encoded_share_name('Work')}\n"
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "1"
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(
+            work.is_dir() and not work.is_symlink() and os.readlink(home / "Mac") == "/mnt/mac",
+            "Mac share link preserves an empty non-xdg folder and falls back to ~/Mac",
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "0"
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(work.is_dir(), "Mac share cleanup leaves the preserved non-xdg folder intact")
+
+        # Names beginning with two dots are valid Mac basenames and must be
+        # included when stale links are removed.
+        cmdline.write_text(
+            f"root=/dev/vda rw omarchy.shared_folder_name={encoded_share_name('..Work')}\n"
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "1"
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        hidden_share = home / "..Work"
+        check(
+            hidden_share.is_symlink() and os.readlink(hidden_share) == "/mnt/mac",
+            "Mac share link supports a name beginning with two dots",
+        )
+        environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "0"
+        subprocess.run([str(mac_share), "--link"], env=environment, check=True, capture_output=True)
+        check(not hidden_share.exists() and not hidden_share.is_symlink(), "Mac share cleanup removes a ..-prefixed link")
+        cmdline.write_text("root=/dev/vda rw\n")
         environment["OMARCHY_MAC_SHARE_ASSUME_MOUNTED"] = "1"
 
         # Sharing turned off: --mount returns at once instead of polling for

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -231,15 +231,27 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
 
         let sharedFolder = sharedFolderStatus()
         let sharedFolderDetail: String
+        let sharedFolderDetailLines: [String]?
         var sharedFolderActions: [(String, Selector)] = [("Choose…", #selector(beginSharedFolderSelection))]
         if let problem = sharedFolder.problem {
             sharedFolderDetail = problem
+            sharedFolderDetailLines = nil
         } else if let displayPath = sharedFolder.displayPath, sharedFolder.isEnabled {
-            sharedFolderDetail = "Omarchy can read and write “\(displayPath)” as ~/\(SharedFolderPolicy.guestLinkName(sharedFolder.path ?? displayPath))."
+            let guestPath = "~/\(SharedFolderPolicy.guestLinkName(sharedFolder.path ?? displayPath))"
+            sharedFolderDetail = "Mac folder: \(displayPath). In Omarchy: \(guestPath)."
+            sharedFolderDetailLines = [
+                "Mac folder: \(displayPath)",
+                "In Omarchy: \(guestPath)",
+            ]
         } else if let displayPath = sharedFolder.displayPath {
-            sharedFolderDetail = "Off. “\(displayPath)” stays private to this Mac until turned on."
+            sharedFolderDetail = "Mac folder: \(displayPath). In Omarchy: Off."
+            sharedFolderDetailLines = [
+                "Mac folder: \(displayPath)",
+                "In Omarchy: Off",
+            ]
         } else {
             sharedFolderDetail = "Optional. Pick a Mac folder to use inside Omarchy under the same name."
+            sharedFolderDetailLines = nil
         }
         if sharedFolder.path != nil {
             sharedFolderActions.append(
@@ -252,18 +264,23 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             symbolName: "folder",
             title: "Shared folder",
             detail: sharedFolderDetail,
+            compactDetailLines: sharedFolderDetailLines,
             granted: sharedFolder.isEnabled && sharedFolder.problem == nil,
             statusLabels: ("●  On", "○  Off"),
-            actions: sharedFolderActions
+            actions: sharedFolderActions,
+            minimumHeight: 92
         )
 
         let permissionRows = NSStackView(
             views: [accessibilityRow, separator(), microphoneRow, separator(), sharedFolderRow]
         )
         permissionRows.orientation = .vertical
-        permissionRows.alignment = .width
+        permissionRows.alignment = .leading
         permissionRows.spacing = 0
         permissionRows.translatesAutoresizingMaskIntoConstraints = false
+        for row in [accessibilityRow, microphoneRow, sharedFolderRow] {
+            row.widthAnchor.constraint(equalTo: permissionRows.widthAnchor).isActive = true
+        }
 
         let permissionCard = NSView()
         permissionCard.wantsLayer = true
@@ -469,14 +486,17 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         symbolName: String,
         title: String,
         detail: String,
+        compactDetailLines: [String]? = nil,
         granted: Bool,
         statusLabels: (granted: String, denied: String),
-        actions: [(String, Selector)]
+        actions: [(String, Selector)],
+        minimumHeight: CGFloat = 76
     ) -> NSView {
         let symbol = NSImageView()
         symbol.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
         symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
         symbol.contentTintColor = .controlAccentColor
+        symbol.identifier = NSUserInterfaceItemIdentifier("permission-symbol-\(symbolName)")
         symbol.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             symbol.widthAnchor.constraint(equalToConstant: 26),
@@ -485,13 +505,31 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
 
         let name = NSTextField(labelWithString: title)
         name.font = .systemFont(ofSize: 14, weight: .semibold)
+        name.identifier = NSUserInterfaceItemIdentifier("permission-title-\(symbolName)")
 
-        let explanation = NSTextField(wrappingLabelWithString: detail)
-        explanation.font = .systemFont(ofSize: 12)
-        explanation.textColor = .secondaryLabelColor
-        explanation.maximumNumberOfLines = 2
+        let explanations: [NSTextField]
+        if let compactDetailLines {
+            explanations = compactDetailLines.enumerated().map { index, line in
+                let explanation = NSTextField(labelWithString: line)
+                explanation.font = .systemFont(ofSize: 12)
+                explanation.textColor = .secondaryLabelColor
+                explanation.maximumNumberOfLines = 1
+                explanation.lineBreakMode = .byTruncatingMiddle
+                explanation.toolTip = line
+                explanation.identifier = NSUserInterfaceItemIdentifier(
+                    "permission-detail-\(symbolName)-\(index)"
+                )
+                return explanation
+            }
+        } else {
+            let explanation = NSTextField(wrappingLabelWithString: detail)
+            explanation.font = .systemFont(ofSize: 12)
+            explanation.textColor = .secondaryLabelColor
+            explanation.maximumNumberOfLines = 2
+            explanations = [explanation]
+        }
 
-        let labels = NSStackView(views: [name, explanation])
+        let labels = NSStackView(views: [name] + explanations)
         labels.orientation = .vertical
         labels.alignment = .leading
         labels.spacing = 3
@@ -518,32 +556,53 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             status.textColor = .secondaryLabelColor
         }
         status.alignment = .right
+        status.identifier = NSUserInterfaceItemIdentifier("permission-status-\(symbolName)")
         status.setContentHuggingPriority(.required, for: .horizontal)
 
         var trailingViews: [NSView] = [status]
-        for (actionTitle, action) in actions {
+        for (index, actionDescription) in actions.enumerated() {
+            let (actionTitle, action) = actionDescription
             let button = NSButton(title: actionTitle, target: self, action: action)
-            button.controlSize = .small
+            button.controlSize = .regular
             button.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
-            button.identifier = NSUserInterfaceItemIdentifier("permission-action-\(symbolName)")
+            let identifier = actions.count == 1
+                ? "permission-action-\(symbolName)"
+                : "permission-action-\(symbolName)-\(index)"
+            button.identifier = NSUserInterfaceItemIdentifier(identifier)
+            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 28).isActive = true
+
             trailingViews.append(button)
         }
         let trailing = NSStackView(views: trailingViews)
         trailing.orientation = .vertical
         trailing.alignment = .trailing
-        trailing.spacing = 6
+        trailing.spacing = 7
+        trailing.translatesAutoresizingMaskIntoConstraints = false
+        if trailingViews.count > 2 {
+            trailing.setCustomSpacing(2, after: trailingViews[1])
+        }
 
-        let row = NSStackView(views: [symbol, labels, trailing])
-        row.orientation = .horizontal
-        row.alignment = .centerY
-        row.spacing = 12
+        labels.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.identifier = NSUserInterfaceItemIdentifier("permission-row-\(symbolName)")
         row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(symbol)
+        row.addSubview(labels)
+        row.addSubview(trailing)
         NSLayoutConstraint.activate([
-            row.heightAnchor.constraint(greaterThanOrEqualToConstant: 76),
-            trailing.widthAnchor.constraint(equalToConstant: 112),
+            row.heightAnchor.constraint(greaterThanOrEqualToConstant: minimumHeight),
+            symbol.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            symbol.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.leadingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 12),
+            labels.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.trailingAnchor.constraint(lessThanOrEqualTo: trailing.leadingAnchor, constant: -12),
+            trailing.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+            trailing.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            trailing.widthAnchor.constraint(equalToConstant: 124),
         ])
-        if let button = trailingViews.last as? NSButton {
-            button.widthAnchor.constraint(equalTo: trailing.widthAnchor).isActive = true
+        for actionView in trailingViews.dropFirst() {
+            actionView.widthAnchor.constraint(equalTo: trailing.widthAnchor).isActive = true
         }
         labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
         labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -407,7 +407,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             granted: sharedFolder.isEnabled && sharedFolder.problem == nil,
             statusLabels: ("●  On", "○  Off"),
             actions: sharedFolderActions,
-            minimumHeight: 92
+            minimumHeight: 100
         )
 
         let permissionRows = NSStackView(

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -11,6 +11,12 @@ private final class PointingHandButton: NSButton {
     }
 }
 
+private final class PermissionActionButton: NSButton {
+    override var alignmentRectInsets: NSEdgeInsets {
+        NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+}
+
 private final class LinkCursorTextField: NSTextField {
     override func resetCursorRects() {
         super.resetCursorRects()
@@ -696,7 +702,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         var trailingViews: [NSView] = [status]
         for (index, actionDescription) in actions.enumerated() {
             let (actionTitle, action) = actionDescription
-            let button = NSButton(title: actionTitle, target: self, action: action)
+            let button = PermissionActionButton(title: actionTitle, target: self, action: action)
             button.controlSize = .regular
             button.isEnabled = !microphoneRequestInFlight && !state.isBusy
             let identifier = actions.count == 1

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -691,6 +691,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         status.alignment = .right
         status.identifier = NSUserInterfaceItemIdentifier("permission-status-\(symbolName)")
         status.setContentHuggingPriority(.required, for: .horizontal)
+        status.translatesAutoresizingMaskIntoConstraints = false
 
         var trailingViews: [NSView] = [status]
         for (index, actionDescription) in actions.enumerated() {
@@ -702,17 +703,37 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
                 ? "permission-action-\(symbolName)"
                 : "permission-action-\(symbolName)-\(index)"
             button.identifier = NSUserInterfaceItemIdentifier(identifier)
+            button.translatesAutoresizingMaskIntoConstraints = false
             button.heightAnchor.constraint(greaterThanOrEqualToConstant: 28).isActive = true
             trailingViews.append(button)
         }
-        let trailing = NSStackView(views: trailingViews)
-        trailing.orientation = .vertical
-        trailing.alignment = .trailing
-        trailing.spacing = 7
+
+        let trailing = NSView()
         trailing.translatesAutoresizingMaskIntoConstraints = false
-        if trailingViews.count > 2 {
-            trailing.setCustomSpacing(2, after: trailingViews[1])
+        for trailingView in trailingViews {
+            trailing.addSubview(trailingView)
         }
+        var trailingConstraints = [
+            status.topAnchor.constraint(equalTo: trailing.topAnchor),
+            status.leadingAnchor.constraint(greaterThanOrEqualTo: trailing.leadingAnchor),
+            status.trailingAnchor.constraint(equalTo: trailing.trailingAnchor),
+        ]
+        var previousTrailingView: NSView = status
+        for (index, actionView) in trailingViews.dropFirst().enumerated() {
+            trailingConstraints.append(contentsOf: [
+                actionView.leadingAnchor.constraint(equalTo: trailing.leadingAnchor),
+                actionView.trailingAnchor.constraint(equalTo: trailing.trailingAnchor),
+                actionView.topAnchor.constraint(
+                    equalTo: previousTrailingView.bottomAnchor,
+                    constant: index == 0 ? 7 : 2
+                ),
+            ])
+            previousTrailingView = actionView
+        }
+        trailingConstraints.append(
+            previousTrailingView.bottomAnchor.constraint(equalTo: trailing.bottomAnchor)
+        )
+        NSLayoutConstraint.activate(trailingConstraints)
 
         labels.translatesAutoresizingMaskIntoConstraints = false
 
@@ -733,13 +754,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             trailing.centerYAnchor.constraint(equalTo: row.centerYAnchor),
             trailing.widthAnchor.constraint(equalToConstant: 124),
         ])
-        for actionView in trailingViews.dropFirst() {
-            actionView.widthAnchor.constraint(equalTo: trailing.widthAnchor).isActive = true
-        }
         labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
         labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        trailing.setContentHuggingPriority(.required, for: .horizontal)
-        trailing.setContentCompressionResistancePriority(.required, for: .horizontal)
         return row
     }
 

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -41,6 +41,10 @@ struct StartMenuWindowTests {
         let microphoneFrame = microphoneAction.convert(microphoneAction.bounds, to: content)
         #expect(abs(accessibilityFrame.minX - microphoneFrame.minX) < 0.5)
         #expect(abs(accessibilityFrame.width - microphoneFrame.width) < 0.5)
+        #expect(accessibilityAction.frame.height >= 28)
+        #expect(microphoneAction.frame.height >= 28)
+        #expect((accessibilityAction as? NSButton)?.controlSize == .regular)
+        #expect((microphoneAction as? NSButton)?.controlSize == .regular)
 
         let launchButton = try #require(
             descendant(withIdentifier: "launch-button", in: content)
@@ -51,6 +55,134 @@ struct StartMenuWindowTests {
         let labelFrame = launchLabel.convert(launchLabel.bounds, to: launchButton)
         #expect(abs(labelFrame.midX - launchButton.bounds.midX) <= 0.5)
         #expect(abs(labelFrame.midY - launchButton.bounds.midY) <= 0.5)
+    }
+
+    @Test("shared folder paths keep separate compact lines and actions stay aligned")
+    func sharedFolderDetailsStayVisible() throws {
+        _ = NSApplication.shared
+        let macPath = "~/Projects/a-very-long-folder-name-that-needs-middle-truncation"
+        let guestPath = "~/a-very-long-folder-name-that-needs-middle-truncation"
+        var sharedFolderEnabled = true
+        let menu = StartMenuWindow(
+            accessibilityStatus: { false },
+            microphoneStatus: { .notDetermined },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(false) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            sharedFolderStatus: {
+                SharedFolderMenuState(
+                    path: "/Users/test/Projects/a-very-long-folder-name-that-needs-middle-truncation",
+                    displayPath: macPath,
+                    isEnabled: sharedFolderEnabled,
+                    problem: nil
+                )
+            },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            launch: {}
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let content = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })?.contentView
+        )
+        content.layoutSubtreeIfNeeded()
+
+        let macLine = try #require(
+            descendant(withIdentifier: "permission-detail-folder-0", in: content) as? NSTextField
+        )
+        let guestLine = try #require(
+            descendant(withIdentifier: "permission-detail-folder-1", in: content) as? NSTextField
+        )
+        #expect(macLine.stringValue == "Mac folder: \(macPath)")
+        #expect(guestLine.stringValue == "In Omarchy: \(guestPath)")
+        #expect(macLine.maximumNumberOfLines == 1)
+        #expect(guestLine.maximumNumberOfLines == 1)
+        #expect(macLine.lineBreakMode == .byTruncatingMiddle)
+        #expect(guestLine.lineBreakMode == .byTruncatingMiddle)
+        #expect(macLine.frame.height > 0)
+        #expect(guestLine.frame.height > 0)
+
+        let choose = try #require(
+            descendant(withIdentifier: "permission-action-folder-0", in: content) as? NSButton
+        )
+        let turnOff = try #require(
+            descendant(withIdentifier: "permission-action-folder-1", in: content) as? NSButton
+        )
+        #expect(choose.controlSize == .regular)
+        #expect(turnOff.controlSize == .regular)
+        #expect(choose.frame.height >= 28)
+        #expect(turnOff.frame.height >= 28)
+        #expect(abs(choose.frame.width - turnOff.frame.width) < 0.5)
+        #expect(abs(choose.frame.width - 124) < 0.5)
+        let chooseFrame = choose.convert(choose.bounds, to: content)
+        let turnOffFrame = turnOff.convert(turnOff.bounds, to: content)
+        #expect(abs(chooseFrame.minY - turnOffFrame.maxY - 2) < 0.5)
+
+        try expectPermissionColumnsAligned(in: content)
+
+        sharedFolderEnabled = false
+        menu.refreshPermissionStatus()
+        content.layoutSubtreeIfNeeded()
+        try expectPermissionColumnsAligned(in: content)
+    }
+
+    private func expectPermissionColumnsAligned(in content: NSView) throws {
+        let accessibilityRow = try #require(
+            descendant(withIdentifier: "permission-row-accessibility", in: content)
+        )
+        let folderRow = try #require(
+            descendant(withIdentifier: "permission-row-folder", in: content)
+        )
+        let accessibilitySymbol = try #require(
+            descendant(withIdentifier: "permission-symbol-accessibility", in: content)
+        )
+        let folderSymbol = try #require(
+            descendant(withIdentifier: "permission-symbol-folder", in: content)
+        )
+        let accessibilityTitle = try #require(
+            descendant(withIdentifier: "permission-title-accessibility", in: content)
+        )
+        let folderTitle = try #require(
+            descendant(withIdentifier: "permission-title-folder", in: content)
+        )
+        let folderStatus = try #require(
+            descendant(withIdentifier: "permission-status-folder", in: content)
+        )
+        let accessibilityAction = try #require(
+            descendant(withIdentifier: "permission-action-accessibility", in: content)
+        )
+        let folderChooseAction = try #require(
+            descendant(withIdentifier: "permission-action-folder-0", in: content)
+        )
+        let folderToggleAction = try #require(
+            descendant(withIdentifier: "permission-action-folder-1", in: content)
+        )
+
+        let accessibilityRowFrame = accessibilityRow.convert(accessibilityRow.bounds, to: content)
+        let folderRowFrame = folderRow.convert(folderRow.bounds, to: content)
+        let accessibilitySymbolFrame = accessibilitySymbol.convert(accessibilitySymbol.bounds, to: content)
+        let folderSymbolFrame = folderSymbol.convert(folderSymbol.bounds, to: content)
+        let accessibilityTitleFrame = accessibilityTitle.convert(accessibilityTitle.bounds, to: content)
+        let folderTitleFrame = folderTitle.convert(folderTitle.bounds, to: content)
+        let folderStatusFrame = folderStatus.convert(folderStatus.bounds, to: content)
+        let accessibilityActionFrame = accessibilityAction.convert(accessibilityAction.bounds, to: content)
+        let folderChooseActionFrame = folderChooseAction.convert(folderChooseAction.bounds, to: content)
+        let folderToggleActionFrame = folderToggleAction.convert(folderToggleAction.bounds, to: content)
+
+        #expect(abs(accessibilityRowFrame.minX - folderRowFrame.minX) < 0.5)
+        #expect(abs(accessibilityRowFrame.width - folderRowFrame.width) < 0.5)
+        #expect(abs(accessibilitySymbolFrame.minX - folderSymbolFrame.minX) < 0.5)
+        #expect(abs(accessibilityTitleFrame.minX - folderTitleFrame.minX) < 0.5)
+        #expect(abs(accessibilityActionFrame.maxX - folderChooseActionFrame.maxX) < 0.5)
+        #expect(abs(accessibilityActionFrame.maxX - folderToggleActionFrame.maxX) < 0.5)
+        #expect(folderRowFrame.height >= 92)
+        #expect(folderRowFrame.maxY - folderStatusFrame.maxY >= 6)
     }
 
     private func descendant(withIdentifier identifier: String, in view: NSView) -> NSView? {

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -181,7 +181,7 @@ struct StartMenuWindowTests {
         #expect(abs(accessibilityTitleFrame.minX - folderTitleFrame.minX) < 0.5)
         #expect(abs(accessibilityActionFrame.maxX - folderChooseActionFrame.maxX) < 0.5)
         #expect(abs(accessibilityActionFrame.maxX - folderToggleActionFrame.maxX) < 0.5)
-        #expect(folderRowFrame.height >= 92)
+        #expect(folderRowFrame.height >= 100)
         #expect(folderRowFrame.maxY - folderStatusFrame.maxY >= 6)
     }
 

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -2,7 +2,7 @@ import AppKit
 import Testing
 @testable import OmarchyVMHelper
 
-@Suite("Start menu layout")
+@Suite("Start menu layout", .serialized)
 @MainActor
 struct StartMenuWindowTests {
     @Test("missing-permission actions share one aligned column and launch text is centered")


### PR DESCRIPTION
## Summary
- Preserve non-XDG directories and safely restore XDG folders when removing shared-folder links.
- Handle hidden and option-like shared folder names correctly.
- Clarify shared-folder access for guest accounts and improve macOS permission-row layout and truncation.
- Add coverage for path display, alignment, sizing, cleanup, and edge-case names.

## Testing
- Added and updated guest verification and macOS `StartMenuWindow` tests for the shared-folder behavior and UI layout.