### PR TITLE
Fix launch when GNU stat shadows macOS stat

### DIFF
--- a/macos/Tests/qemu-persistent-storage.test.sh
+++ b/macos/Tests/qemu-persistent-storage.test.sh
@@ -130,18 +130,30 @@ cleanup() {
 }
 trap cleanup EXIT HUP INT TERM
 
+# Runtime filesystem checks must use macOS BSD stat even when Homebrew
+# coreutils shadows it in the caller's PATH.
+shadow_bin="$test_root/path-shadow"
+mkdir "$shadow_bin"
+printf '%s\n' \
+  '#!/bin/bash' \
+  'echo "qemu-persistent-storage.test: PATH stat was invoked" >&2' \
+  'exit 97' \
+  >"$shadow_bin/stat"
+chmod 700 "$shadow_bin/stat"
+export PATH="$shadow_bin:$PATH"
+
 export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/state"
 export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=1
 source_disk="$test_root/source.ext4"
 dd if=/dev/zero of="$source_disk" bs=4096 count=1 >/dev/null 2>&1
 printf 'immutable-base' | dd of="$source_disk" bs=1 seek=32 conv=notrunc >/dev/null 2>&1
 printf '\x53\xef' | dd of="$source_disk" bs=1 seek=1080 conv=notrunc >/dev/null 2>&1
-source_bytes=$(stat -f '%z' "$source_disk")
+source_bytes=$(/usr/bin/stat -f '%z' "$source_disk")
 source_sha=$(shasum -a 256 "$source_disk" | awk '{print $1}')
 source_disk_b="$test_root/source-b.ext4"
 /bin/cp "$source_disk" "$source_disk_b"
 printf 'updated-factory' | dd of="$source_disk_b" bs=1 seek=64 conv=notrunc >/dev/null 2>&1
-source_bytes_b=$(stat -f '%z' "$source_disk_b")
+source_bytes_b=$(/usr/bin/stat -f '%z' "$source_disk_b")
 source_sha_b=$(shasum -a 256 "$source_disk_b" | awk '{print $1}')
 identity_a=$(printf 'bundle-a' | shasum -a 256 | awk '{print $1}')
 identity_b=$(printf 'bundle-b' | shasum -a 256 | awk '{print $1}')
@@ -162,7 +174,7 @@ set -euo pipefail
 /bin/cp "$3" "$5"
 EOF
 chmod 700 "$zstd_test"
-compressed_bytes=$(stat -f '%z' "$compressed_disk")
+compressed_bytes=$(/usr/bin/stat -f '%z' "$compressed_disk")
 qemu_persistent_storage_materialize_source \
   "$identity_compressed" "$compressed_disk" "$compressed_bytes" \
   "$source_sha" "$source_bytes" "$zstd_test"
@@ -179,7 +191,7 @@ expanded_bytes=$((source_bytes + 16384))
 qemu_persistent_storage_select \
   persistent "$identity_expanded" "$source_disk" "$source_sha" "$source_bytes" '' "$expanded_bytes"
 expanded_disk=$QEMU_SELECTED_DISK
-assert_eq "$(stat -f '%z' "$expanded_disk")" "$expanded_bytes"
+assert_eq "$(/usr/bin/stat -f '%z' "$expanded_disk")" "$expanded_bytes"
 printf 'expanded-persistence' | dd of="$expanded_disk" bs=1 seek="$source_bytes" conv=notrunc >/dev/null 2>&1
 qemu_persistent_storage_release_lock
 qemu_persistent_storage_select \
@@ -193,7 +205,7 @@ persistent_a=$QEMU_SELECTED_DISK
 assert_eq "$QEMU_SELECTED_STORAGE_MODE" persistent
 assert test -f "$persistent_a"
 assert test -f "${persistent_a%/*}/metadata.json"
-assert_eq "$(stat -f '%Lp' "$persistent_a")" 600
+assert_eq "$(/usr/bin/stat -f '%Lp' "$persistent_a")" 600
 printf 'saved-user-data' | dd of="$persistent_a" bs=1 seek=128 conv=notrunc >/dev/null 2>&1
 qemu_persistent_storage_release_lock
 

