### PR TITLE
Fix AUR packages missing and installations failing

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,6 +14,9 @@ code.
 - **ANGLE, VirGLRenderer, libepoxy, SDL, libslirp, GLib, Pixman, and other QEMU
   dependencies** — retain their respective upstream licenses.
 - **mise** — MIT; the reviewed ARM64 release is pinned in `guest/spec.json`.
+- **yay** — GPL-3.0-or-later; the official ARM64 release and its versioned
+  license are pinned in `guest/spec.json` and packaged into the guest's local
+  repository.
 
 See `guest/spec.json`, `guest/packages.lock.json`, and
 `macos/build-qemu-gpu-runtime.sh` for exact source identities and checksums.

--- a/docs/guest-updates.md
+++ b/docs/guest-updates.md
@@ -15,7 +15,7 @@ promotes that candidate only after the updated guest reports healthy.
   "bootABI": "arm64-qemu-direct-v1",
   "compressedImage": "update.ext4.zst",
   "controlPort": "dev.tryomarchy.control",
-  "guestStateSchema": 1,
+  "guestStateSchema": 2,
   "image": "update.ext4",
   "protocolVersion": 1
 }
@@ -120,14 +120,14 @@ before pacman runs, covering configuration owned by ordinary OS packages.
 Update success is one canonical JSON line:
 
 ```json
-{"bootABI":"arm64-qemu-direct-v1","fromGuestStateSchema":0,"guestStateSchema":1,"protocolVersion":1,"status":"complete","transaction":"<64hex>","type":"update"}
+{"bootABI":"arm64-qemu-direct-v1","fromGuestStateSchema":1,"guestStateSchema":2,"protocolVersion":1,"status":"complete","transaction":"<64hex>","type":"update"}
 ```
 
 Failure uses `"status":"failed"` and adds a stable kebab-case `errorCode`.
 Trial-boot health is:
 
 ```json
-{"bootABI":"arm64-qemu-direct-v1","guestStateSchema":1,"protocolVersion":1,"readiness":"system","status":"ready","transaction":"<64hex>","type":"health"}
+{"bootABI":"arm64-qemu-direct-v1","guestStateSchema":2,"protocolVersion":1,"readiness":"system","status":"ready","transaction":"<64hex>","type":"health"}
 ```
 
 The transaction nonce is mandatory during an update and lets the host reject

--- a/guest/build.sh
+++ b/guest/build.sh
@@ -235,6 +235,11 @@ done
   --work "$work" \
   --spec "$spec" \
   --pacman-config "$pacman_config"
+"$guest_dir/scripts/register-pinned-yay.sh" \
+  --root "$root" \
+  --work "$work" \
+  --spec "$spec" \
+  --pacman-config "$pacman_config"
 "$guest_dir/scripts/register-local-repository.sh" --root "$root" --spec "$spec"
 arch-chroot "$root" /usr/bin/env TRY_OMARCHY_DEFER_INITRAMFS=1 \
   /usr/local/lib/try-omarchy/finalize-rootfs

--- a/guest/migrations/0001-0002-add-yay.sh
+++ b/guest/migrations/0001-0002-add-yay.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# The package transaction runs before schema migrations and installs these
+# files from the signed offline repository. This migration records and verifies
+# the package-only state change; there is no additional mutable state to apply.
+
+set -eu
+
+[ "$#" -eq 3 ] || exit 64
+mode=$1
+candidate_root=$2
+
+verify_yay() {
+  [ -x "$candidate_root/usr/bin/yay" ] \
+    && [ -x "$candidate_root/usr/bin/fakeroot" ] \
+    && [ -f "$candidate_root/usr/share/licenses/try-omarchy-yay/LICENSE" ] \
+    && [ ! -L "$candidate_root/usr/bin/yay" ] \
+    && [ ! -L "$candidate_root/usr/share/licenses/try-omarchy-yay/LICENSE" ]
+}
+
+case "$mode" in
+  verify)
+    verify_yay
+    ;;
+  apply)
+    # Pacman owns the payload. The following verify pass will fail closed if
+    # the preceding package transaction did not install the expected files.
+    :
+    ;;
+  *)
+    exit 64
+    ;;
+esac

--- a/guest/packages.lock.json
+++ b/guest/packages.lock.json
@@ -60,6 +60,7 @@
     "exiv2": "0.28.8-2",
     "expat": "2.8.3-1",
     "eza": "0.23.5-2",
