### PR TITLE
Improve fullscreen UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Try Omarchy is not official or affiliated with Omarchy.
 2. Open the DMG and drag **Try Omarchy** to **Applications**.
 3. Launch **Try Omarchy** from Applications.
 
-Every launch begins at the start menu. Accessibility enables Mac Command-to-guest-Super shortcuts; microphone access is optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
+Every launch begins at the start menu. **Immersive** is on by default and its caption explains how to leave Full Screen. Turn it off to keep Omarchy full screen while letting the Mac menu bar and Dock appear at the screen edges. Accessibility enables Mac Command-to-guest-Super shortcuts; microphone access is optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
 
 ## Clipboard sharing
 

--- a/macos/Sources/OmarchyVMHelper/FullscreenPreferences.swift
+++ b/macos/Sources/OmarchyVMHelper/FullscreenPreferences.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct FullscreenPreferences: Equatable {
+    var isImmersive: Bool
+
+    static let defaults = Self(isImmersive: true)
+}
+
+struct FullscreenPreferenceStore {
+    static let key = "fullscreenPreferences"
+    static let schemaVersion = 1
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> FullscreenPreferences {
+        guard let data = defaults.data(forKey: Self.key),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              payload.schemaVersion == Self.schemaVersion else {
+            return .defaults
+        }
+        return FullscreenPreferences(isImmersive: payload.isImmersive)
+    }
+
+    func save(_ preferences: FullscreenPreferences) {
+        let payload = Payload(
+            schemaVersion: Self.schemaVersion,
+            isImmersive: preferences.isImmersive
+        )
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+
+    private struct Payload: Codable {
+        let schemaVersion: Int
+        let isImmersive: Bool
+    }
+}
+
+struct FullscreenLaunchConfiguration: Equatable {
+    static let immersiveEnvironmentKey = "OMARCHY_QEMU_GPU_IMMERSIVE"
+
+    let environment: [String: String]
+
+    static func make(
+        baseEnvironment: [String: String],
+        preferences: FullscreenPreferences
+    ) -> Self {
+        var environment = baseEnvironment
+        environment.removeValue(forKey: immersiveEnvironmentKey)
+        environment[immersiveEnvironmentKey] = preferences.isImmersive ? "1" : "0"
+        return Self(environment: environment)
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -57,6 +57,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private let sharedFolderStatus: () -> SharedFolderMenuState
     private let chooseSharedFolder: (String) -> String?
     private let setSharedFolderEnabled: (Bool) -> Void
+    private let immersiveMode: () -> Bool
+    private let setImmersiveMode: (Bool) -> Void
     private let launch: () -> Void
     private let canResetStorage: Bool
     private let storageLocation: String?
@@ -66,6 +68,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private var resetInProgress = false
     private var launchInProgress = false
     private var pendingResetSpaceEstimate: String?
+    private weak var immersiveCaption: NSTextField?
 
     init(
         accessibilityStatus: @escaping () -> Bool,
@@ -80,6 +83,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         sharedFolderStatus: @escaping () -> SharedFolderMenuState,
         chooseSharedFolder: @escaping (String) -> String?,
         setSharedFolderEnabled: @escaping (Bool) -> Void,
+        immersiveMode: @escaping () -> Bool,
+        setImmersiveMode: @escaping (Bool) -> Void,
         launch: @escaping () -> Void
     ) {
         self.accessibilityStatus = accessibilityStatus
@@ -94,6 +99,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         self.sharedFolderStatus = sharedFolderStatus
         self.chooseSharedFolder = chooseSharedFolder
         self.setSharedFolderEnabled = setSharedFolderEnabled
+        self.immersiveMode = immersiveMode
+        self.setImmersiveMode = setImmersiveMode
         self.launch = launch
 
         window = NSWindow(
@@ -192,9 +199,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         title.font = .systemFont(ofSize: 27, weight: .bold)
 
         let headingStack = NSStackView(views: [icon, title])
-        headingStack.orientation = .vertical
-        headingStack.alignment = .leading
-        headingStack.spacing = 10
+        headingStack.orientation = .horizontal
+        headingStack.alignment = .centerY
+        headingStack.spacing = 14
 
         let accessibilityGranted = accessibilityStatus()
         let accessibilityRow = permissionRow(
@@ -277,14 +284,24 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             minimumHeight: 100
         )
 
+        let immersiveRow = immersiveSettingRow(isEnabled: immersiveMode())
+
         let permissionRows = NSStackView(
-            views: [accessibilityRow, separator(), microphoneRow, separator(), sharedFolderRow]
+            views: [
+                accessibilityRow,
+                separator(),
+                microphoneRow,
+                separator(),
+                sharedFolderRow,
+                separator(),
+                immersiveRow,
+            ]
         )
         permissionRows.orientation = .vertical
         permissionRows.alignment = .leading
         permissionRows.spacing = 0
         permissionRows.translatesAutoresizingMaskIntoConstraints = false
-        for row in [accessibilityRow, microphoneRow, sharedFolderRow] {
+        for row in [accessibilityRow, microphoneRow, sharedFolderRow, immersiveRow] {
             row.widthAnchor.constraint(equalTo: permissionRows.widthAnchor).isActive = true
         }
 
@@ -451,18 +468,18 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 18
-        stack.setCustomSpacing(22, after: headingStack)
+        stack.setCustomSpacing(14, after: headingStack)
         stack.setCustomSpacing(12, after: permissionCard)
-        stack.setCustomSpacing(20, after: resetSection)
-        stack.setCustomSpacing(10, after: launchButton)
+        stack.setCustomSpacing(12, after: resetSection)
+        stack.setCustomSpacing(8, after: launchButton)
         stack.translatesAutoresizingMaskIntoConstraints = false
         content.addSubview(stack)
 
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 42),
             stack.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -42),
-            stack.topAnchor.constraint(equalTo: content.topAnchor, constant: 48),
-            stack.bottomAnchor.constraint(lessThanOrEqualTo: content.bottomAnchor, constant: -30),
+            stack.topAnchor.constraint(equalTo: content.topAnchor, constant: 26),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: content.bottomAnchor, constant: -20),
             permissionCard.widthAnchor.constraint(equalTo: stack.widthAnchor),
             resetSection.widthAnchor.constraint(lessThanOrEqualTo: stack.widthAnchor),
             launchButton.widthAnchor.constraint(equalTo: stack.widthAnchor),
@@ -496,7 +513,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         granted: Bool,
         statusLabels: (granted: String, denied: String),
         actions: [(String, Selector)],
-        minimumHeight: CGFloat = 76
+        minimumHeight: CGFloat = 68
     ) -> NSView {
         let symbol = NSImageView()
         symbol.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
@@ -638,6 +655,71 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         return view
     }
 
+    private func immersiveSettingRow(isEnabled: Bool) -> NSView {
+        let symbol = NSImageView()
+        symbol.image = NSImage(
+            systemSymbolName: "arrow.up.left.and.arrow.down.right",
+            accessibilityDescription: nil
+        )
+        symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
+        symbol.contentTintColor = .controlAccentColor
+        symbol.identifier = NSUserInterfaceItemIdentifier("immersive-symbol")
+        symbol.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            symbol.widthAnchor.constraint(equalToConstant: 26),
+            symbol.heightAnchor.constraint(equalToConstant: 26),
+        ])
+
+        let title = NSTextField(labelWithString: "Immersive")
+        title.font = .systemFont(ofSize: 14, weight: .semibold)
+        title.identifier = NSUserInterfaceItemIdentifier("immersive-title")
+
+        let detailText = Self.immersiveDetailText(isEnabled: isEnabled)
+        let detail = NSTextField(wrappingLabelWithString: detailText)
+        detail.font = .systemFont(ofSize: 12)
+        detail.textColor = .secondaryLabelColor
+        detail.maximumNumberOfLines = 2
+        detail.identifier = NSUserInterfaceItemIdentifier("immersive-caption")
+        immersiveCaption = detail
+
+        let labels = NSStackView(views: [title, detail])
+        labels.orientation = .vertical
+        labels.alignment = .leading
+        labels.spacing = 3
+        labels.translatesAutoresizingMaskIntoConstraints = false
+
+        let toggle = NSSwitch()
+        toggle.state = isEnabled ? .on : .off
+        toggle.target = self
+        toggle.action = #selector(changeImmersiveMode(_:))
+        toggle.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
+        toggle.identifier = NSUserInterfaceItemIdentifier("immersive-toggle")
+        toggle.setAccessibilityLabel("Immersive mode")
+        toggle.setAccessibilityTitleUIElement(title)
+        toggle.setAccessibilityHelp(detailText)
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.identifier = NSUserInterfaceItemIdentifier("immersive-row")
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(symbol)
+        row.addSubview(labels)
+        row.addSubview(toggle)
+        NSLayoutConstraint.activate([
+            row.heightAnchor.constraint(greaterThanOrEqualToConstant: 72),
+            symbol.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            symbol.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.leadingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 12),
+            labels.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.trailingAnchor.constraint(lessThanOrEqualTo: toggle.leadingAnchor, constant: -12),
+            toggle.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+            toggle.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+        ])
+        labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return row
+    }
+
     @objc private func beginAccessibilityRequest() {
         requestAccessibility()
         render()
@@ -731,6 +813,29 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     @objc private func disableSharedFolder() {
         setSharedFolderEnabled(false)
         render()
+    }
+
+    @objc private func changeImmersiveMode(_ sender: NSSwitch) {
+        guard !launchInProgress, !resetInProgress else { return }
+        let isEnabled = sender.state == .on
+        setImmersiveMode(isEnabled)
+        let detailText = Self.immersiveDetailText(isEnabled: isEnabled)
+        immersiveCaption?.stringValue = detailText
+        sender.setAccessibilityHelp(detailText)
+        NSAccessibility.post(
+            element: NSApplication.shared,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: detailText,
+                .priority: NSAccessibilityPriorityLevel.medium.rawValue,
+            ]
+        )
+    }
+
+    private static func immersiveDetailText(isEnabled: Bool) -> String {
+        isEnabled
+            ? "Mac controls stay hidden. First press Control-Option-G, then Command-F to leave Full Screen."
+            : "Move the pointer to the top of the screen, then choose View › Exit Full Screen or press Command-F."
     }
 
     private func confirmReset() {

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -11,6 +11,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let supervisor: QEMUGPUProcessSupervisor
     private let preferenceStore: AudioRoutingPreferenceStore
     private let sharedFolderStore: SharedFolderPreferenceStore
+    private let fullscreenPreferenceStore: FullscreenPreferenceStore
     private let deviceProvider: HostAudioDeviceProviding
     private var startMenuWindow: StartMenuWindow?
 
@@ -28,6 +29,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         supervisor: QEMUGPUProcessSupervisor = QEMUGPUProcessSupervisor(),
         preferenceStore: AudioRoutingPreferenceStore = AudioRoutingPreferenceStore(),
         sharedFolderStore: SharedFolderPreferenceStore = SharedFolderPreferenceStore(),
+        fullscreenPreferenceStore: FullscreenPreferenceStore = FullscreenPreferenceStore(),
         deviceProvider: HostAudioDeviceProviding = CoreAudioHostAudioDeviceProvider()
     ) {
         self.launcherURL = launcherURL
@@ -36,6 +38,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         self.supervisor = supervisor
         self.preferenceStore = preferenceStore
         self.sharedFolderStore = sharedFolderStore
+        self.fullscreenPreferenceStore = fullscreenPreferenceStore
         self.deviceProvider = deviceProvider
     }
 
