### PR TITLE
Preinstall Simplified Chinese fonts and Pinyin input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Try Omarchy is not official or affiliated with Omarchy.
 - Mac audio input/output selection inside Omarchy, with live routing and system-default fallback
 - Two-way clipboard sharing for text and PNG images between macOS and Omarchy
 - One optional shared Mac folder, available inside Omarchy under the same name (`~/Work` stays `~/Work`)
+- Simplified Chinese display and Pinyin input preinstalled in the factory guest (desktop language stays English)
 
 > **Current limitation:** Video decoding is CPU-only, so playback can be slow, especially at high resolutions. An improved video path is in development.
 
@@ -25,6 +26,20 @@ Try Omarchy is not official or affiliated with Omarchy.
 3. Launch **Try Omarchy** from Applications.
 
 Every launch begins at the start menu. Accessibility enables Mac Command-to-guest-Super shortcuts; microphone access is optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
+
+## Simplified Chinese display and input
+
+The factory guest preinstalls CJK fonts (`noto-fonts-cjk`) and the Chinese
+input engine recommended by the [Omarchy manual](https://omarchy.org/manual/keyboard-mouse-trackpad/)
+(`fcitx5-chinese-addons` and `fcitx5-configtool`), together with the `fcitx5`
+framework Omarchy already uses for compose sequences. `zh_CN.UTF-8` is
+generated so applications can render Chinese text, but the desktop `LANG`
+stays `en_US.UTF-8` because Omarchy's menus are English-only.
+
+New accounts get Pinyin in the default Fcitx5 group alongside the US keyboard.
+Switch input methods with the Fcitx5 trigger. Existing VMs keep their home
+directories across updates; use a factory reset, or install the same packages
+inside Omarchy, to pick up the factory seed there.
 
 ## Clipboard sharing
 

--- a/guest/README.md
+++ b/guest/README.md
@@ -25,7 +25,10 @@ guest/test
 
 `spec.json` is the authoritative image and runtime contract. `packages.txt` is
 the requested transaction and `packages.lock.json` pins the full resolved ARM64
-package set. Source repositories, commits, downloads, versions, and hashes are
+package set. The transaction includes CJK fonts and `fcitx5-chinese-addons` so
+Simplified Chinese can be displayed and typed without changing the desktop LANG.
+
+Source repositories, commits, downloads, versions, and hashes are
 reviewed inputs rather than floating build dependencies.
 
 The output includes the kernel, initramfs, raw and compressed ext4 image,

--- a/guest/factory-overlay/etc/skel/.config/fcitx5/profile
+++ b/guest/factory-overlay/etc/skel/.config/fcitx5/profile
@@ -1,0 +1,18 @@
+# Seed Pinyin into the default Fcitx5 group for new accounts.
+# Leave the US keyboard as DefaultIM so English typing and Omarchy compose
+# sequences stay unchanged until the user switches input methods.
+[Groups/0]
+Name=Default
+Default Layout=us
+DefaultIM=keyboard-us
+
+[Groups/0/Items/0]
+Name=keyboard-us
+Layout=
+
+[Groups/0/Items/1]
+Name=pinyin
+Layout=
+
+[GroupOrder]
+0=Default

--- a/guest/packages.lock.json
+++ b/guest/packages.lock.json
@@ -594,6 +594,6 @@
     "zram-generator": "1.2.1-1",
     "zstd": "1.5.7-3"
   },
-  "requestedFileSha256": "d4e35a4991fb8e86f00db88518d7ebb5382a59c45ca549edd207beb9eda11d8f",
+  "requestedFileSha256": "ada21289a0a13b940ca188461016166fa208c759d778fc7da899a5e06b811410",
   "schemaVersion": 1
 }

--- a/guest/packages.txt
+++ b/guest/packages.txt
@@ -12,6 +12,11 @@ dua-cli
 e2fsprogs
 eza
 fastfetch
+fcitx5
+fcitx5-chinese-addons
+fcitx5-configtool
+fcitx5-gtk
+fcitx5-qt
 fd
 fontconfig
 foot
@@ -39,6 +44,7 @@ nautilus
 neovim
 networkmanager
 noto-fonts
+noto-fonts-cjk
 noto-fonts-emoji
 omarchy-keyring
 pacman-contrib

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -121,7 +121,13 @@ cat >"$root/etc/hosts" <<EOF
 ::1 localhost
 127.0.1.1 $hostname
 EOF
-printf 'en_US.UTF-8 UTF-8\n' >"$root/etc/locale.gen"
+# Generate zh_CN.UTF-8 so applications can render Simplified Chinese.
+# Keep LANG=en_US.UTF-8: Omarchy's menus are English-only, and changing the
+# desktop language breaks those labels.
+cat >"$root/etc/locale.gen" <<'EOF'
+en_US.UTF-8 UTF-8
+zh_CN.UTF-8 UTF-8
+EOF
 printf 'LANG=en_US.UTF-8\n' >"$root/etc/locale.conf"
 printf 'KEYMAP=us\n' >"$root/etc/vconsole.conf"
 # An unprovisioned machine receives a new identity from systemd on first boot.

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -121,6 +121,23 @@ def main() -> None:
     )
     packages = package_lock.get("packages")
     check(isinstance(packages, dict) and len(packages) > 100, "package transaction is fully locked")