+    "fakeroot": "1:1.37.2-3",
     "fastfetch": "2.67.1-1",
     "fcft": "3.3.3-1",
     "fd": "10.4.2-2",
@@ -337,7 +338,7 @@
     "libusbmuxd": "2.1.1-2",
     "libutempter": "1.2.3-1",
     "libutf8proc": "2.11.3-1",
-    "libuv": "1.52.1-1",
+    "libuv": "1.52.1-2",
     "libva": "2.24.1-1",
     "libvdpau": "1.5-4",
     "libverto": "0.3.2-6",
@@ -594,6 +595,6 @@
     "zram-generator": "1.2.1-1",
     "zstd": "1.5.7-3"
   },
-  "requestedFileSha256": "d4e35a4991fb8e86f00db88518d7ebb5382a59c45ca549edd207beb9eda11d8f",
+  "requestedFileSha256": "c63acbf1a06b04b494bd65b38f1ee10847786fcbc3ff5cab4e8e0039c0582f30",
   "schemaVersion": 1
 }

--- a/guest/packages.txt
+++ b/guest/packages.txt
@@ -11,6 +11,7 @@ desktop-file-utils
 dua-cli
 e2fsprogs
 eza
+fakeroot
 fastfetch
 fd
 fontconfig

--- a/guest/scripts/register-local-repository.sh
+++ b/guest/scripts/register-local-repository.sh
@@ -67,11 +67,12 @@ repo_dir="$root/usr/share/try-omarchy/repo"
 shopt -s nullglob
 archives=("$repo_dir"/*.pkg.tar.zst)
 shopt -u nullglob
-expected_archive_count=2
+expected_archive_count=3
 (( ${#archives[@]} == expected_archive_count )) ||
   fail "local repository expected $expected_archive_count package archive(s), found ${#archives[@]}"
 [[ ${archives[*]} == *'/try-omarchy-runtime-'* ]] || fail "local repository is missing the Omarchy runtime"
 [[ ${archives[*]} == *'/try-omarchy-mise-'* ]] || fail "factory repository is missing pinned mise"
+[[ ${archives[*]} == *'/try-omarchy-yay-'* ]] || fail "factory repository is missing pinned yay"
 
 temporary=$(mktemp -d "$root/usr/share/try-omarchy/.repo-db.XXXXXX")
 cleanup() {

--- a/guest/scripts/register-pinned-yay.sh
+++ b/guest/scripts/register-pinned-yay.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: register-pinned-yay.sh --root ROOT --work WORK --spec SPEC --pacman-config CONFIG
+
+Downloads the spec-pinned official yay ARM64 release and license, verifies
+their digests and exact archive shape, then installs yay as a local Arch
+package staged in the guest's immutable repository.
+USAGE
+}
+
+fail() {
+  echo "register-pinned-yay: $*" >&2
+  exit 1
+}
+
+root=""
+work=""
+spec=""
+pacman_config=""
+
+while (($#)); do
+  case "$1" in
+    --root)
+      root=${2:-}
+      shift 2
+      ;;
+    --work)
+      work=${2:-}
+      shift 2
+      ;;
+    --spec)
+      spec=${2:-}
+      shift 2
+      ;;
+    --pacman-config)
+      pacman_config=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ $root == /* && -d $root ]] || fail "--root must be an absolute staged root"
+case "$root" in
+  /|/bin|/boot|/etc|/home|/opt|/root|/usr|/var)
+    fail "refusing unsafe root: $root"
+    ;;
+esac
+[[ $work == /* && -d $work ]] || fail "--work must be an absolute directory"
+[[ -f $spec ]] || fail "spec not found: $spec"
+[[ -f $pacman_config ]] || fail "pacman config not found: $pacman_config"
+for command in arch-chroot curl install pacman python3 sha256sum tar zstd; do
+  command -v "$command" >/dev/null || fail "$command is required"
+done
+
+mapfile -t metadata < <(python3 - "$spec" <<'PY'
+import json
+import pathlib
+import sys
+
+spec = json.loads(pathlib.Path(sys.argv[1]).read_text())
+component = spec.get("supplyChain", {}).get("yay")
+if component is None:
+    print("disabled")
+    raise SystemExit
+print("enabled")
+for key in (
+    "version",
+    "url",
+    "sha256",
+    "binarySha256",
+    "reportedVersion",
+    "license",
+    "licenseUrl",
+    "licenseSha256",
+):
+    print(component[key])
+print(spec["image"]["architecture"])
+print(spec["image"]["sourceDateEpoch"])
+PY
+) || fail "could not read pinned yay metadata"
+[[ ${metadata[0]:-} == disabled ]] && exit 0
+[[ ${metadata[0]:-} == enabled ]] || fail "invalid pinned yay state"
+(( ${#metadata[@]} == 11 )) || fail "pinned yay metadata is incomplete"
+version=${metadata[1]}
+url=${metadata[2]}
+sha256=${metadata[3]}
+binary_sha256=${metadata[4]}
+reported_version=${metadata[5]}
+license=${metadata[6]}
+license_url=${metadata[7]}
+license_sha256=${metadata[8]}
+architecture=${metadata[9]}
+source_date_epoch=${metadata[10]}
+
+[[ $architecture == aarch64 ]] || fail "pinned yay component supports only aarch64"
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "invalid yay version: $version"
+[[ $sha256 =~ ^[0-9a-f]{64}$ ]] || fail "invalid yay archive digest"
+[[ $binary_sha256 =~ ^[0-9a-f]{64}$ ]] || fail "invalid yay binary digest"
+[[ $reported_version == "yay v$version - libalpm v"* ]] || fail "invalid yay reported version"
+[[ $license == GPL-3.0-or-later ]] || fail "unexpected yay license: $license"
+[[ $license_sha256 =~ ^[0-9a-f]{64}$ ]] || fail "invalid yay license digest"
+[[ $source_date_epoch =~ ^[0-9]+$ ]] || fail "invalid source date epoch"
+expected_url="https://github.com/Jguer/yay/releases/download/v$version/yay_${version}_aarch64.tar.gz"
+expected_license_url="https://raw.githubusercontent.com/Jguer/yay/v$version/LICENSE"
+[[ $url == "$expected_url" ]] || fail "yay URL does not match the pinned official release"
+[[ $license_url == "$expected_license_url" ]] || fail "yay license URL does not match the pinned tag"
+
+cache_dir="$work/download-cache"
+install -d -m 0755 "$cache_dir"
+asset_cache="$cache_dir/yay_${version}_aarch64.tar.gz"
+license_cache="$cache_dir/yay-$version.LICENSE"
+
+verify_file() {
+  local expected=$1
+  local path=$2
+  printf '%s  %s\n' "$expected" "$path" | sha256sum -c - >/dev/null
+}
+
+download_verified() {
+  local source_url=$1
+  local expected=$2
+  local destination=$3
+  local temporary=""
+
+  [[ ! -L $destination ]] || fail "refusing symlinked download cache entry: $destination"
+  if [[ -f $destination ]] && verify_file "$expected" "$destination"; then
+    return 0
+  fi
+  rm -f "$destination"
+  temporary=$(mktemp "$cache_dir/.download.XXXXXX")
+  if ! curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error \
+    "$source_url" --output "$temporary"; then
+    rm -f "$temporary"
+    fail "download failed: $source_url"
+  fi
+  if ! verify_file "$expected" "$temporary"; then
+    rm -f "$temporary"
+    fail "download digest mismatch: $source_url"
+  fi
+  chmod 0644 "$temporary"
+  mv "$temporary" "$destination"
+}
+
+download_verified "$url" "$sha256" "$asset_cache"
+download_verified "$license_url" "$license_sha256" "$license_cache"
+
+package_name=try-omarchy-yay
+package_version="$version-1"
+stage=$(mktemp -d "$work/yay-package.XXXXXX")
+cleanup() {
+  rm -rf "$stage"
+}
+trap cleanup EXIT
+
+expected_members=$(cat <<EOF
+yay_${version}_aarch64/
+yay_${version}_aarch64/bash
+yay_${version}_aarch64/ca.mo
+yay_${version}_aarch64/ca_ES.mo
+yay_${version}_aarch64/cs.mo
+yay_${version}_aarch64/da.mo
+yay_${version}_aarch64/da_DK.mo
+yay_${version}_aarch64/de.mo
+yay_${version}_aarch64/en.mo
+yay_${version}_aarch64/es.mo
+yay_${version}_aarch64/eu.mo
+yay_${version}_aarch64/fi.mo
+yay_${version}_aarch64/fish
+yay_${version}_aarch64/fr.mo
+yay_${version}_aarch64/fr_FR.mo
+yay_${version}_aarch64/he.mo
+yay_${version}_aarch64/he_IL.mo
+yay_${version}_aarch64/hu.mo
+yay_${version}_aarch64/id.mo
+yay_${version}_aarch64/it_IT.mo
+yay_${version}_aarch64/ja.mo
+yay_${version}_aarch64/ko.mo
+yay_${version}_aarch64/nl.mo
+yay_${version}_aarch64/pl.mo
+yay_${version}_aarch64/pl_PL.mo
+yay_${version}_aarch64/pt.mo
+yay_${version}_aarch64/pt_BR.mo
+yay_${version}_aarch64/ru.mo
+yay_${version}_aarch64/ru_RU.mo
+yay_${version}_aarch64/sk.mo
+yay_${version}_aarch64/sv.mo
+yay_${version}_aarch64/tr.mo
+yay_${version}_aarch64/uk.mo
+yay_${version}_aarch64/vi.mo
+yay_${version}_aarch64/vi_VN.mo
+yay_${version}_aarch64/yay
+yay_${version}_aarch64/yay.8
+yay_${version}_aarch64/zh_CN.mo
+yay_${version}_aarch64/zh_TW.mo
+yay_${version}_aarch64/zsh
+EOF
+)
+actual_members=$(tar -tzf "$asset_cache" | LC_ALL=C sort)
+[[ $actual_members == "$expected_members" ]] || fail "yay archive has an unexpected member set"
+
+install -d -m 0755 "$stage/extracted"
+tar -xzf "$asset_cache" --no-same-owner -C "$stage/extracted"
+asset_root="$stage/extracted/yay_${version}_aarch64"
+verify_file "$binary_sha256" "$asset_root/yay" || fail "extracted yay binary digest mismatch"
+
+install -Dm0755 "$asset_root/yay" "$stage/usr/bin/yay"
+install -Dm0644 "$asset_root/yay.8" "$stage/usr/share/man/man8/yay.8"
+install -Dm0644 "$asset_root/bash" "$stage/usr/share/bash-completion/completions/yay"
+install -Dm0644 "$asset_root/zsh" "$stage/usr/share/zsh/site-functions/_yay"
+install -Dm0644 "$asset_root/fish" "$stage/usr/share/fish/vendor_completions.d/yay.fish"
+install -Dm0644 "$license_cache" "$stage/usr/share/licenses/$package_name/LICENSE"
+for message_catalog in "$asset_root"/*.mo; do
+  locale=$(basename "$message_catalog" .mo)
+  [[ $locale =~ ^[A-Za-z_]+$ ]] || fail "unsafe yay locale: $locale"
+  install -Dm0644 "$message_catalog" "$stage/usr/share/locale/$locale/LC_MESSAGES/yay.mo"
+done
+
+installed_size=$(du -sb "$stage/usr" | awk '{print $1}')
+cat >"$stage/.PKGINFO" <<EOF
+pkgname = $package_name
+pkgbase = $package_name
+pkgver = $package_version
+pkgdesc = Pinned official yay $version binary for the Omarchy ARM64 guest
+url = https://github.com/Jguer/yay
+builddate = $source_date_epoch
+packager = Try Omarchy reproducible guest builder
+size = $installed_size
+arch = aarch64
+license = GPL-3.0-or-later
+provides = yay=$version
+conflict = yay
+depend = pacman>=7.1
+depend = git
+depend = sudo
+depend = fakeroot
+EOF
+
+package_archive="$stage/$package_name-$package_version-aarch64.pkg.tar.zst"
+tar \
+  --sort=name \
+  --mtime="@$source_date_epoch" \
+  --owner=0 \
+  --group=0 \
+  --numeric-owner \
+  --format=gnu \
+  -C "$stage" \
+  -cf - .PKGINFO usr |
+  zstd --force --quiet -12 --threads=1 -o "$package_archive"
+
+pacman \
+  --noconfirm \
+  --config "$pacman_config" \
+  --root "$root" \
+  --dbpath "$root/var/lib/pacman" \
+  --logfile "$root/var/log/pacman.log" \
+  -U "$package_archive"
+
+query=$(pacman --config "$pacman_config" --root "$root" --dbpath "$root/var/lib/pacman" -Q "$package_name")
+[[ $query == "$package_name $package_version" ]] || fail "provider query returned: $query"
+pacman --config "$pacman_config" --root "$root" --dbpath "$root/var/lib/pacman" -Qkk "$package_name" >/dev/null ||
+  fail "installed yay package failed its ownership check"
+pacman --config "$pacman_config" --root "$root" --dbpath "$root/var/lib/pacman" -T yay >/dev/null ||
+  fail "installed yay package does not satisfy the yay dependency"
+verify_file "$binary_sha256" "$root/usr/bin/yay" || fail "installed yay binary digest mismatch"
+reported=$(arch-chroot "$root" /usr/bin/runuser -u alpm -- /usr/bin/yay --version)
+[[ $reported == "$reported_version" ]] || fail "yay reported an unexpected identity: $reported"
+
+repo_dir="$root/usr/share/try-omarchy/repo"
+install -d -m 0755 "$repo_dir"
+install -m 0644 "$package_archive" "$repo_dir/$(basename "$package_archive")"
+echo "Registered $query from verified official asset $sha256"

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -43,6 +43,16 @@
       "binarySha256": "6b7471271a990cbd6a795b24f9df83338aa220c227bf75fd083442e5a728f5f7",
       "reportedVersion": "2026.8.11 linux-arm64 (2026-08-23)",
       "license": "MIT"
+    },
+    "yay": {
+      "version": "13.0.1",
+      "url": "https://github.com/Jguer/yay/releases/download/v13.0.1/yay_13.0.1_aarch64.tar.gz",
+      "sha256": "75bc500c8677d6760f51117ae0a61689e9cf165bea3c4800825a5c879d030726",
+      "binarySha256": "ec7453a87021f28331782d8077b8a2a7c69870710fcee991f2164dc197362ff2",
+      "reportedVersion": "yay v13.0.1 - libalpm v16.0.1",
+      "license": "GPL-3.0-or-later",
+      "licenseUrl": "https://raw.githubusercontent.com/Jguer/yay/v13.0.1/LICENSE",
+      "licenseSha256": "589ed823e9a84c56feb95ac58e7cf384626b9cbf4fda2a907bc36e103de1bad2"
     }
   },
   "themes": [
@@ -135,7 +145,7 @@
       "bootABI": "arm64-qemu-direct-v1",
       "compressedImage": "update.ext4.zst",
       "controlPort": "dev.tryomarchy.control",
-      "guestStateSchema": 1,
+      "guestStateSchema": 2,
       "image": "update.ext4",
       "protocolVersion": 1
     },

--- a/guest/tests/test_guest_update.py
+++ b/guest/tests/test_guest_update.py
@@ -23,6 +23,7 @@ HEALTH_REPORT = GUEST / "native-overlay/usr/local/lib/try-omarchy/health-report"
 UPDATE_RUNNER = GUEST / "native-overlay/usr/local/lib/try-omarchy/update-runner"
 OWNED_PAYLOAD = GUEST / "native-overlay/usr/local/lib/try-omarchy/owned-payload"
 BOOTSTRAP_MIGRATION = GUEST / "migrations/0000-0001-bootstrap-update-v1.sh"
+YAY_MIGRATION = GUEST / "migrations/0001-0002-add-yay.sh"
 
 
 def load_module(name: str, path: Path):
@@ -68,7 +69,7 @@ class UpdateContractTests(unittest.TestCase):
             environment_path = root / "usr/share/try-omarchy/update/release.env"
             state = json.loads(state_path.read_text())
             release = json.loads(release_path.read_text())
-            self.assertEqual(state["guestStateSchema"], 1)
+            self.assertEqual(state["guestStateSchema"], 2)
             self.assertEqual(state["bootABI"], "arm64-qemu-direct-v1")
             self.assertEqual(state["releaseId"], release_id)
             self.assertEqual(state["kind"], "try-omarchy-guest-state")
@@ -80,7 +81,7 @@ class UpdateContractTests(unittest.TestCase):
                 json.dumps(state, separators=(",", ":"), sort_keys=True) + "\n",
             )
             environment = environment_path.read_text()
-            self.assertIn("TRY_OMARCHY_GUEST_STATE_SCHEMA=1\n", environment)
+            self.assertIn("TRY_OMARCHY_GUEST_STATE_SCHEMA=2\n", environment)
             self.assertIn(f"TRY_OMARCHY_UPDATE_SHA256SUMS={digest}\n", environment)
 
 
@@ -390,6 +391,41 @@ class BootstrapMigrationTests(unittest.TestCase):
             )
             self.assertEqual(preserved_stale.read_text(), "old archive\n")
 
+    def test_yay_migration_verifies_package_transaction_postconditions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            candidate = root / "candidate"
+            update = root / "update"
+            candidate.mkdir()
+            update.mkdir()
+
+            before = subprocess.run(
+                ["/bin/sh", str(YAY_MIGRATION), "verify", str(candidate), str(update)],
+                check=False,
+            )
+            self.assertNotEqual(before.returncode, 0)
+            subprocess.run(
+                ["/bin/sh", str(YAY_MIGRATION), "apply", str(candidate), str(update)],
+                check=True,
+            )
+
+            for relative in ("usr/bin/yay", "usr/bin/fakeroot"):
+                executable = candidate / relative
+                executable.parent.mkdir(parents=True, exist_ok=True)
+                executable.write_text("#!/bin/sh\n", encoding="ascii")
+                executable.chmod(0o755)
+            license_file = (
+                candidate / "usr/share/licenses/try-omarchy-yay/LICENSE"
+            )
+            license_file.parent.mkdir(parents=True, exist_ok=True)
+            license_file.write_text("GPL-3.0-or-later\n", encoding="ascii")
+
+            for mode in ("verify", "apply", "verify"):
+                subprocess.run(
+                    ["/bin/sh", str(YAY_MIGRATION), mode, str(candidate), str(update)],
+                    check=True,
+                )
+
 
 class UpdateRunnerTests(unittest.TestCase):
     release_id = "c" * 64
@@ -584,7 +620,7 @@ class HealthReportTests(unittest.TestCase):
             self.assertEqual(message["status"], "ready")
             self.assertEqual(message["readiness"], "system")
             self.assertEqual(message["transaction"], UpdateRunnerTests.transaction)
-            self.assertEqual(message["guestStateSchema"], 1)
+            self.assertEqual(message["guestStateSchema"], 2)
             self.assertEqual(message["bootABI"], "arm64-qemu-direct-v1")
 
     def test_normal_health_requires_live_graphical_session_marker(self) -> None:

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -72,8 +72,7 @@ def main() -> None:
         }
         and update["bootABI"] == "arm64-qemu-direct-v1"
         and update["controlPort"] == "dev.tryomarchy.control"
-        and isinstance(update["guestStateSchema"], int)
-        and update["guestStateSchema"] > 0
+        and update["guestStateSchema"] == 2
         and isinstance(update["protocolVersion"], int)
         and update["protocolVersion"] > 0,
         "offline update protocol is explicit and versioned",
@@ -121,6 +120,40 @@ def main() -> None:
     )
     packages = package_lock.get("packages")
     check(isinstance(packages, dict) and len(packages) > 100, "package transaction is fully locked")
+    requested_packages = {
+        line.strip()
+        for line in package_text.decode().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    check(
+        "fakeroot" in requested_packages and "fakeroot" in packages,
+        "factory transaction includes fakeroot for AUR package builds",
+    )
+    yay = spec.get("supplyChain", {}).get("yay", {})
+    check(
+        set(yay)
+        == {
+            "binarySha256",
+            "license",
+            "licenseSha256",
+            "licenseUrl",
+            "reportedVersion",
+            "sha256",
+            "url",
+            "version",
+        }
+        and re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", yay.get("version", "")) is not None
+        and yay.get("url")
+        == f"https://github.com/Jguer/yay/releases/download/v{yay.get('version')}/yay_{yay.get('version')}_aarch64.tar.gz"
+        and yay.get("licenseUrl")
+        == f"https://raw.githubusercontent.com/Jguer/yay/v{yay.get('version')}/LICENSE"
+        and yay.get("license") == "GPL-3.0-or-later"
+        and all(
+            re.fullmatch(r"[0-9a-f]{64}", yay.get(key, "")) is not None
+            for key in ("sha256", "binarySha256", "licenseSha256")
+        ),
+        "official ARM64 yay release and license are fully pinned",
+    )
 
     container = read(GUEST / "build-container.sh")
     check("linux/arm64" in container and '"$guest_dir/Containerfile"' in container, "container builder targets ARM64")
@@ -179,6 +212,11 @@ def main() -> None:
         in local_repository,
         "pacman recovery files snapshot the final local-repository configuration",
     )
+    check(
+        "expected_archive_count=3" in local_repository
+        and "factory repository is missing pinned yay" in local_repository,
+        "immutable local repository requires the pinned yay package",
+    )
     shared_folder = spec["runtime"]["sharedFolder"]
     check(
         shared_folder["device"] == "virtio-9p-pci"
@@ -209,6 +247,24 @@ def main() -> None:
     check("cmp -s" not in configure, "rootfs configuration uses only declared build tools")
 
     build = read(GUEST / "build.sh")
+    register_yay = read(GUEST / "scripts/register-pinned-yay.sh")
+    check(
+        "register-pinned-yay.sh" in build
+        and build.index("register-pinned-yay.sh")
+        < build.index("register-local-repository.sh")
+        and "download digest mismatch" in register_yay
+        and "yay archive has an unexpected member set" in register_yay
+        and "installed yay binary digest mismatch" in register_yay
+        and "depend = fakeroot" in register_yay
+        and "provides = yay=$version" in register_yay
+        and "runuser -u alpm -- /usr/bin/yay --version" in register_yay,
+        "guest installs verified yay before sealing its local repository",
+    )
+    third_party_notices = read(REPO / "THIRD_PARTY_NOTICES.md")
+    check(
+        "**yay**" in third_party_notices and "GPL-3.0-or-later" in third_party_notices,
+        "third-party notices cover the pinned yay redistribution",
+    )
     pack_image = read(GUEST / "scripts/pack-image.sh")
     check(
         "build-update-image.sh" in build
@@ -261,6 +317,19 @@ def main() -> None:
         "migrations/0000-0001-bootstrap-update-v1.sh" not in configure
         and "native-overlay/." in configure,
         "factory image retains the universal owned-payload reconciler",
+    )
+    yay_migration = read(GUEST / "migrations/0001-0002-add-yay.sh")
+    check(
+        all(
+            marker in yay_migration
+            for marker in (
+                "/usr/bin/yay",
+                "/usr/bin/fakeroot",
+                "/usr/share/licenses/try-omarchy-yay/LICENSE",
+                "The package transaction runs before schema migrations",
+            )
+        ),
+        "schema 1-to-2 migration verifies the pinned yay package state",
     )
     update_hook = read(
         GUEST / "native-overlay/usr/lib/initcpio/hooks/try-omarchy-update"

--- a/macos/Tests/run-qemu-update-contract.test.sh
+++ b/macos/Tests/run-qemu-update-contract.test.sh
@@ -366,9 +366,12 @@ checksums["guest-manifest.json"] = hashlib.sha256(manifest_data).hexdigest()
 )
 PY
 
-PATH="$shim_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+if ! PATH="$shim_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
   "$fixture_macos/build-app.sh" --guest-dir "$fixture_guest" \
-  >"$test_root/build.stdout" 2>"$test_root/build.stderr"
+  >"$test_root/build.stdout" 2>"$test_root/build.stderr"; then
+  /bin/cat "$test_root/build.stderr" >&2
+  fail "fixture app build failed"
+fi
 
 app="$fixture_repo/dist/Try Omarchy.app"
 launch_plist="$app/Contents/Resources/guest/launch.plist"
@@ -394,7 +397,7 @@ assert_eq "$(plist_read updateDiskSHA256)" "$(printf 'b%.0s' {1..64})"
 assert_eq "$(plist_read updateDiskBytes)" 8388608
 assert_eq "$(plist_read compressedUpdateDiskBytes)" \
   "$(stat -f '%z' "$fixture_guest/update.ext4.zst")"
-assert_eq "$(plist_read guestStateSchema)" 1
+assert_eq "$(plist_read guestStateSchema)" 2
 assert_eq "$(plist_read bootABI)" arm64-qemu-direct-v1
 assert_eq "$(plist_read controlPort)" dev.tryomarchy.control
 assert_eq "$(plist_read protocolVersion)" 1
@@ -419,7 +422,7 @@ assert_eq "$inspect_command_line" "$expected_kernel_command_line"
 assert_eq "$inspect_update_sha" "$(printf 'b%.0s' {1..64})"
 assert_eq "$inspect_update_bytes" 8388608
 assert_eq "$inspect_update_zst_bytes" "$(stat -f '%z' "$fixture_guest/update.ext4.zst")"
-assert_eq "$inspect_schema" 1
+assert_eq "$inspect_schema" 2
 assert_eq "$inspect_abi" arm64-qemu-direct-v1
 assert_eq "$inspect_control_port" dev.tryomarchy.control
 assert_eq "$inspect_protocol" 1
@@ -664,7 +667,7 @@ assert_eq "$(sed -n '1p' "$success_control_log")" --bridge-native-control
 assert_eq "$(sed -n '5p' "$success_control_log")" update
 assert_eq "$(sed -n '6p' "$success_control_log")" "$control_token"
 assert_eq "$(sed -n '7p' "$success_control_log")" arm64-qemu-direct-v1
-assert_eq "$(sed -n '8p' "$success_control_log")" 1
+assert_eq "$(sed -n '8p' "$success_control_log")" 2
 assert_contains "$(<"$success_storage_log")" 'materialize-update '
 assert_contains "$(<"$success_storage_log")" 'prepare-update '
 assert_before "$success_storage_log" prepare-update 'qemu-exit 0'
@@ -727,7 +730,7 @@ clean_control_log="$test_root/clean-normal-launch/control.log"
 assert_eq "$(sed -n '5p' "$clean_control_log")" health
 assert_eq "$(sed -n '6p' "$clean_control_log")" -
 assert_eq "$(sed -n '7p' "$clean_control_log")" arm64-qemu-direct-v1
-assert_eq "$(sed -n '8p' "$clean_control_log")" 1
+assert_eq "$(sed -n '8p' "$clean_control_log")" 2
 
 # QEMU status zero alone is not a guest-health proof. If the normal boot never
 # publishes the validated marker, keep the predecessor for the next retry.

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -503,6 +503,7 @@ supply_chain_keys = {
     "mise",
     "omarchyPackagesCommit",
     "omarchyPackagesRepository",
+    "yay",
 }
 supply_chain = exact_keys(spec.get("supplyChain"), supply_chain_keys, "build spec supply chain")
 if (
@@ -526,6 +527,31 @@ if mise != {
     "license": "MIT",
 }:
     fail("factory mise component is not the reviewed ARM64 release")
+yay = exact_keys(
+    supply_chain.get("yay"),
+    {
+        "binarySha256",
+        "license",
+        "licenseSha256",
+        "licenseUrl",
+        "reportedVersion",
+        "sha256",
+        "url",
+        "version",
+    },
+    "build spec yay component",
+)
+if yay != {
+    "version": "13.0.1",
+    "url": "https://github.com/Jguer/yay/releases/download/v13.0.1/yay_13.0.1_aarch64.tar.gz",
+    "sha256": "75bc500c8677d6760f51117ae0a61689e9cf165bea3c4800825a5c879d030726",
+    "binarySha256": "ec7453a87021f28331782d8077b8a2a7c69870710fcee991f2164dc197362ff2",
+    "reportedVersion": "yay v13.0.1 - libalpm v16.0.1",
+    "license": "GPL-3.0-or-later",
+    "licenseUrl": "https://raw.githubusercontent.com/Jguer/yay/v13.0.1/LICENSE",
+    "licenseSha256": "589ed823e9a84c56feb95ac58e7cf384626b9cbf4fda2a907bc36e103de1bad2",
+}:
+    fail("factory yay component is not the reviewed ARM64 release")
 
 command_line = runtime.get("kernelCommandLine")
 if not isinstance(command_line, str) or not command_line or any(character in command_line for character in "\x00\r\n\t"):


### PR DESCRIPTION
Fixes #2 

## Summary

- Add a verified, reproducibly packaged ARM64 `yay` release to the guest’s local repository.
- Include `fakeroot`, supply-chain metadata, licensing notices, and archive/binary/license validation.
- Add the schema 1-to-2 migration and update guest/update contract checks.

## Testing

- Extended guest verification and migration tests.
- Updated QEMU update contract fixtures for guest state schema 2.