### PR TITLE
Refresh libuv and libslirp version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Factory reset remains a separate, confirmed action for malformed, ambiguous, or 
 - Python 3
 - A running Docker-compatible engine that supports privileged `linux/arm64`
   containers
-- `zstd`, `pkg-config`, GLib, Pixman, libslirp 4.9.3, and SDL2 2.32.70
+- `zstd`, `pkg-config`, GLib, Pixman, libslirp 4.9.4, and SDL2 2.32.70
 - Roughly 20 GB free for guest, runtime, caches, and assembled output
 
 Install the Homebrew dependencies with:

--- a/guest/packages.lock.json
+++ b/guest/packages.lock.json
@@ -337,7 +337,7 @@
     "libusbmuxd": "2.1.1-2",
     "libutempter": "1.2.3-1",
     "libutf8proc": "2.11.3-1",
-    "libuv": "1.52.1-1",
+    "libuv": "1.52.1-2",
     "libva": "2.24.1-1",
     "libvdpau": "1.5-4",
     "libverto": "0.3.2-6",

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -97,7 +97,7 @@ epoxy_archive_name=libepoxy-1.0.4.arm64_sequoia.bottle.tar.gz
 epoxy_url="https://github.com/startergo/homebrew-libepoxy/releases/download/v1.0.4/$epoxy_archive_name"
 epoxy_sha256=8787cc8c34921834665262dff4941216dd6717edddf2c6d5cdfe04f03b24c517
 
-slirp_version=4.9.3
+slirp_version=4.9.4
 sdl_version=2.32.70
 
 die() {


### PR DESCRIPTION
Two pinned upstream versions drifted, and both build guards fired as designed.

- **`libuv` 1.52.1-1 -> 1.52.1-2** — Arch rebuild (pkgrel bump only, same upstream release). `guest/build.sh` refused the build because the resolved transaction no longer matched `guest/packages.lock.json`. Refreshed via `guest/build-container.sh --refresh-package-lock`; the diff is that one line.
- **`libslirp` 4.9.3 -> 4.9.4** — Homebrew moved the formula, so `require_pkg_version slirp` in `macos/build-qemu-gpu-runtime.sh` failed. Bumped the pin, plus the matching prerequisite line in `README.md` that `brew install` users read.

## Verification

`make build` is green end to end on macOS 15 / Apple Silicon: guest image packed, QEMU runtime source-built and signed against libslirp 4.9.4, and `Try Omarchy.app` assembled with a valid signature satisfying its Designated Requirement.

## Note

The libslirp version lives in two places (build script and README). They have to move together, so a future bump needs both.
