### PR TITLE
Fix QEMU fullscreen menu reveal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test:
 	@mkdir -p $(ROOT)/macos/.build/module-cache/swift $(ROOT)/macos/.build/module-cache/clang
 	@cd $(ROOT)/macos && SWIFT_MODULECACHE_PATH=$(ROOT)/macos/.build/module-cache/swift CLANG_MODULE_CACHE_PATH=$(ROOT)/macos/.build/module-cache/clang swift test --disable-sandbox
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
+	@$(ROOT)/macos/Tests/qemu-fullscreen-presentation.test.sh
 
 guest:
 	@OMARCHY_FORCE_BUILD="$(FORCE)" "$(BUILD_CACHE)" \

--- a/macos/Tests/qemu-fullscreen-presentation.test.sh
+++ b/macos/Tests/qemu-fullscreen-presentation.test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "$0")" && pwd -P)
+macos_dir=$(cd "$test_dir/.." && pwd -P)
+
+fail() {
+  printf 'qemu-fullscreen-presentation.test: %s\n' "$*" >&2
+  exit 1
+}
+
+patch_path="$macos_dir/patches/qemu-cocoa-fullscreen-autohide.patch"
+build_script="$macos_dir/build-qemu-gpu-runtime.sh"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+[[ -f $patch_path && ! -L $patch_path ]] || \
+  fail "missing regular Cocoa fullscreen patch: $patch_path"
+[[ -f $build_script && ! -L $build_script ]] || \
+  fail "missing regular QEMU build script: $build_script"
+
+actual_sha=$(hash_file "$patch_path")
+script_sha=$(awk -F= '$1 == "fullscreen_autohide_patch_sha256" { print $2 }' "$build_script")
+[[ $script_sha == "$actual_sha" ]] || \
+  fail "build script checksum for the Cocoa fullscreen patch is stale"
+
+grep -Fq 'fullscreen_autohide_patch="$native_dir/patches/qemu-cocoa-fullscreen-autohide.patch"' \
+  "$build_script" || fail "build script does not reference the Cocoa fullscreen patch"
+grep -Fq 'verify_file_sha "Try Omarchy Cocoa fullscreen autohide patch"' \
+  "$build_script" || fail "build script does not verify the Cocoa fullscreen patch"
+grep -Fq '"$fullscreen_autohide_patch" "$fullscreen_autohide_patch_sha256"' \
+  "$build_script" || fail "build script does not verify the pinned fullscreen patch checksum"
+grep -Fq 'patch -d "$source_dir" -p1 -f -i "$fullscreen_autohide_patch"' \
+  "$build_script" || fail "build script does not apply the Cocoa fullscreen patch"
+
+grep -Fq 'willUseFullScreenPresentationOptions' "$patch_path" || \
+  fail "patch does not target the fullscreen presentation delegate"
+grep -Fq '+           NSApplicationPresentationHideDock |' "$patch_path" || \
+  fail "fullscreen patch no longer keeps the dock hidden"
+grep -Fq '+           NSApplicationPresentationAutoHideMenuBar;' "$patch_path" || \
+  fail "fullscreen patch does not enable the auto-hidden macOS menu bar"
+if grep -Eq '^\+.*NSApplicationPresentationHideMenuBar' "$patch_path"; then
+  fail "the presentation delegate still requests a permanently hidden menu bar"
+fi

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -43,6 +43,7 @@ done
 native_dir=$(cd "$(dirname "$0")" && pwd -P)
 identity_patch="$native_dir/patches/qemu-cocoa-product-identity.patch"
 display_patch="$native_dir/patches/qemu-cocoa-dynamic-display.patch"
+fullscreen_autohide_patch="$native_dir/patches/qemu-cocoa-fullscreen-autohide.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
 shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 prepare_runtime="$native_dir/prepare-qemu-gpu-runtime.sh"
@@ -62,6 +63,7 @@ texture_patch_sha256=428528d3203fe487e7aac21f313bc83e53ad22168e8fd39aa9eb1791bc1
 gpu_fix_patch_sha256=2b0a589d5821fbbfaa65177c97395ec50382373373e5c6860821279f07d62bb2
 identity_patch_sha256=5c9358c2858a74d6a678eacaae550a021f3e616c98c4e4e98c0e50bd869a0666
 display_patch_sha256=19392fe5723829edea348b82a6b0a74f874724af243ed0fb9101007a22fa5bbb
+fullscreen_autohide_patch_sha256=29b88abb0763bc0b6e50231b872b847949949a3f51269b9f25131fcaac22b7e7
 audio_device_patch_sha256=20469691f4cdabcd6b9513d6bf00fab9f66983e17b1e8477cc2e5ac47416feed
 shared_folder_patch_sha256=585a5ed40cc7e4a155ca799d731e15354db9e75d4f517d0689be60200750f3e3
 