@@ -91,6 +94,14 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             },
             setSharedFolderEnabled: { [weak self] enabled in
                 self?.setSharedFolderEnabled(enabled)
+            },
+            immersiveMode: { [weak self] in
+                self?.fullscreenPreferenceStore.load().isImmersive ?? true
+            },
+            setImmersiveMode: { [weak self] isImmersive in
+                self?.fullscreenPreferenceStore.save(
+                    FullscreenPreferences(isImmersive: isImmersive)
+                )
             },
             launch: { [weak self] in
                 self?.startVirtualMachine()
@@ -212,11 +223,15 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             preference: sharedFolderStore.load(),
             homeDirectory: Self.homeDirectory
         )
+        let fullscreen = FullscreenLaunchConfiguration.make(
+            baseEnvironment: sharing.environment,
+            preferences: fullscreenPreferenceStore.load()
+        )
 
         try supervisor.start(
             executableURL: launcherURL,
             arguments: arguments,
-            environment: sharing.environment,
+            environment: fullscreen.environment,
             launchEvent: { [weak self] event in
                 if event == .virtualMachineReady {
                     self?.virtualMachineDidStart()

--- a/macos/Tests/OmarchyVMHelperTests/FullscreenNativeContractTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/FullscreenNativeContractTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@Suite("Immersive Full Screen native contract")
+struct FullscreenNativeContractTests {
+    @Test("Runner keeps both modes full screen and maps the grab policy")
+    func runnerMapping() throws {
+        let runner = try source(named: "run-qemu-gpu.sh")
+
+        #expect(runner.contains("case ${OMARCHY_QEMU_GPU_IMMERSIVE:-1} in"))
+        #expect(runner.contains("1) cocoa_full_grab=on ;;"))
+        #expect(runner.contains("0) cocoa_full_grab=off ;;"))
+        #expect(runner.contains("OMARCHY_QEMU_GPU_IMMERSIVE must be 0 or 1"))
+        #expect(runner.contains(
+            "full-screen=on,full-grab=$cocoa_full_grab,swap-opt-cmd=off"
+        ))
+    }
+
+    @Test("Cocoa standard mode reveals host controls and keeps the exit action accurate")
+    func cocoaBehavior() throws {
+        let patch = try source(named: "patches/qemu-cocoa-immersive-mode.patch")
+
+        #expect(patch.contains("if (!full_grab_enabled)"))
+        #expect(patch.contains("return proposedOptions;"))
+        #expect(patch.contains("(!isMouseGrabbed || !full_grab_enabled)"))
+        #expect(patch.contains("[fullScreenMenuItem setTitle:@\"Exit Full Screen\"]"))
+        #expect(patch.contains("[fullScreenMenuItem setTitle:@\"Enter Full Screen\"]"))
+
+        let configuration = try #require(
+            patch.range(of: "full_grab_enabled = opts->u.cocoa.has_full_grab")
+        )
+        let fullScreenEntry = try #require(
+            patch.range(of: "[[cocoaView window] toggleFullScreen: nil]")
+        )
+        #expect(configuration.lowerBound < fullScreenEntry.lowerBound)
+    }
+
+    private func source(named relativePath: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let macosDirectory = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: macosDirectory.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/FullscreenPreferencesTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/FullscreenPreferencesTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Full Screen preferences")
+struct FullscreenPreferenceStoreTests {
+    @Test("Immersive mode is on until the user changes it")
+    func defaultsToImmersive() {
+        let fixture = DefaultsFixture()
+
+        #expect(fixture.store.load() == .defaults)
+        #expect(fixture.store.load().isImmersive)
+    }
+
+    @Test("Immersive choice persists")
+    func savesChoice() {
+        let fixture = DefaultsFixture()
+        fixture.store.save(FullscreenPreferences(isImmersive: false))
+
+        let reopened = FullscreenPreferenceStore(defaults: fixture.defaults)
+        #expect(reopened.load() == FullscreenPreferences(isImmersive: false))
+    }
+
+    @Test("Invalid or future preferences fail safely")
+    func invalidPreferencesUseDefault() throws {
+        let fixture = DefaultsFixture()
+        fixture.defaults.set(Data("junk".utf8), forKey: FullscreenPreferenceStore.key)
+        #expect(fixture.store.load() == .defaults)
+
+        let future = try JSONSerialization.data(withJSONObject: [
+            "schemaVersion": FullscreenPreferenceStore.schemaVersion + 1,
+            "isImmersive": false,
+        ])
+        fixture.defaults.set(future, forKey: FullscreenPreferenceStore.key)
+        #expect(fixture.store.load() == .defaults)
+    }
+
+    private final class DefaultsFixture {
+        let suiteName = "FullscreenPreferenceStoreTests.\(UUID().uuidString)"
+        let defaults: UserDefaults
+        let store: FullscreenPreferenceStore
+
+        init() {
+            defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            store = FullscreenPreferenceStore(defaults: defaults)
+        }
+
+        deinit {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}
+
+@Suite("Full Screen launch configuration")
+struct FullscreenLaunchConfigurationTests {
+    @Test("Publishes immersive mode and replaces inherited values")
+    func publishesChoice() {
+        let inherited = [
+            "KEEP_ME": "yes",
+            FullscreenLaunchConfiguration.immersiveEnvironmentKey: "invalid",
+        ]
+
+        let immersive = FullscreenLaunchConfiguration.make(
+            baseEnvironment: inherited,
+            preferences: FullscreenPreferences(isImmersive: true)
+        )
+        #expect(immersive.environment["KEEP_ME"] == "yes")
+        #expect(immersive.environment[FullscreenLaunchConfiguration.immersiveEnvironmentKey] == "1")
+
+        let standard = FullscreenLaunchConfiguration.make(
+            baseEnvironment: inherited,
+            preferences: FullscreenPreferences(isImmersive: false)
+        )
+        #expect(standard.environment["KEEP_ME"] == "yes")
+        #expect(standard.environment[FullscreenLaunchConfiguration.immersiveEnvironmentKey] == "0")
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -14,13 +14,17 @@ struct StartMenuWindowTests {
             requestAccessibility: {},
             requestMicrophone: { completion in completion(false) },
             canResetStorage: false,
-            storageLocation: nil,
-            storageLocationURL: nil,
+            storageLocation: "~/Library/Application Support/Try Omarchy",
+            storageLocationURL: URL(
+                fileURLWithPath: "/Users/test/Library/Application Support/Try Omarchy"
+            ),
             storageSpaceEstimate: { nil },
             resetStorage: {},
             sharedFolderStatus: { .disabled },
             chooseSharedFolder: { _ in nil },
             setSharedFolderEnabled: { _ in },
+            immersiveMode: { true },
+            setImmersiveMode: { _ in },
             launch: {}
         )
         menu.show()
@@ -55,6 +59,9 @@ struct StartMenuWindowTests {
         let labelFrame = launchLabel.convert(launchLabel.bounds, to: launchButton)
         #expect(abs(labelFrame.midX - launchButton.bounds.midX) <= 0.5)
         #expect(abs(labelFrame.midY - launchButton.bounds.midY) <= 0.5)
+        let launchFrame = launchButton.convert(launchButton.bounds, to: content)
+        #expect(launchFrame.minY >= content.bounds.minY)
+        #expect(launchFrame.maxY <= content.bounds.maxY)
     }
 
     @Test("shared folder paths keep separate compact lines and actions stay aligned")
@@ -83,6 +90,8 @@ struct StartMenuWindowTests {
             },
             chooseSharedFolder: { _ in nil },
             setSharedFolderEnabled: { _ in },
+            immersiveMode: { true },
+            setImmersiveMode: { _ in },
             launch: {}
         )
         menu.show()
@@ -130,6 +139,93 @@ struct StartMenuWindowTests {
         menu.refreshPermissionStatus()
         content.layoutSubtreeIfNeeded()
         try expectPermissionColumnsAligned(in: content)
+    }
+
+    @Test("Immersive toggle explains how to leave both Full Screen modes")
+    func immersiveToggleUpdatesItsGuidance() throws {
+        _ = NSApplication.shared
+        var isImmersive = true
+        var savedChoices: [Bool] = []
+        let menu = StartMenuWindow(
+            accessibilityStatus: { true },
+            microphoneStatus: { .authorized },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(true) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            immersiveMode: { isImmersive },
+            setImmersiveMode: { choice in
+                isImmersive = choice
+                savedChoices.append(choice)
+            },
+            launch: {}
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let content = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })?.contentView
+        )
+        content.layoutSubtreeIfNeeded()
+
+        let immersiveToggle = try #require(
+            descendant(withIdentifier: "immersive-toggle", in: content) as? NSSwitch
+        )
+        let immersiveCaption = try #require(
+            descendant(withIdentifier: "immersive-caption", in: content) as? NSTextField
+        )
+        let immersiveRow = try #require(
+            descendant(withIdentifier: "immersive-row", in: content)
+        )
+        let launchButton = try #require(
+            descendant(withIdentifier: "launch-button", in: content)
+        )
+        #expect(immersiveToggle.state == .on)
+        #expect(immersiveCaption.stringValue.contains("Control-Option-G, then Command-F"))
+        #expect(immersiveToggle.accessibilityLabel() == "Immersive mode")
+        #expect(immersiveToggle.accessibilityHelp() == immersiveCaption.stringValue)
+        #expect(immersiveToggle.frame.height >= 24)
+        #expect(immersiveCaption.frame.height > 0)
+        let immersiveRowFrame = immersiveRow.convert(immersiveRow.bounds, to: content)
+        #expect(immersiveRowFrame.minY >= content.bounds.minY)
+        #expect(immersiveRowFrame.maxY <= content.bounds.maxY)
+        let launchButtonFrame = launchButton.convert(launchButton.bounds, to: content)
+        #expect(launchButtonFrame.minY >= content.bounds.minY)
+        #expect(launchButtonFrame.maxY <= content.bounds.maxY)
+
+        content.window?.makeFirstResponder(immersiveToggle)
+        immersiveToggle.performClick(nil)
+        content.layoutSubtreeIfNeeded()
+
+        #expect(savedChoices == [false])
+        #expect(content.window?.firstResponder === immersiveToggle)
+        let standardToggle = try #require(
+            descendant(withIdentifier: "immersive-toggle", in: content) as? NSSwitch
+        )
+        let standardCaption = try #require(
+            descendant(withIdentifier: "immersive-caption", in: content) as? NSTextField
+        )
+        #expect(standardToggle.state == .off)
+        #expect(standardCaption.stringValue ==
+            "Move the pointer to the top of the screen, then choose View › Exit Full Screen or press Command-F.")
+        #expect(standardToggle.accessibilityHelp() == standardCaption.stringValue)
+
+        menu.refreshPermissionStatus()
+        content.layoutSubtreeIfNeeded()
+        let refreshedToggle = try #require(
+            descendant(withIdentifier: "immersive-toggle", in: content) as? NSSwitch
+        )
+        let refreshedCaption = try #require(
+            descendant(withIdentifier: "immersive-caption", in: content) as? NSTextField
+        )
+        #expect(refreshedToggle.state == .off)
+        #expect(refreshedCaption.stringValue == standardCaption.stringValue)
     }
 
     private func expectPermissionColumnsAligned(in content: NSView) throws {

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -7,7 +7,8 @@ usage() {
 Usage: macos/build-qemu-gpu-runtime.sh [--archive-dir DIR]
 
 Build the pinned startergo QEMU/VirGL source stack with Try Omarchy's Cocoa
-identity and dynamic-display patches, then relocate, sign, validate, and
+identity, dynamic-display, and immersive-mode patches, then relocate, sign,
+validate, and
 atomically stage it at:
   macos/.build/qemu-gpu-runtime
 
@@ -43,6 +44,7 @@ done
 native_dir=$(cd "$(dirname "$0")" && pwd -P)
 identity_patch="$native_dir/patches/qemu-cocoa-product-identity.patch"
 display_patch="$native_dir/patches/qemu-cocoa-dynamic-display.patch"
+immersive_patch="$native_dir/patches/qemu-cocoa-immersive-mode.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
 shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 prepare_runtime="$native_dir/prepare-qemu-gpu-runtime.sh"
@@ -62,6 +64,7 @@ texture_patch_sha256=428528d3203fe487e7aac21f313bc83e53ad22168e8fd39aa9eb1791bc1
 gpu_fix_patch_sha256=2b0a589d5821fbbfaa65177c97395ec50382373373e5c6860821279f07d62bb2
 identity_patch_sha256=5c9358c2858a74d6a678eacaae550a021f3e616c98c4e4e98c0e50bd869a0666
 display_patch_sha256=19392fe5723829edea348b82a6b0a74f874724af243ed0fb9101007a22fa5bbb
+immersive_patch_sha256=787b271b3c7260305f54f9d7ed5fbbf82d085347954977df6b12898c2efb5f0f
 audio_device_patch_sha256=20469691f4cdabcd6b9513d6bf00fab9f66983e17b1e8477cc2e5ac47416feed
 shared_folder_patch_sha256=585a5ed40cc7e4a155ca799d731e15354db9e75d4f517d0689be60200750f3e3
 
@@ -123,6 +126,8 @@ macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
   die "missing Cocoa product-identity patch: $identity_patch"
 [[ -f $display_patch && ! -L $display_patch ]] || \
   die "missing dynamic-display patch: $display_patch"
+[[ -f $immersive_patch && ! -L $immersive_patch ]] || \
+  die "missing immersive-mode patch: $immersive_patch"
 [[ -f $audio_device_patch && ! -L $audio_device_patch ]] || \
   die "missing SDL audio-device patch: $audio_device_patch"
 [[ -f $shared_folder_patch && ! -L $shared_folder_patch ]] || \
@@ -304,16 +309,19 @@ verify_file_sha "startergo GPU-resolution patch" "$gpu_fix_patch" "$gpu_fix_patc
 verify_file_sha "Try Omarchy Cocoa product-identity patch" \
   "$identity_patch" "$identity_patch_sha256"
 verify_file_sha "Try Omarchy dynamic-display patch" "$display_patch" "$display_patch_sha256"
+verify_file_sha "Try Omarchy Cocoa immersive-mode patch" \
+  "$immersive_patch" "$immersive_patch_sha256"
 verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
 verify_file_sha "Try Omarchy 9p shared-folder patch" \
   "$shared_folder_patch" "$shared_folder_patch_sha256"
 
-log "Applying the exact render, product-identity, dynamic-display, audio-device, and shared-folder patches"
+log "Applying the exact render, product-identity, dynamic-display, immersive-mode, audio-device, and shared-folder patches"
 patch -d "$source_dir" -p1 -f -i "$texture_patch"
 patch -d "$source_dir" -p1 -f -i "$gpu_fix_patch"
 patch -d "$source_dir" -p1 -f -i "$identity_patch"
 patch -d "$source_dir" -p1 -f -i "$display_patch"
+patch -d "$source_dir" -p1 -f -i "$immersive_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
 patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 

--- a/macos/patches/qemu-cocoa-immersive-mode.patch
+++ b/macos/patches/qemu-cocoa-immersive-mode.patch
@@ -1,0 +1,125 @@
+From: Try Omarchy contributors
+Subject: [PATCH] cocoa: make full grab opt into immersive fullscreen
+
+Applies after the Try Omarchy product-identity and dynamic-display patches.
+
+QEMU's Cocoa fullscreen always replaces AppKit's auto-hidden menu bar and Dock
+with hard-hidden variants. Treat the existing full-grab display option as the
+user's immersive-mode choice: full grab keeps today's hidden chrome and guest
+Command-key capture, while standard fullscreen preserves AppKit's top-edge
+reveal and routes Command chords to the host even after the guest view grabs
+input. Both modes remain fullscreen and keep normal guest pointer handling.
+The View menu also follows the current state so its exit action stays obvious.
+
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -89,6 +89,7 @@
+ static int cursor_hide = 1;
+ static int left_command_key_enabled = 1;
+ static bool swap_opt_cmd;
++static bool full_grab_enabled;
+ 
+ static bool zoom_interpolation;
+ static NSTextField *pauseLabel;
+@@ -1013,7 +1014,8 @@
+ 
+                 /* Don't pass command key changes to guest unless mouse is grabbed */
+                 case kVK_Command:
+-                    if (isMouseGrabbed &&
++                    if (full_grab_enabled &&
++                        isMouseGrabbed &&
+                         !!(modifiers & NSEventModifierFlagCommand) &&
+                         left_command_key_enabled) {
+                         if (swap_opt_cmd) {
+@@ -1025,7 +1027,8 @@
+                     break;
+ 
+                 case kVK_RightCommand:
+-                    if (isMouseGrabbed &&
++                    if (full_grab_enabled &&
++                        isMouseGrabbed &&
+                         !!(modifiers & NSEventModifierFlagCommand)) {
+                         if (swap_opt_cmd) {
+                             [self toggleKey:Q_KEY_CODE_ALT_R];
+@@ -1039,8 +1042,10 @@
+         case NSEventTypeKeyDown:
+             keycode = cocoa_keycode_to_qemu([event keyCode]);
+ 
+-            // forward command key combos to the host UI unless the mouse is grabbed
+-            if (!isMouseGrabbed && ([event modifierFlags] & NSEventModifierFlagCommand)) {
++            // Keep Command chords with the host when ungrabbed or when the
++            // user selected standard, non-immersive fullscreen.
++            if ((!isMouseGrabbed || !full_grab_enabled) &&
++                ([event modifierFlags] & NSEventModifierFlagCommand)) {
+                 return false;
+             }
+ 
+@@ -1077,7 +1082,8 @@
+ 
+             // don't pass the guest a spurious key-up if we treated this
+             // command-key combo as a host UI action
+-            if (!isMouseGrabbed && ([event modifierFlags] & NSEventModifierFlagCommand)) {
++            if ((!isMouseGrabbed || !full_grab_enabled) &&
++                ([event modifierFlags] & NSEventModifierFlagCommand)) {
+                 return true;
+             }
+ 
+@@ -1301,5 +1307,6 @@
+ @interface QemuCocoaAppController : NSObject
+                                        <NSWindowDelegate, NSApplicationDelegate>
+ {
++    NSMenuItem *fullScreenMenuItem;
+ }
+ - (void)doToggleFullScreen:(id)sender;
+@@ -1458,12 +1465,14 @@
+ - (void)windowDidEnterFullScreen:(NSNotification *)notification
+ {
++    [fullScreenMenuItem setTitle:@"Exit Full Screen"];
+     [cocoaView updateScale];
+     [cocoaView updateUIInfo];
+     [cocoaView grabMouse];
+ }
+ 
+ - (void)windowDidExitFullScreen:(NSNotification *)notification
+ {
++    [fullScreenMenuItem setTitle:@"Enter Full Screen"];
+     [cocoaView resizeWindow];
+     [cocoaView updateScale];
+     [cocoaView updateUIInfo];
+@@ -1493,6 +1502,10 @@
+                                      willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions;
+ 
+ {
++    if (!full_grab_enabled) {
++        return proposedOptions;
++    }
++
+     return (proposedOptions & ~(NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar)) |
+            NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar;
+ }
+@@ -1834,6 +1847,7 @@
+     // View menu
+     menu = [[NSMenu alloc] initWithTitle:@"View"];
+-    [menu addItem: [[[NSMenuItem alloc] initWithTitle:@"Enter Fullscreen" action:@selector(doToggleFullScreen:) keyEquivalent:@"f"] autorelease]]; // Fullscreen
++    fullScreenMenuItem = [[[NSMenuItem alloc] initWithTitle:@"Enter Full Screen" action:@selector(doToggleFullScreen:) keyEquivalent:@"f"] autorelease];
++    [menu addItem:fullScreenMenuItem];
+     menuItem = [[[NSMenuItem alloc] initWithTitle:@"Zoom To Fit" action:@selector(zoomToFit:) keyEquivalent:@""] autorelease];
+     [menuItem setState: [[cocoaView window] styleMask] & NSWindowStyleMaskResizable ? NSControlStateValueOn : NSControlStateValueOff];
+     [menu addItem: menuItem];
+@@ -2584,11 +2598,14 @@
+         dcl.ops = &dcl_ops;
+     }
+ 
++    full_grab_enabled = opts->u.cocoa.has_full_grab &&
++                        opts->u.cocoa.full_grab;
++
+     /* if fullscreen mode is to be used */
+     if (opts->has_full_screen && opts->full_screen) {
+         [[cocoaView window] toggleFullScreen: nil];
+     }
+-    if (opts->u.cocoa.has_full_grab && opts->u.cocoa.full_grab) {
++    if (full_grab_enabled) {
+         [controller setFullGrab: nil];
+     }
+ 

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -918,6 +918,12 @@ if ((reset_only)); then
   exit 0
 fi
 
+case ${OMARCHY_QEMU_GPU_IMMERSIVE:-1} in
+  1) cocoa_full_grab=on ;;
+  0) cocoa_full_grab=off ;;
+  *) fail "OMARCHY_QEMU_GPU_IMMERSIVE must be 0 or 1" ;;
+esac
+
 qemu_args=(
   -name 'Try Omarchy'
   # HVF exposes the ARM virtual GICv2 interface on current Apple Silicon.
@@ -946,9 +952,10 @@ qemu_args=(
   -device "$gpu_device"
   # Cocoa forwards its live backing-pixel dimensions and the current host
   # display refresh rate through Virtio GPU EDID. Its accessibility-backed
-  # full grab captures system/global Command chords before Spotlight or a
-  # launcher can consume them; Command remains guest Super and Option guest Alt.
-  -display 'cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=on,full-grab=on,swap-opt-cmd=off'
+  # Immersive mode uses Cocoa's full grab to capture system/global Command
+  # chords and hard-hide Mac chrome. Standard mode stays full screen but lets
+  # Cocoa reveal the Mac menu bar and Dock at the screen edges.
+  -display "cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=on,full-grab=$cocoa_full_grab,swap-opt-cmd=off"
   -device 'virtio-keyboard-pci,romfile='
   -device 'virtio-tablet-pci,romfile='
   -object 'rng-random,id=omarchy-rng,filename=/dev/urandom'


### PR DESCRIPTION
A new "immersive" toggle on the Start Menu makes fullscreen mode optional and explicit, instructing users how to exit fullscreen.

Default behavior is unchanged, because fullscreen brings a better native-like experience, which is our goal.

Closes #12