+    requested_names = {
+        line.split("#", 1)[0].strip()
+        for line in package_text.decode().splitlines()
+        if line.split("#", 1)[0].strip()
+    }
+    check(
+        {
+            "fcitx5",
+            "fcitx5-chinese-addons",
+            "fcitx5-configtool",
+            "fcitx5-gtk",
+            "fcitx5-qt",
+            "noto-fonts-cjk",
+        }
+        <= requested_names,
+        "factory transaction requests CJK fonts and Simplified Chinese input",
+    )
 
     container = read(GUEST / "build-container.sh")
     check("linux/arm64" in container and '"$guest_dir/Containerfile"' in container, "container builder targets ARM64")
@@ -137,6 +154,18 @@ def main() -> None:
 
     configure = read(GUEST / "scripts/configure-rootfs.sh")
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
+    check(
+        "zh_CN.UTF-8 UTF-8" in configure
+        and 'printf \'LANG=en_US.UTF-8\\n\' >"$root/etc/locale.conf"' in configure,
+        "factory generates zh_CN.UTF-8 without changing the English desktop LANG",
+    )
+    fcitx_profile = read(GUEST / "factory-overlay/etc/skel/.config/fcitx5/profile")
+    check(
+        "Name=pinyin" in fcitx_profile
+        and "Name=keyboard-us" in fcitx_profile
+        and "DefaultIM=keyboard-us" in fcitx_profile,
+        "new users get Pinyin in the default Fcitx5 group",
+    )
     check("omarchy-provision-owner.service" in configure, "first boot uses upstream owner provisioning")
     check("omarchy-native-audio-bridge" in configure, "guest installs native host-audio integration")
     check(


### PR DESCRIPTION
The factory guest currently ships `noto-fonts` / `noto-fonts-emoji` and no `fcitx5` stack, so Chinese text becomes tofu and there is no Pinyin engine until the user can `omarchy pkg add` extra packages. That extra step is brittle when guest mirrors are broken (see the now-closed #2). Upstream Omarchy already lists `noto-fonts-cjk`, `fcitx5`, `fcitx5-gtk`, and `fcitx5-qt` in `install/omarchy-base.packages`; this restore plus the official Chinese engine matches the [Omarchy keyboard manual](https://omarchy.org/manual/keyboard-mouse-trackpad/).

There is no existing Chinese / locale / fcitx / CJK issue or PR on this repository. This is not an i18n request to `basecamp/omarchy` (English-only product decision).

## What changed

- Request `noto-fonts-cjk`, `fcitx5`, `fcitx5-gtk`, `fcitx5-qt`, `fcitx5-chinese-addons`, and `fcitx5-configtool` in `guest/packages.txt`.
- Update `packages.lock.json` `requestedFileSha256` to match the new list. The resolved package set is **not** refreshed here: that needs the privileged ARM64 builder (`guest/build-container.sh --refresh-package-lock`).
- Generate `zh_CN.UTF-8` in the factory `locale.gen`. Keep `LANG=en_US.UTF-8` so Omarchy menus stay English.
- Seed Pinyin into the default Fcitx5 group for new accounts via `/etc/skel`, leaving `keyboard-us` as `DefaultIM`.
- Document the seed in the root and guest READMEs.
- Extend `guest/tests/verify.py` so the package list, locale contract, and Fcitx5 profile stay pinned.

## Verification

- `python3 tests/test-build-cache.py` — 6 tests passed.
- `guest/test` — 30 unit tests plus the guest contract checks passed, including the new CJK / locale / Pinyin assertions.
- `bash -n guest/scripts/configure-rootfs.sh` and `python3 -m py_compile guest/tests/verify.py` passed.
- Did **not** run a full `make guest` / Docker ARM64 image rebuild (privileged builder + ~20 GB). The next guest rebuild must refresh `packages.lock.json` and confirm the 6144 MiB factory disk still fits CJK fonts.
- Did **not** run `swift test` or `make test`; this change is guest-contract only.

## Existing VMs

`/etc/skel` changes apply to newly provisioned accounts. Existing homes are preserved across updates. A factory reset, or installing the same packages inside Omarchy, picks up the seed there.

## Change graph

```mermaid
flowchart TD
    A[Factory guest build] --> B[packages.txt transaction]
    B --> C[Install noto-fonts-cjk]
    B --> D[Install fcitx5 plus chinese-addons]
    A --> E[configure-rootfs]
    E --> F[Generate zh_CN.UTF-8]
    E --> G[Keep LANG as en_US.UTF-8]
    E --> H[Copy factory overlay]
    H --> I[Skel Fcitx5 profile adds Pinyin]
    I --> J[New user can display and type Simplified Chinese]
```