@@ -123,6 +125,8 @@ macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
   die "missing Cocoa product-identity patch: $identity_patch"
 [[ -f $display_patch && ! -L $display_patch ]] || \
   die "missing dynamic-display patch: $display_patch"
+[[ -f $fullscreen_autohide_patch && ! -L $fullscreen_autohide_patch ]] || \
+  die "missing Cocoa fullscreen autohide patch: $fullscreen_autohide_patch"
 [[ -f $audio_device_patch && ! -L $audio_device_patch ]] || \
   die "missing SDL audio-device patch: $audio_device_patch"
 [[ -f $shared_folder_patch && ! -L $shared_folder_patch ]] || \
@@ -304,16 +308,19 @@ verify_file_sha "startergo GPU-resolution patch" "$gpu_fix_patch" "$gpu_fix_patc
 verify_file_sha "Try Omarchy Cocoa product-identity patch" \
   "$identity_patch" "$identity_patch_sha256"
 verify_file_sha "Try Omarchy dynamic-display patch" "$display_patch" "$display_patch_sha256"
+verify_file_sha "Try Omarchy Cocoa fullscreen autohide patch" \
+  "$fullscreen_autohide_patch" "$fullscreen_autohide_patch_sha256"
 verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
 verify_file_sha "Try Omarchy 9p shared-folder patch" \
   "$shared_folder_patch" "$shared_folder_patch_sha256"
 
-log "Applying the exact render, product-identity, dynamic-display, audio-device, and shared-folder patches"
+log "Applying the exact render, product-identity, dynamic-display, fullscreen-autohide, audio-device, and shared-folder patches"
 patch -d "$source_dir" -p1 -f -i "$texture_patch"
 patch -d "$source_dir" -p1 -f -i "$gpu_fix_patch"
 patch -d "$source_dir" -p1 -f -i "$identity_patch"
 patch -d "$source_dir" -p1 -f -i "$display_patch"
+patch -d "$source_dir" -p1 -f -i "$fullscreen_autohide_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
 patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 

--- a/macos/patches/qemu-cocoa-fullscreen-autohide.patch
+++ b/macos/patches/qemu-cocoa-fullscreen-autohide.patch
@@ -1,0 +1,23 @@
+From: Try Omarchy contributors
+Subject: [PATCH] cocoa: allow the menu bar to auto-hide in fullscreen
+
+Upstream Cocoa removes the auto-hide presentation flags and permanently hides
+the menu bar whenever QEMU enters native fullscreen. That prevents the usual
+macOS hover-to-reveal behavior. Keep the dock immersive, but let the user
+reveal the menu bar by moving the pointer to the top of the screen.
+
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -1407,8 +1407,9 @@ - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)theAppl
+ - (NSApplicationPresentationOptions) window:(NSWindow *)window
+                                      willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions;
+
+ {
+     return (proposedOptions & ~(NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar)) |
+-           NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar;
++           NSApplicationPresentationHideDock |
++           NSApplicationPresentationAutoHideMenuBar;
+ }
+
+ /*


### PR DESCRIPTION
## Summary

- Allow the macOS menu bar to auto-hide and reveal on pointer hover while QEMU is in native fullscreen.
- Keep the Dock hidden for an immersive fullscreen presentation.
- Wire the Cocoa patch into the checksum-pinned QEMU runtime build.
- Extend the regression test to verify the patch checksum, build wiring, and fullscreen presentation flags.

## Problem

QEMU's Cocoa fullscreen delegate removes the automatic-hide presentation flags and replaces them with permanent `HideDock` and `HideMenuBar` flags. In Try Omarchy, this means moving the pointer to the top of a fullscreen VM cannot reveal the macOS menu bar.

## Root cause and fix

The fullscreen presentation callback explicitly requested `NSApplicationPresentationHideMenuBar`. This change keeps `NSApplicationPresentationHideDock` but requests `NSApplicationPresentationAutoHideMenuBar`, restoring the normal macOS hover-to-reveal behavior.

The patch is treated as a pinned runtime input: the build rejects a missing or symlinked patch, verifies its SHA-256 before use, and applies it in the existing QEMU patch sequence. The contract test also checks the reference, checksum pin, verification/apply wiring, and intended Dock/Menu flag combination.

## Validation

- `macos/Tests/qemu-fullscreen-presentation.test.sh`
- `bash -n macos/Tests/qemu-fullscreen-presentation.test.sh macos/build-qemu-gpu-runtime.sh`
- `git diff --check origin/main...HEAD`
- The patch was compiled successfully in the macOS QEMU runtime build before PR preparation.
- In the current Linux environment, `make test` completed 6 build-cache tests, 32 guest tests, and the native guest contract, then stopped at the unavailable `swift` executable; the macOS GitHub Actions job will run the complete suite.
