### PR TITLE
Support VM reboot without closing the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test:
 	@$(ROOT)/guest/test
 	@mkdir -p $(ROOT)/macos/.build/module-cache/swift $(ROOT)/macos/.build/module-cache/clang
 	@cd $(ROOT)/macos && SWIFT_MODULECACHE_PATH=$(ROOT)/macos/.build/module-cache/swift CLANG_MODULE_CACHE_PATH=$(ROOT)/macos/.build/module-cache/clang swift test --disable-sandbox
+	@$(ROOT)/macos/Tests/qemu-power-actions.test.sh
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
 
 guest:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Try Omarchy is not official or affiliated with Omarchy.
 
 Every launch begins at the start menu. Accessibility enables Mac Command-to-guest-Super shortcuts; microphone access is optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
 
+Restarting from inside Omarchy reboots the guest in the same Try Omarchy app.
+Shutting down Omarchy closes the app and leaves it closed.
+
 ## Clipboard sharing
 
 Copy and paste work in both directions as soon as you sign in to Omarchy: text

--- a/macos/Tests/qemu-power-actions.test.sh
+++ b/macos/Tests/qemu-power-actions.test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "$0")" && pwd -P)
+launcher=$(cd "$test_dir/.." && pwd -P)/run-qemu-gpu.sh
+
+fail() {
+  printf 'qemu-power-actions.test: %s\n' "$*" >&2
+  exit 1
+}
+
+qemu_arguments=$(sed -n '/^qemu_args=(/,/^)/p' "$launcher")
+[[ -n $qemu_arguments ]] || fail 'could not find the QEMU argument list'
+
+action_count=$(printf '%s\n' "$qemu_arguments" | grep -Ec -- \
+  "^[[:space:]]+-action 'reboot=reset,shutdown=poweroff'[[:space:]]*$" || true)
+[[ $action_count == 1 ]] || {
+  fail 'QEMU must reset on guest reboot and power off on guest shutdown'
+}
+[[ $qemu_arguments != *-no-reboot* ]] || {
+  fail 'QEMU must not turn a guest reboot into a process exit'
+}
+[[ $qemu_arguments != *-no-shutdown* ]] || {
+  fail 'QEMU must not remain open after a guest shutdown'
+}
+
+printf 'qemu-power-actions.test: reboot/shutdown policy: PASS\n'

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -98,6 +98,12 @@ qemu_help=$("$qemu_bin" -help 2>&1) || fail "cannot inspect staged QEMU options"
 printf '%s\n' "$qemu_help" | grep -q -- '^-add-fd fd=fd,set=set' || {
   fail "staged QEMU cannot preserve the persistent-disk lock descriptor"
 }
+printf '%s\n' "$qemu_help" | grep -Fq -- '-action reboot=reset|shutdown' || {
+  fail "staged QEMU cannot apply the required reboot policy"
+}
+printf '%s\n' "$qemu_help" | grep -Fq -- '-action shutdown=poweroff|pause' || {
+  fail "staged QEMU cannot apply the required shutdown policy"
+}
 printf '%s\n' "$qemu_help" | grep -Fq 'full-grab=on|off' || {
   fail "staged QEMU cannot capture macOS system key combinations"
 }
@@ -929,7 +935,8 @@ qemu_args=(
   -smp "$vcpu_count,sockets=1,cores=$vcpu_count,threads=1"
   -m 4G
   -nodefaults
-  -no-reboot
+  # Reboot the guest inside this QEMU process, but let shutdown close the app.
+  -action 'reboot=reset,shutdown=poweroff'
   -netdev 'user,id=omarchy-net'
   -device 'virtio-net-pci,netdev=omarchy-net,mac=52:54:00:12:34:56,romfile='
   -audiodev 'sdl,id=omarchy-audio'


### PR DESCRIPTION
## Summary

- Configure QEMU to reset on guest reboot without exiting the app
- Configure guest shutdown to power off QEMU and close the app
- Add coverage for the QEMU power-action policy
- Document the resulting restart and shutdown behavior

## Testing

- Not run (not requested)