--- a/macos/qemu-persistent-storage.sh
+++ b/macos/qemu-persistent-storage.sh
@@ -53,23 +53,23 @@ _qps_is_positive_integer() {
 }
 
 _qps_lstat_kind() {
-  stat -f '%HT' "$1" 2>/dev/null
+  /usr/bin/stat -f '%HT' "$1" 2>/dev/null
 }
 
 _qps_owner() {
-  stat -f '%u' "$1" 2>/dev/null
+  /usr/bin/stat -f '%u' "$1" 2>/dev/null
 }
 
 _qps_permissions() {
-  stat -f '%Lp' "$1" 2>/dev/null
+  /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
 }
 
 _qps_size() {
-  stat -f '%z' "$1" 2>/dev/null
+  /usr/bin/stat -f '%z' "$1" 2>/dev/null
 }
 
 _qps_file_identity() {
-  stat -f '%d:%i' "$1" 2>/dev/null
+  /usr/bin/stat -f '%d:%i' "$1" 2>/dev/null
 }
 
 _qps_assert_private_directory() {
@@ -235,7 +235,7 @@ _qps_lock_fd_is_open() {
 _qps_fd_matches_path() {
   local qps_fd=$1
   local qps_path=$2
-  [[ $(stat -f '%HT:%u:%i' "/dev/fd/$qps_fd" 2>/dev/null) == \
+  [[ $(/usr/bin/stat -f '%HT:%u:%i' "/dev/fd/$qps_fd" 2>/dev/null) == \
      "Regular File:$(id -u):$(_qps_file_identity "$qps_path" | sed 's/^.*://')" ]]
 }
 
@@ -1008,7 +1008,7 @@ _qps_migrate_legacy_single_workspace() {
       _qps_error "leaving oversized legacy workspace untouched: $qps_candidate_name"
       continue
     fi
-    qps_candidate_mtime=$(stat -f '%m' "$qps_candidate/rootfs.ext4" 2>/dev/null)
+    qps_candidate_mtime=$(/usr/bin/stat -f '%m' "$qps_candidate/rootfs.ext4" 2>/dev/null)
     [[ $qps_candidate_mtime =~ ^[0-9]+$ ]] || {
       [[ $qps_candidate_name != "$qps_identity" ]] || qps_exact_invalid=1
       _qps_error "leaving legacy workspace with an unreadable modification time untouched: $qps_candidate_name"

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -47,7 +47,7 @@ port_forwarding_library="$script_dir/qemu-port-forwarding.sh"
 [[ -d $guest_input && ! -L $guest_input ]] || fail "ARM guest directory is missing or unsafe: $guest_input"
 guest_dir=$(cd "$guest_input" && pwd -P)
 
-for command in codesign file getconf id mktemp ps stat sysctl; do
+for command in codesign file getconf id mktemp ps sysctl; do
   command -v "$command" >/dev/null || fail "$command is required"
 done
 
@@ -745,7 +745,7 @@ if [[ -n $shared_folder ]]; then
   [[ $shared_folder != *$'\n'* && $shared_folder != *$'\r'* && $shared_folder != *,* ]] || {
     fail "shared folder resolves to a path with an unsupported character: $shared_folder"
   }
-  [[ $(stat -f '%u' "$shared_folder") == $(id -u) ]] || {
+  [[ $(_qps_owner "$shared_folder") == $(id -u) ]] || {
     fail "shared folder must be owned by this user: $shared_folder"
   }
   home_dir=$(cd "$HOME" 2>/dev/null && pwd -P || true)
@@ -816,7 +816,7 @@ cleanup() {
     case "$work_dir" in
       /private/tmp/omarchy-qemu-gpu.??????)
         if [[ -d $work_dir && ! -L $work_dir && -f $owner_marker && ! -L $owner_marker ]] &&
-           [[ $(stat -f '%u' "$work_dir" 2>/dev/null) == $(id -u) ]] &&
+           [[ $(_qps_owner "$work_dir") == $(id -u) ]] &&
            [[ $(<"$owner_marker") == "$owner_token" ]]; then
           /bin/rm -rf "$work_dir" || {
             echo "run-qemu-gpu: could not remove owned temporary directory $work_dir" >&2
@@ -850,8 +850,8 @@ reap_stale_work_dirs() {
 
   for candidate in /private/tmp/omarchy-qemu-gpu.??????; do
     [[ -d $candidate && ! -L $candidate ]] || continue
-    [[ $(stat -f '%u' "$candidate" 2>/dev/null) == $(id -u) ]] || continue
-    [[ $(stat -f '%Lp' "$candidate" 2>/dev/null) == 700 ]] || continue
+    [[ $(_qps_owner "$candidate") == $(id -u) ]] || continue
+    [[ $(_qps_permissions "$candidate") == 700 ]] || continue
 
     marker="$candidate/.run-qemu-gpu.owner"
     [[ -f $marker && ! -L $marker ]] || continue
@@ -890,7 +890,7 @@ case "$work_dir" in
   *) fail "mktemp returned an unexpected path: $work_dir" ;;
 esac
 [[ -d $work_dir && ! -L $work_dir ]] || fail "temporary directory is unsafe: $work_dir"
-[[ $(stat -f '%u' "$work_dir") == $(id -u) ]] || fail "temporary directory is not owned by this user"
+[[ $(_qps_owner "$work_dir") == $(id -u) ]] || fail "temporary directory is not owned by this user"
 owner_marker="$work_dir/.run-qemu-gpu.owner"
 owner_token="run-qemu-gpu:v1:$$:${RANDOM}${RANDOM}"
 printf '%s\n' "$owner_token" >"$owner_marker"


### PR DESCRIPTION
## Summary

- use `/usr/bin/stat` for BSD-specific filesystem metadata checks
- reuse the storage helpers for launcher ownership and permission checks
- run the storage regression suite with a deliberately failing `stat` first in `PATH`

## Problem

When Homebrew coreutils precedes the system tools in `PATH`, the launcher resolves GNU `stat` for BSD-only invocations such as `stat -f '%u'`. GNU `stat` interprets those arguments differently:

```
stat: cannot read file system information for '%u': No such file or directory
run-qemu-gpu: temporary directory is not owned by this user
```

The app then reports only that its virtual machine stopped during startup. Pinning these security-sensitive metadata checks to macOS `/usr/bin/stat` avoids the PATH-dependent behavior without hiding Homebrew Python or other development tools.

## Testing

- `make test`
- manually reproduced the failure with Homebrew GNU coreutils first in `PATH`
- verified the storage lifecycle test passes with a failing shadow `stat` first in `PATH`

The staged-QEMU lock inheritance subtest was skipped because this checkout has no locally built QEMU runtime; all other tests passed.