### PR TITLE
Add port mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test:
 	@$(ROOT)/guest/test
 	@mkdir -p $(ROOT)/macos/.build/module-cache/swift $(ROOT)/macos/.build/module-cache/clang
 	@cd $(ROOT)/macos && SWIFT_MODULECACHE_PATH=$(ROOT)/macos/.build/module-cache/swift CLANG_MODULE_CACHE_PATH=$(ROOT)/macos/.build/module-cache/clang swift test --disable-sandbox
+	@$(ROOT)/macos/Tests/qemu-port-forwarding.test.sh
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
 
 guest:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Try Omarchy is not official or affiliated with Omarchy.
 - Mac audio input/output selection inside Omarchy, with live routing and system-default fallback
 - Two-way clipboard sharing for text and PNG images between macOS and Omarchy
 - One optional shared Mac folder, available inside Omarchy under the same name (`~/Work` stays `~/Work`)
+- Loopback-only TCP and UDP port forwarding from the Mac into Omarchy
 
 > **Current limitation:** Video decoding is CPU-only, so playback can be slow, especially at high resolutions. An improved video path is in development.
 
@@ -46,6 +47,18 @@ such as `~/Documents` that the link had taken over. The share belongs to the
 first Omarchy account created during
 provisioning. Additional guest accounts can reach the same share, with each
 entry's normal Unix permission bits deciding whether they can modify it.
+
+## Forwarding ports to Omarchy
+
+Use **Configure…** next to **Port forwarding** on the start menu to map a Mac
+localhost port to a service port in Omarchy. Each mapping can use TCP or UDP;
+the same Mac port may be used once for each protocol. Forwarded ports bind only
+to `127.0.0.1`, so other devices on the network cannot connect to them. The
+service inside Omarchy must listen on `0.0.0.0` or the guest network interface,
+not only on the guest's own localhost.
+
+The reverse direction does not need a mapping. From Omarchy, connect to
+`10.0.2.2:<Mac port>` to reach a service running on the Mac.
 
 ## Requirements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,12 @@ guest mounts the tag at `/mnt/mac` before the display manager starts, and a
 user unit links `~/<folder name>` to it at login; the name travels on the
 kernel command line as `omarchy.shared_folder_name=<base64url>`.
 
+Optional port mappings are stored as a versioned launcher preference, validated
+again at every Swift-to-shell boundary, and translated into QEMU user-network
+`hostfwd` rules. The host side is always bound explicitly to `127.0.0.1`; the
+launcher never creates wildcard or LAN-facing listeners. TCP and UDP occupy
+separate host-port namespaces, matching QEMU's socket behavior.
+
 ## The ARM64 image
 
 The guest image is built by this project; it is not an official prebuilt image

--- a/macos/Sources/OmarchyVMHelper/PortForwarding.swift
+++ b/macos/Sources/OmarchyVMHelper/PortForwarding.swift
@@ -1,0 +1,220 @@
+import Darwin
+import Foundation
+
+/// The transport protocol QEMU should forward between the Mac and the guest.
+enum PortForwardProtocol: String, Codable, CaseIterable, Sendable {
+    case tcp
+    case udp
+
+    var displayName: String {
+        rawValue.uppercased()
+    }
+}
+
+/// One loopback port on the Mac mapped to a port inside the guest.
+struct PortForwardMapping: Codable, Equatable, Hashable, Sendable {
+    let hostPort: Int
+    let guestPort: Int
+    let `protocol`: PortForwardProtocol
+}
+
+enum PortForwardPolicyError: LocalizedError, Equatable {
+    case invalidHostPort(Int)
+    case invalidGuestPort(Int)
+    case duplicateHostPort(PortForwardProtocol, Int)
+    case tooManyMappings(maximum: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidHostPort(let port):
+            "The Mac port must be between 1 and 65535 (received \(port))."
+        case .invalidGuestPort(let port):
+            "The Omarchy port must be between 1 and 65535 (received \(port))."
+        case .duplicateHostPort(let transport, let port):
+            "Mac \(transport.displayName) port \(port) is already mapped."
+        case .tooManyMappings(let maximum):
+            "You can add up to \(maximum) port mappings."
+        }
+    }
+}
+
+/// Shared validation and serialization rules for the menu, preferences, and launcher.
+enum PortForwardPolicy {
+    static let environmentKey = "OMARCHY_QEMU_GPU_PORT_FORWARDS"
+    static let guestToHostAddress = "10.0.2.2"
+    static let maximumMappings = 32
+    static let validPortRange = 1...65_535
+
+    static func validate(_ mapping: PortForwardMapping) throws {
+        guard validPortRange.contains(mapping.hostPort) else {
+            throw PortForwardPolicyError.invalidHostPort(mapping.hostPort)
+        }
+        guard validPortRange.contains(mapping.guestPort) else {
+            throw PortForwardPolicyError.invalidGuestPort(mapping.guestPort)
+        }
+    }
+
+    /// Validates a complete ordered set. A host port may be reused only when
+    /// the transport protocol differs, matching QEMU's socket semantics.
+    static func validate(_ mappings: [PortForwardMapping]) throws {
+        guard mappings.count <= maximumMappings else {
+            throw PortForwardPolicyError.tooManyMappings(maximum: maximumMappings)
+        }
+
+        var occupiedHostPorts = Set<HostPortKey>()
+        for mapping in mappings {
+            try validate(mapping)
+            let key = HostPortKey(protocol: mapping.protocol, port: mapping.hostPort)
+            guard occupiedHostPorts.insert(key).inserted else {
+                throw PortForwardPolicyError.duplicateHostPort(mapping.protocol, mapping.hostPort)
+            }
+        }
+    }
+
+    /// Returns the strict representation consumed by the launcher script.
+    /// Array order is deliberately preserved for stable UI and launch behavior.
+    static func encodedEnvironmentValue(for mappings: [PortForwardMapping]) throws -> String? {
+        try validate(mappings)
+        guard !mappings.isEmpty else { return nil }
+        return mappings.map {
+            "\($0.protocol.rawValue):\($0.hostPort):\($0.guestPort)"
+        }.joined(separator: ";")
+    }
+
+    private struct HostPortKey: Hashable {
+        let `protocol`: PortForwardProtocol
+        let port: Int
+    }
+}
+
+/// Persists the user's ordered mapping list as one versioned, atomic value.
+struct PortForwardingPreferenceStore {
+    static let key = "portForwardingPreferences"
+    static let schemaVersion = 1
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Unknown, malformed, or policy-invalid data fails closed to no mappings.
+    func load() -> [PortForwardMapping] {
+        guard let data = defaults.data(forKey: Self.key),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              payload.schemaVersion == Self.schemaVersion,
+              (try? PortForwardPolicy.validate(payload.mappings)) != nil else {
+            return []
+        }
+        return payload.mappings
+    }
+
+    /// Invalid edits are rejected without replacing the last valid preference.
+    func save(_ mappings: [PortForwardMapping]) throws {
+        try PortForwardPolicy.validate(mappings)
+        let payload = Payload(schemaVersion: Self.schemaVersion, mappings: mappings)
+        defaults.set(try JSONEncoder().encode(payload), forKey: Self.key)
+    }
+
+    private struct Payload: Codable {
+        let schemaVersion: Int
+        let mappings: [PortForwardMapping]
+    }
+}
+
+struct PortForwardLaunchConfiguration: Equatable {
+    let mappings: [PortForwardMapping]
+    let environment: [String: String]
+
+    /// Strips any inherited forwarding value before considering preferences.
+    /// The complete set is emitted only when every mapping is valid.
+    static func make(
+        baseEnvironment: [String: String],
+        mappings: [PortForwardMapping]
+    ) -> Self {
+        var environment = baseEnvironment
+        environment.removeValue(forKey: PortForwardPolicy.environmentKey)
+
+        guard let encoded = try? PortForwardPolicy.encodedEnvironmentValue(for: mappings) else {
+            return Self(mappings: [], environment: environment)
+        }
+        environment[PortForwardPolicy.environmentKey] = encoded
+        return Self(mappings: mappings, environment: environment)
+    }
+}
+
+enum PortForwardAvailabilityError: LocalizedError, Equatable {
+    case unavailable(PortForwardProtocol, Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let protocolValue, let port):
+            "Mac \(protocolValue.displayName) port \(port) isn’t available. Another app may already be using it. Choose another Mac port in Port Forwarding and try again."
+        }
+    }
+}
+
+/// Converts QEMU's authoritative host-forward bind failure into a recovery
+/// message that keeps the start menu open after the small preflight race.
+enum PortForwardStartupFailure {
+    private static let qemuBindFailure = "could not set up host forwarding rule"
+
+    static func message(
+        standardError: String,
+        mappings: [PortForwardMapping]
+    ) -> String? {
+        guard standardError.localizedCaseInsensitiveContains(qemuBindFailure) else {
+            return nil
+        }
+
+        if let mapping = mappings.first(where: { mapping in
+            standardError.contains(
+                "\(mapping.protocol.rawValue):127.0.0.1:\(mapping.hostPort)-"
+            )
+        }) {
+            return "Mac \(mapping.protocol.displayName) port \(mapping.hostPort) couldn’t be opened. Another app may have started using it. Choose another Mac port in Port Forwarding and try again."
+        }
+
+        return "A configured Mac port couldn’t be opened. Review Port Forwarding and try another Mac port."
+    }
+}
+
+/// Gives an immediate, actionable error for the common startup failure where
+/// another Mac app already owns a requested loopback port. QEMU still performs
+/// the authoritative bind moments later; this preflight exists for better UX.
+enum PortForwardAvailability {
+    static func validate(_ mappings: [PortForwardMapping]) throws {
+        try PortForwardPolicy.validate(mappings)
+        for mapping in mappings where !canBind(mapping) {
+            throw PortForwardAvailabilityError.unavailable(mapping.protocol, mapping.hostPort)
+        }
+    }
+
+    private static func canBind(_ mapping: PortForwardMapping) -> Bool {
+        let socketType: Int32
+        switch mapping.protocol {
+        case .tcp:
+            socketType = SOCK_STREAM
+        case .udp:
+            socketType = SOCK_DGRAM
+        }
+        let descriptor = Darwin.socket(AF_INET, socketType, 0)
+        guard descriptor >= 0 else { return false }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(mapping.hostPort).bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        return withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(
+                    descriptor,
+                    $0,
+                    socklen_t(MemoryLayout<sockaddr_in>.size)
+                ) == 0
+            }
+        }
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/PortForwardingEditor.swift
+++ b/macos/Sources/OmarchyVMHelper/PortForwardingEditor.swift
@@ -1,0 +1,562 @@
+import AppKit
+import Foundation
+
+/// A fixed-size editor keeps a growing forwarding list out of the launch menu.
+/// Rows scroll independently once they no longer fit in the sheet.
+@MainActor
+final class PortForwardingEditor: NSObject, NSWindowDelegate, NSTextFieldDelegate {
+    typealias SaveHandler = ([PortForwardMapping]) -> String?
+
+    private struct Draft {
+        var hostPort: String
+        var guestPort: String
+        var `protocol`: PortForwardProtocol
+
+        init(mapping: PortForwardMapping) {
+            hostPort = String(mapping.hostPort)
+            guestPort = String(mapping.guestPort)
+            `protocol` = mapping.protocol
+        }
+
+        init() {
+            hostPort = ""
+            guestPort = ""
+            `protocol` = .tcp
+        }
+    }
+
+    private enum FieldKind: Int {
+        case host = 0
+        case guest = 1
+    }
+
+    private struct Validation {
+        let mappings: [PortForwardMapping]?
+        let message: String
+        let isError: Bool
+    }
+
+    private let initialMappings: [PortForwardMapping]
+    private let saveHandler: SaveHandler
+    private let closeHandler: () -> Void
+    private var drafts: [Draft]
+
+    private(set) var window: NSWindow!
+    private let rowsStack = NSStackView()
+    private let scrollView = NSScrollView()
+    private let addButton = NSButton()
+    private let saveButton = NSButton()
+    private let validationLabel = NSTextField(wrappingLabelWithString: "")
+    private var announcedValidationError: String?
+
+    init(
+        mappings: [PortForwardMapping],
+        save: @escaping SaveHandler,
+        didClose: @escaping () -> Void = {}
+    ) {
+        initialMappings = mappings
+        saveHandler = save
+        closeHandler = didClose
+        drafts = mappings.map(Draft.init(mapping:))
+        super.init()
+        buildWindow()
+        rebuildRows()
+    }
+
+    func beginSheet(for parent: NSWindow) {
+        parent.beginSheet(window)
+    }
+
+    func show() {
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    func dismiss() {
+        closeWindow()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        closeWindow()
+        return false
+    }
+
+    private func buildWindow() {
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 540, height: 430),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Port Forwarding"
+        window.titlebarAppearsTransparent = true
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+        window.setAccessibilityLabel("Port Forwarding")
+
+        let title = NSTextField(labelWithString: "Port forwarding")
+        title.font = .systemFont(ofSize: 21, weight: .bold)
+
+        let explanation = NSTextField(
+            wrappingLabelWithString: "Mac → Omarchy mappings expose guest services on Mac localhost. For Omarchy → Mac, connect to \(PortForwardPolicy.guestToHostAddress)."
+        )
+        explanation.font = .systemFont(ofSize: 12.5)
+        explanation.textColor = .secondaryLabelColor
+        explanation.maximumNumberOfLines = 2
+        explanation.identifier = NSUserInterfaceItemIdentifier("port-forward-explanation")
+
+        let heading = NSStackView(views: [title, explanation])
+        heading.orientation = .vertical
+        heading.alignment = .leading
+        heading.spacing = 5
+
+        rowsStack.orientation = .vertical
+        rowsStack.alignment = .leading
+        rowsStack.spacing = 0
+        rowsStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let document = FlippedDocumentView()
+        document.translatesAutoresizingMaskIntoConstraints = false
+        document.addSubview(rowsStack)
+        NSLayoutConstraint.activate([
+            rowsStack.leadingAnchor.constraint(equalTo: document.leadingAnchor),
+            rowsStack.trailingAnchor.constraint(equalTo: document.trailingAnchor),
+            rowsStack.topAnchor.constraint(equalTo: document.topAnchor),
+            rowsStack.bottomAnchor.constraint(equalTo: document.bottomAnchor),
+        ])
+
+        scrollView.documentView = document
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .bezelBorder
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .controlBackgroundColor
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.identifier = NSUserInterfaceItemIdentifier("port-forward-scroll")
+        NSLayoutConstraint.activate([
+            document.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 224),
+        ])
+
+        addButton.title = "Add Port"
+        addButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)
+        addButton.imagePosition = .imageLeading
+        addButton.bezelStyle = .rounded
+        addButton.controlSize = .regular
+        addButton.target = self
+        addButton.action = #selector(addPort)
+        addButton.identifier = NSUserInterfaceItemIdentifier("port-forward-add")
+        addButton.setAccessibilityHelp("Adds another localhost-to-Omarchy port mapping")
+
+        validationLabel.font = .systemFont(ofSize: 11.5)
+        validationLabel.maximumNumberOfLines = 2
+        validationLabel.identifier = NSUserInterfaceItemIdentifier("port-forward-validation")
+        validationLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let listFooter = NSStackView(views: [addButton, validationLabel])
+        listFooter.orientation = .vertical
+        listFooter.alignment = .leading
+        listFooter.spacing = 6
+
+        let cancelButton = NSButton(title: "Cancel", target: self, action: #selector(cancel))
+        cancelButton.bezelStyle = .rounded
+        cancelButton.keyEquivalent = "\u{1b}"
+        cancelButton.identifier = NSUserInterfaceItemIdentifier("port-forward-cancel")
+
+        saveButton.title = "Save"
+        saveButton.bezelStyle = .rounded
+        saveButton.keyEquivalent = "\r"
+        saveButton.target = self
+        saveButton.action = #selector(save)
+        saveButton.identifier = NSUserInterfaceItemIdentifier("port-forward-save")
+
+        let spacer = NSView()
+        let actions = NSStackView(views: [spacer, cancelButton, saveButton])
+        actions.orientation = .horizontal
+        actions.alignment = .centerY
+        actions.spacing = 8
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let contentStack = NSStackView(views: [heading, scrollView, listFooter, actions])
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.spacing = 14
+        contentStack.setCustomSpacing(18, after: heading)
+        contentStack.setCustomSpacing(18, after: listFooter)
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let content = NSView()
+        content.addSubview(contentStack)
+        window.contentView = content
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 26),
+            contentStack.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -26),
+            contentStack.topAnchor.constraint(equalTo: content.topAnchor, constant: 38),
+            contentStack.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -22),
+            heading.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            scrollView.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            listFooter.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+            actions.widthAnchor.constraint(equalTo: contentStack.widthAnchor),
+        ])
+    }
+
+    private func rebuildRows(
+        focusRow: Int? = nil,
+        focusAddButton: Bool = false,
+        scrollToBottom: Bool = false
+    ) {
+        for view in rowsStack.arrangedSubviews {
+            rowsStack.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
+        if drafts.isEmpty {
+            addFullWidthArrangedSubview(emptyState())
+        } else {
+            for index in drafts.indices {
+                if index > drafts.startIndex {
+                    addFullWidthArrangedSubview(separator())
+                }
+                addFullWidthArrangedSubview(mappingRow(at: index))
+            }
+        }
+
+        updateValidation()
+        rowsStack.layoutSubtreeIfNeeded()
+        scrollView.documentView?.layoutSubtreeIfNeeded()
+
+        if let index = focusRow,
+           let field = descendant(
+               withIdentifier: "port-forward-host-\(index)",
+               in: rowsStack
+            ) as? NSTextField {
+            window.makeFirstResponder(field)
+            reveal(field: field, atBottom: scrollToBottom)
+            // Repeat after AppKit's next layout pass in case the document grew.
+            DispatchQueue.main.async { [weak self, weak field] in
+                guard let self, let field, field.window === self.window else { return }
+                self.reveal(field: field, atBottom: scrollToBottom)
+            }
+        } else if focusAddButton {
+            window.makeFirstResponder(addButton)
+        }
+    }
+
+    private func emptyState() -> NSView {
+        let icon = NSImageView()
+        icon.image = NSImage(systemSymbolName: "network", accessibilityDescription: nil)
+        icon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 26, weight: .regular)
+        icon.contentTintColor = .tertiaryLabelColor
+
+        let title = NSTextField(labelWithString: "No ports forwarded")
+        title.font = .systemFont(ofSize: 14, weight: .semibold)
+
+        let detail = NSTextField(
+            wrappingLabelWithString: "Add a port for a guest service listening beyond guest localhost."
+        )
+        detail.font = .systemFont(ofSize: 11.5)
+        detail.textColor = .secondaryLabelColor
+        detail.alignment = .center
+        detail.maximumNumberOfLines = 2
+
+        let stack = NSStackView(views: [icon, title, detail])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.identifier = NSUserInterfaceItemIdentifier("port-forward-empty")
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(greaterThanOrEqualToConstant: 220),
+            stack.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 30),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -30),
+        ])
+        return container
+    }
+
+    private func mappingRow(at index: Int) -> NSView {
+        let draft = drafts[index]
+        let localhost = secondaryLabel("localhost:")
+        let hostField = portField(value: draft.hostPort, index: index, kind: .host)
+        let arrow = secondaryLabel("→")
+        arrow.alignment = .center
+        let guest = secondaryLabel("Omarchy:")
+        let guestField = portField(value: draft.guestPort, index: index, kind: .guest)
+
+        let protocolPicker = NSPopUpButton(frame: .zero, pullsDown: false)
+        protocolPicker.addItems(withTitles: PortForwardProtocol.allCases.map(\.displayName))
+        protocolPicker.selectItem(withTitle: draft.protocol.displayName)
+        protocolPicker.controlSize = .regular
+        protocolPicker.target = self
+        protocolPicker.action = #selector(protocolChanged(_:))
+        protocolPicker.tag = index
+        protocolPicker.identifier = NSUserInterfaceItemIdentifier("port-forward-protocol-\(index)")
+        protocolPicker.setAccessibilityLabel("Protocol for mapping \(index + 1)")
+        protocolPicker.widthAnchor.constraint(equalToConstant: 72).isActive = true
+
+        let remove = NSButton(
+            image: NSImage(systemSymbolName: "minus.circle", accessibilityDescription: nil) ?? NSImage(),
+            target: self,
+            action: #selector(removePort(_:))
+        )
+        remove.isBordered = false
+        remove.contentTintColor = .secondaryLabelColor
+        remove.tag = index
+        remove.identifier = NSUserInterfaceItemIdentifier("port-forward-remove-\(index)")
+        remove.setAccessibilityLabel("Remove mapping \(index + 1)")
+        remove.toolTip = "Remove this mapping"
+        remove.widthAnchor.constraint(equalToConstant: 28).isActive = true
+
+        let rowStack = NSStackView(
+            views: [localhost, hostField, arrow, guest, guestField, protocolPicker, remove]
+        )
+        rowStack.orientation = .horizontal
+        rowStack.alignment = .centerY
+        rowStack.spacing = 7
+        rowStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.identifier = NSUserInterfaceItemIdentifier("port-forward-row-\(index)")
+        row.addSubview(rowStack)
+        NSLayoutConstraint.activate([
+            row.heightAnchor.constraint(equalToConstant: 48),
+            rowStack.leadingAnchor.constraint(equalTo: row.leadingAnchor, constant: 12),
+            rowStack.trailingAnchor.constraint(equalTo: row.trailingAnchor, constant: -8),
+            rowStack.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+        ])
+        return row
+    }
+
+    private func portField(value: String, index: Int, kind: FieldKind) -> NSTextField {
+        let field = NSTextField(string: value)
+        field.placeholderString = kind == .host ? "8080" : "3000"
+        field.alignment = .right
+        field.font = .monospacedDigitSystemFont(ofSize: 13, weight: .regular)
+        field.controlSize = .regular
+        field.delegate = self
+        field.tag = (index * 2) + kind.rawValue
+        field.identifier = NSUserInterfaceItemIdentifier(
+            kind == .host ? "port-forward-host-\(index)" : "port-forward-guest-\(index)"
+        )
+        field.setAccessibilityLabel(
+            kind == .host
+                ? "Mac port for mapping \(index + 1)"
+                : "Omarchy port for mapping \(index + 1)"
+        )
+        field.widthAnchor.constraint(equalToConstant: 72).isActive = true
+        return field
+    }
+
+    private func secondaryLabel(_ value: String) -> NSTextField {
+        let field = NSTextField(labelWithString: value)
+        field.font = .systemFont(ofSize: 12)
+        field.textColor = .secondaryLabelColor
+        field.setContentHuggingPriority(.required, for: .horizontal)
+        return field
+    }
+
+    private func separator() -> NSView {
+        let separator = NSBox()
+        separator.boxType = .separator
+        return separator
+    }
+
+    private func addFullWidthArrangedSubview(_ view: NSView) {
+        rowsStack.addArrangedSubview(view)
+        view.widthAnchor.constraint(equalTo: rowsStack.widthAnchor).isActive = true
+    }
+
+    func controlTextDidChange(_ notification: Notification) {
+        guard let field = notification.object as? NSTextField else { return }
+        let index = field.tag / 2
+        guard drafts.indices.contains(index), let kind = FieldKind(rawValue: field.tag % 2) else {
+            return
+        }
+        switch kind {
+        case .host:
+            drafts[index].hostPort = field.stringValue
+        case .guest:
+            drafts[index].guestPort = field.stringValue
+        }
+        updateValidation()
+    }
+
+    @objc private func protocolChanged(_ sender: NSPopUpButton) {
+        guard drafts.indices.contains(sender.tag),
+              let rawValue = sender.titleOfSelectedItem?.lowercased(),
+              let protocolValue = PortForwardProtocol(rawValue: rawValue) else { return }
+        drafts[sender.tag].protocol = protocolValue
+        updateValidation()
+    }
+
+    @objc private func addPort() {
+        guard drafts.count < PortForwardPolicy.maximumMappings else { return }
+        drafts.append(Draft())
+        rebuildRows(
+            focusRow: drafts.index(before: drafts.endIndex),
+            scrollToBottom: true
+        )
+    }
+
+    @objc private func removePort(_ sender: NSButton) {
+        guard drafts.indices.contains(sender.tag) else { return }
+        let removedIndex = sender.tag
+        drafts.remove(at: removedIndex)
+        if drafts.isEmpty {
+            rebuildRows(focusAddButton: true)
+        } else {
+            rebuildRows(focusRow: min(removedIndex, drafts.index(before: drafts.endIndex)))
+        }
+    }
+
+    @objc private func cancel() {
+        closeWindow()
+    }
+
+    @objc private func save() {
+        let validation = validation()
+        guard let mappings = validation.mappings else {
+            updateValidation()
+            return
+        }
+        if let problem = saveHandler(mappings) {
+            validationLabel.stringValue = problem
+            validationLabel.textColor = .systemRed
+            saveButton.isEnabled = false
+            return
+        }
+        closeWindow()
+    }
+
+    private func updateValidation() {
+        let validation = validation()
+        validationLabel.stringValue = validation.message
+        validationLabel.isHidden = validation.message.isEmpty
+        validationLabel.textColor = validation.isError ? .systemRed : .secondaryLabelColor
+        if validation.isError, announcedValidationError != validation.message {
+            announcedValidationError = validation.message
+            NSAccessibility.post(
+                element: validationLabel,
+                notification: .announcementRequested,
+                userInfo: [
+                    .announcement: validation.message,
+                    .priority: NSAccessibilityPriorityLevel.high.rawValue,
+                ]
+            )
+        } else if !validation.isError {
+            announcedValidationError = nil
+        }
+        let hasChanges = validation.mappings.map { $0 != initialMappings } ?? false
+        saveButton.isEnabled = validation.mappings != nil && hasChanges
+        addButton.isEnabled = drafts.count < PortForwardPolicy.maximumMappings
+        addButton.toolTip = addButton.isEnabled
+            ? "Add a port mapping"
+            : "Up to \(PortForwardPolicy.maximumMappings) mappings are supported"
+    }
+
+    private func validation() -> Validation {
+        guard !drafts.isEmpty else {
+            return Validation(mappings: [], message: "", isError: false)
+        }
+
+        var mappings: [PortForwardMapping] = []
+        for (offset, draft) in drafts.enumerated() {
+            let row = offset + 1
+            let host = draft.hostPort.trimmingCharacters(in: .whitespacesAndNewlines)
+            let guest = draft.guestPort.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !host.isEmpty, !guest.isEmpty else {
+                return Validation(
+                    mappings: nil,
+                    message: "",
+                    isError: false
+                )
+            }
+            guard host.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+                  let hostPort = Int(host),
+                  PortForwardPolicy.validPortRange.contains(hostPort) else {
+                return Validation(
+                    mappings: nil,
+                    message: "Mac port in mapping \(row) must be a number from 1 to 65535.",
+                    isError: true
+                )
+            }
+            guard guest.utf8.allSatisfy({ $0 >= 48 && $0 <= 57 }),
+                  let guestPort = Int(guest),
+                  PortForwardPolicy.validPortRange.contains(guestPort) else {
+                return Validation(
+                    mappings: nil,
+                    message: "Omarchy port in mapping \(row) must be a number from 1 to 65535.",
+                    isError: true
+                )
+            }
+            mappings.append(
+                PortForwardMapping(
+                    hostPort: hostPort,
+                    guestPort: guestPort,
+                    protocol: draft.protocol
+                )
+            )
+        }
+
+        do {
+            try PortForwardPolicy.validate(mappings)
+        } catch {
+            return Validation(
+                mappings: nil,
+                message: error.localizedDescription,
+                isError: true
+            )
+        }
+
+        return Validation(
+            mappings: mappings,
+            message: "",
+            isError: false
+        )
+    }
+
+    private func closeWindow() {
+        if let parent = window.sheetParent {
+            parent.endSheet(window)
+        }
+        window.orderOut(nil)
+        closeHandler()
+    }
+
+    private func reveal(field: NSTextField, atBottom: Bool) {
+        window.contentView?.layoutSubtreeIfNeeded()
+        scrollView.layoutSubtreeIfNeeded()
+        scrollView.documentView?.layoutSubtreeIfNeeded()
+        if atBottom {
+            let documentHeight = scrollView.documentView?.frame.height
+                ?? rowsStack.frame.height
+            scrollView.contentView.scroll(
+                to: NSPoint(
+                    x: 0,
+                    y: max(0, documentHeight - scrollView.contentView.bounds.height)
+                )
+            )
+        } else if let document = scrollView.documentView {
+            document.scrollToVisible(field.convert(field.bounds, to: document))
+        }
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    private func descendant(withIdentifier value: String, in root: NSView) -> NSView? {
+        if root.identifier?.rawValue == value { return root }
+        for child in root.subviews {
+            if let match = descendant(withIdentifier: value, in: child) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
+private final class FlippedDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}

--- a/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
+++ b/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
@@ -8,6 +8,34 @@ enum QEMUGPUStorageOption: String, Equatable {
     case resetStorageOnly = "--reset-storage-only"
 }
 
+/// Build-only controls and user-facing integration values must never leak
+/// into an ordinary app launch or a storage reset through the parent process.
+enum QEMUGPURuntimeEnvironment {
+    static let inspectOnlyKey = "OMARCHY_QEMU_GPU_INSPECT_ONLY"
+    static let dryRunKey = "OMARCHY_QEMU_GPU_DRY_RUN"
+
+    static func sanitizedForLaunch(_ base: [String: String]) -> [String: String] {
+        var environment = base
+        environment.removeValue(forKey: inspectOnlyKey)
+        environment.removeValue(forKey: dryRunKey)
+        return environment
+    }
+
+    static func sanitizedForReset(_ base: [String: String]) -> [String: String] {
+        var environment = sanitizedForLaunch(base)
+        for key in [
+            AudioLaunchConfiguration.inheritedSDLDeviceNameKey,
+            AudioLaunchConfiguration.outputDeviceNameKey,
+            AudioLaunchConfiguration.inputDeviceNameKey,
+            SharedFolderPolicy.environmentKey,
+            PortForwardPolicy.environmentKey,
+        ] {
+            environment.removeValue(forKey: key)
+        }
+        return environment
+    }
+}
+
 enum QEMUGPUStorageSpaceEstimate {
     private static let stateRootEnvironmentKey = "OMARCHY_QEMU_GPU_STATE_ROOT"
 
@@ -437,7 +465,20 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
         case virtualMachineReady
     }
 
+    struct StandardErrorDrain {
+        let data: Data
+        let reachedEnd: Bool
+    }
+
+    private struct StandardErrorConsumption {
+        let reachedEnd: Bool
+        let reportsVirtualMachineStart: Bool
+    }
+
+    private static let standardErrorReadBudget = 64 * 1_024
+
     private let lock = NSLock()
+    private let standardErrorReadLock = NSLock()
     private var child: Process?
     private var errorPipe: Pipe?
     private var errorBuffer = ""
@@ -459,19 +500,32 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
         process.standardOutput = FileHandle.standardOutput
         process.standardError = pipe
         pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
+            guard let self else {
                 handle.readabilityHandler = nil
                 return
             }
-            try? FileHandle.standardError.write(contentsOf: data)
-            if self?.recordStandardError(data) == true {
+            let consumption = self.consumeAvailableStandardError(from: handle)
+            if consumption.reachedEnd {
+                handle.readabilityHandler = nil
+            }
+            if consumption.reportsVirtualMachineStart {
                 DispatchQueue.main.async {
                     launchEvent(.virtualMachineReady)
                 }
             }
         }
         process.terminationHandler = { [weak self] process in
+            pipe.fileHandleForReading.readabilityHandler = nil
+            // QEMU inherits this pipe from the shell launcher and can outlive
+            // it after a crash. Drain only bytes available now; waiting for
+            // EOF here could strand process completion for the QEMU lifetime.
+            if self?.consumeAvailableStandardError(
+                from: pipe.fileHandleForReading
+            ).reportsVirtualMachineStart == true {
+                DispatchQueue.main.async {
+                    launchEvent(.virtualMachineReady)
+                }
+            }
             self?.clear(process)
             let status = Self.status(for: process)
             // NSApplication owns a synchronous AppKit run loop. Dispatching a
@@ -507,6 +561,12 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
         return child?.isRunning == true
     }
 
+    var recentStandardError: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return errorBuffer
+    }
+
     func forward(signal: Int32) {
         lock.lock()
         defer { lock.unlock() }
@@ -522,6 +582,102 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
             errorPipe = nil
         }
         lock.unlock()
+    }
+
+    private func consumeAvailableStandardError(
+        from handle: FileHandle
+    ) -> StandardErrorConsumption {
+        standardErrorReadLock.lock()
+        defer { standardErrorReadLock.unlock() }
+
+        let drain = Self.drainAvailableStandardError(
+            from: handle,
+            maximumBytes: Self.standardErrorReadBudget
+        )
+        guard !drain.data.isEmpty else {
+            return StandardErrorConsumption(
+                reachedEnd: drain.reachedEnd,
+                reportsVirtualMachineStart: false
+            )
+        }
+        try? FileHandle.standardError.write(contentsOf: drain.data)
+        return StandardErrorConsumption(
+            reachedEnd: drain.reachedEnd,
+            reportsVirtualMachineStart: recordStandardError(drain.data)
+        )
+    }
+
+    static func drainAvailableStandardError(
+        from handle: FileHandle,
+        maximumBytes: Int
+    ) -> StandardErrorDrain {
+        guard maximumBytes > 0 else {
+            return StandardErrorDrain(data: Data(), reachedEnd: false)
+        }
+
+        let descriptor = handle.fileDescriptor
+        let originalFlags = fileStatusFlags(for: descriptor)
+        guard originalFlags >= 0 else {
+            return StandardErrorDrain(data: Data(), reachedEnd: false)
+        }
+
+        let changedFlags = originalFlags & O_NONBLOCK == 0
+        if changedFlags,
+           !setFileStatusFlags(originalFlags | O_NONBLOCK, for: descriptor) {
+            return StandardErrorDrain(data: Data(), reachedEnd: false)
+        }
+        defer {
+            if changedFlags {
+                _ = setFileStatusFlags(originalFlags, for: descriptor)
+            }
+        }
+
+        var data = Data()
+        var reachedEnd = false
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while data.count < maximumBytes {
+            let requestedBytes = min(buffer.count, maximumBytes - data.count)
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, requestedBytes)
+            }
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+                continue
+            }
+            if count == 0 {
+                reachedEnd = true
+                break
+            }
+            if errno == EINTR {
+                continue
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                break
+            }
+            break
+        }
+        return StandardErrorDrain(data: data, reachedEnd: reachedEnd)
+    }
+
+    private static func fileStatusFlags(for descriptor: Int32) -> Int32 {
+        while true {
+            let result = Darwin.fcntl(descriptor, F_GETFL)
+            if result >= 0 || errno != EINTR {
+                return result
+            }
+        }
+    }
+
+    private static func setFileStatusFlags(_ flags: Int32, for descriptor: Int32) -> Bool {
+        while true {
+            let result = Darwin.fcntl(descriptor, F_SETFL, flags)
+            if result >= 0 {
+                return true
+            }
+            if errno != EINTR {
+                return false
+            }
+        }
     }
 
     private func recordStandardError(_ data: Data) -> Bool {

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -57,6 +57,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private let sharedFolderStatus: () -> SharedFolderMenuState
     private let chooseSharedFolder: (String) -> String?
     private let setSharedFolderEnabled: (Bool) -> Void
+    private let portForwardingStatus: () -> [PortForwardMapping]
+    private let savePortForwarding: ([PortForwardMapping]) -> String?
     private let launch: () -> Void
     private let canResetStorage: Bool
     private let storageLocation: String?
@@ -66,6 +68,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private var resetInProgress = false
     private var launchInProgress = false
     private var pendingResetSpaceEstimate: String?
+    private weak var startMenuScrollView: NSScrollView?
+    private(set) var portForwardingEditor: PortForwardingEditor?
 
     init(
         accessibilityStatus: @escaping () -> Bool,
@@ -80,6 +84,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         sharedFolderStatus: @escaping () -> SharedFolderMenuState,
         chooseSharedFolder: @escaping (String) -> String?,
         setSharedFolderEnabled: @escaping (Bool) -> Void,
+        portForwardingStatus: @escaping () -> [PortForwardMapping] = { [] },
+        savePortForwarding: @escaping ([PortForwardMapping]) -> String? = { _ in nil },
         launch: @escaping () -> Void
     ) {
         self.accessibilityStatus = accessibilityStatus
@@ -94,10 +100,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         self.sharedFolderStatus = sharedFolderStatus
         self.chooseSharedFolder = chooseSharedFolder
         self.setSharedFolderEnabled = setSharedFolderEnabled
+        self.portForwardingStatus = portForwardingStatus
+        self.savePortForwarding = savePortForwarding
         self.launch = launch
 
         window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 590),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 690),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -114,6 +122,10 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
 
     func show() {
         render()
+        if let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame {
+            let availableHeight = max(480, visibleFrame.height - 32)
+            window.setContentSize(NSSize(width: 600, height: min(690, availableHeight)))
+        }
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -131,6 +143,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     func dismiss() {
+        portForwardingEditor?.dismiss()
+        portForwardingEditor = nil
         window.orderOut(nil)
     }
 
@@ -171,12 +185,27 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         alert.beginSheetModal(for: window)
     }
 
+    func launchDidFail(errorMessage: String) {
+        guard launchInProgress else { return }
+        launchInProgress = false
+        render()
+
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Try Omarchy couldn’t start"
+        alert.informativeText = errorMessage
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window)
+    }
+
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         NSApp.terminate(nil)
         return false
     }
 
     private func render() {
+        let preservedScrollOffset = startMenuScrollView?.contentView.bounds.minY ?? 0
+        startMenuScrollView = nil
         content.subviews.forEach { $0.removeFromSuperview() }
 
         let icon = NSImageView()
@@ -277,14 +306,55 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             minimumHeight: 100
         )
 
+        let portMappings = portForwardingStatus()
+        let portForwardingDetail: String
+        let portForwardingDetailLines: [String]?
+        if portMappings.isEmpty {
+            portForwardingDetail = "Optional. Reach services running in Omarchy at localhost on this Mac."
+            portForwardingDetailLines = nil
+        } else if portMappings.count == 1, let mapping = portMappings.first {
+            portForwardingDetail = "localhost:\(mapping.hostPort) → Omarchy:\(mapping.guestPort) · \(mapping.protocol.displayName)"
+            portForwardingDetailLines = [
+                "Mac: localhost:\(mapping.hostPort)",
+                "Omarchy: port \(mapping.guestPort) · \(mapping.protocol.displayName)",
+            ]
+        } else {
+            portForwardingDetail = "\(portMappings.count) localhost mappings. Available only on this Mac."
+            portForwardingDetailLines = [
+                "\(portMappings.count) localhost mappings",
+                "Available only on this Mac",
+            ]
+        }
+        let portForwardingRow = permissionRow(
+            symbolName: "network",
+            title: "Port forwarding",
+            detail: portForwardingDetail,
+            compactDetailLines: portForwardingDetailLines,
+            granted: !portMappings.isEmpty,
+            statusLabels: (
+                "●  \(portMappings.count) \(portMappings.count == 1 ? "Port" : "Ports")",
+                "○  Off"
+            ),
+            actions: [("Configure…", #selector(beginPortForwardingConfiguration))],
+            minimumHeight: 90
+        )
+
         let permissionRows = NSStackView(
-            views: [accessibilityRow, separator(), microphoneRow, separator(), sharedFolderRow]
+            views: [
+                accessibilityRow,
+                separator(),
+                microphoneRow,
+                separator(),
+                sharedFolderRow,
+                separator(),
+                portForwardingRow,
+            ]
         )
         permissionRows.orientation = .vertical
         permissionRows.alignment = .leading
         permissionRows.spacing = 0
         permissionRows.translatesAutoresizingMaskIntoConstraints = false
-        for row in [accessibilityRow, microphoneRow, sharedFolderRow] {
+        for row in [accessibilityRow, microphoneRow, sharedFolderRow, portForwardingRow] {
             row.widthAnchor.constraint(equalTo: permissionRows.widthAnchor).isActive = true
         }
 
@@ -456,18 +526,53 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         stack.setCustomSpacing(20, after: resetSection)
         stack.setCustomSpacing(10, after: launchButton)
         stack.translatesAutoresizingMaskIntoConstraints = false
-        content.addSubview(stack)
+
+        let document = StartMenuDocumentView()
+        document.translatesAutoresizingMaskIntoConstraints = false
+        document.addSubview(stack)
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = document
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.identifier = NSUserInterfaceItemIdentifier("start-menu-scroll")
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(scrollView)
+        startMenuScrollView = scrollView
 
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 42),
-            stack.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -42),
-            stack.topAnchor.constraint(equalTo: content.topAnchor, constant: 48),
-            stack.bottomAnchor.constraint(lessThanOrEqualTo: content.bottomAnchor, constant: -30),
+            scrollView.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: content.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            document.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+            document.heightAnchor.constraint(greaterThanOrEqualTo: scrollView.contentView.heightAnchor),
+            stack.leadingAnchor.constraint(equalTo: document.leadingAnchor, constant: 42),
+            stack.trailingAnchor.constraint(equalTo: document.trailingAnchor, constant: -42),
+            stack.topAnchor.constraint(equalTo: document.topAnchor, constant: 48),
+            stack.bottomAnchor.constraint(equalTo: document.bottomAnchor, constant: -30),
             permissionCard.widthAnchor.constraint(equalTo: stack.widthAnchor),
             resetSection.widthAnchor.constraint(lessThanOrEqualTo: stack.widthAnchor),
             launchButton.widthAnchor.constraint(equalTo: stack.widthAnchor),
             footerContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
         ])
+
+        content.layoutSubtreeIfNeeded()
+        document.layoutSubtreeIfNeeded()
+        let maximumOffset = max(
+            0,
+            document.frame.height - scrollView.contentView.bounds.height
+        )
+        scrollView.contentView.scroll(
+            to: NSPoint(
+                x: 0,
+                y: min(max(0, preservedScrollOffset), maximumOffset)
+            )
+        )
+        scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
     private func permissionRow(
@@ -733,6 +838,26 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         render()
     }
 
+    @objc private func beginPortForwardingConfiguration() {
+        guard !launchInProgress, !resetInProgress, portForwardingEditor == nil else { return }
+        let editor = PortForwardingEditor(
+            mappings: portForwardingStatus(),
+            save: { [weak self] mappings in
+                guard let self else {
+                    return "Port forwarding could not be saved because the start menu is unavailable."
+                }
+                return self.savePortForwarding(mappings)
+            },
+            didClose: { [weak self] in
+                guard let self else { return }
+                self.portForwardingEditor = nil
+                self.render()
+            }
+        )
+        portForwardingEditor = editor
+        editor.beginSheet(for: window)
+    }
+
     private func confirmReset() {
         guard canResetStorage, !launchInProgress, !resetInProgress else { return }
         let estimate = storageSpaceEstimate()
@@ -760,4 +885,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         render()
         launch()
     }
+}
+
+private final class StartMenuDocumentView: NSView {
+    override var isFlipped: Bool { true }
 }

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -11,6 +11,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let supervisor: QEMUGPUProcessSupervisor
     private let preferenceStore: AudioRoutingPreferenceStore
     private let sharedFolderStore: SharedFolderPreferenceStore
+    private let portForwardingStore: PortForwardingPreferenceStore
     private let deviceProvider: HostAudioDeviceProviding
     private var startMenuWindow: StartMenuWindow?
 
@@ -28,6 +29,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         supervisor: QEMUGPUProcessSupervisor = QEMUGPUProcessSupervisor(),
         preferenceStore: AudioRoutingPreferenceStore = AudioRoutingPreferenceStore(),
         sharedFolderStore: SharedFolderPreferenceStore = SharedFolderPreferenceStore(),
+        portForwardingStore: PortForwardingPreferenceStore = PortForwardingPreferenceStore(),
         deviceProvider: HostAudioDeviceProviding = CoreAudioHostAudioDeviceProvider()
     ) {
         self.launcherURL = launcherURL
@@ -36,6 +38,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         self.supervisor = supervisor
         self.preferenceStore = preferenceStore
         self.sharedFolderStore = sharedFolderStore
+        self.portForwardingStore = portForwardingStore
         self.deviceProvider = deviceProvider
     }
 
@@ -91,6 +94,12 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             },
             setSharedFolderEnabled: { [weak self] enabled in
                 self?.setSharedFolderEnabled(enabled)
+            },
+            portForwardingStatus: { [weak self] in
+                self?.portForwardingStore.load() ?? []
+            },
+            savePortForwarding: { [weak self] mappings in
+                self?.savePortForwarding(mappings)
             },
             launch: { [weak self] in
                 self?.startVirtualMachine()
@@ -151,7 +160,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             try supervisor.start(
                 executableURL: launcherURL,
                 arguments: resetArguments(),
-                environment: baseEnvironment
+                environment: QEMUGPURuntimeEnvironment.sanitizedForReset(baseEnvironment)
             ) { [weak self] status in
                 self?.resetDidExit(status: status)
             }
@@ -203,7 +212,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         let preferences = preferenceStore.load()
         let catalog = deviceProvider.catalog()
         let configuration = AudioLaunchConfiguration.make(
-            baseEnvironment: baseEnvironment,
+            baseEnvironment: QEMUGPURuntimeEnvironment.sanitizedForLaunch(baseEnvironment),
             preferences: preferences,
             catalog: catalog
         )
@@ -212,11 +221,16 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             preference: sharedFolderStore.load(),
             homeDirectory: Self.homeDirectory
         )
+        let forwarding = PortForwardLaunchConfiguration.make(
+            baseEnvironment: sharing.environment,
+            mappings: portForwardingStore.load()
+        )
+        try PortForwardAvailability.validate(forwarding.mappings)
 
         try supervisor.start(
             executableURL: launcherURL,
             arguments: arguments,
-            environment: sharing.environment,
+            environment: forwarding.environment,
             launchEvent: { [weak self] event in
                 if event == .virtualMachineReady {
                     self?.virtualMachineDidStart()
@@ -264,6 +278,15 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         sharedFolderStore.save(preference)
     }
 
+    private func savePortForwarding(_ mappings: [PortForwardMapping]) -> String? {
+        do {
+            try portForwardingStore.save(mappings)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
     private func requestOptionalAccessibilityPermission() {
         guard !AXIsProcessTrusted() else { return }
         // A replacement app can leave a disabled TCC row tied to the old
@@ -283,6 +306,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private func childDidExit(status: Int32) {
         guard childRunning else { return }
         childRunning = false
+        let recentStandardError = supervisor.recentStandardError
 
         let wasStopping = lifecycle.isStopping
         let presentation = VMExitPresentationDecision.make(
@@ -294,6 +318,15 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         if applicationTerminationPending {
             NSApp.reply(toApplicationShouldTerminate: true)
         } else {
+            if presentation.showsStartupFailure,
+               let startMenuWindow,
+               let portFailure = PortForwardStartupFailure.message(
+                   standardError: recentStandardError,
+                   mappings: portForwardingStore.load()
+               ) {
+                startMenuWindow.launchDidFail(errorMessage: portFailure)
+                return
+            }
             if presentation.requiresWorkspaceReset {
                 startMenuWindow?.launchRequiresReset()
                 return
@@ -314,15 +347,11 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
 
     private func failLaunch(_ error: Error) {
         fputs("omarchy-vm-helper: \(error.localizedDescription)\n", stderr)
-        startMenuWindow?.dismiss()
-        startMenuWindow = nil
-        let alert = NSAlert()
-        alert.alertStyle = .critical
-        alert.messageText = "Try Omarchy couldn’t start"
-        alert.informativeText = error.localizedDescription
-        alert.addButton(withTitle: "Close")
-        alert.runModal()
-        finish(status: 1)
+        guard let startMenuWindow else {
+            finish(status: 1)
+            return
+        }
+        startMenuWindow.launchDidFail(errorMessage: error.localizedDescription)
     }
 
     private func finish(status: Int32) {

--- a/macos/Tests/OmarchyVMHelperTests/PortForwardAvailabilityTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/PortForwardAvailabilityTests.swift
@@ -1,0 +1,93 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Port forwarding availability")
+struct PortForwardAvailabilityTests {
+    @Test("reports an occupied TCP port with an actionable mapping error")
+    func occupiedTCPPort() throws {
+        let reserved = try ReservedLoopbackPort(protocol: .tcp)
+        defer { reserved.close() }
+
+        #expect(throws: PortForwardAvailabilityError.unavailable(.tcp, reserved.port)) {
+            try PortForwardAvailability.validate([
+                PortForwardMapping(hostPort: reserved.port, guestPort: 3000, protocol: .tcp),
+            ])
+        }
+    }
+
+    @Test("reports an occupied UDP port independently")
+    func occupiedUDPPort() throws {
+        let reserved = try ReservedLoopbackPort(protocol: .udp)
+        defer { reserved.close() }
+
+        #expect(throws: PortForwardAvailabilityError.unavailable(.udp, reserved.port)) {
+            try PortForwardAvailability.validate([
+                PortForwardMapping(hostPort: reserved.port, guestPort: 5353, protocol: .udp),
+            ])
+        }
+    }
+
+    private final class ReservedLoopbackPort {
+        let descriptor: Int32
+        let port: Int
+
+        init(protocol protocolValue: PortForwardProtocol) throws {
+            let type = protocolValue == .tcp
+                ? SOCK_STREAM
+                : SOCK_DGRAM
+            let localDescriptor = Darwin.socket(AF_INET, type, 0)
+            guard localDescriptor >= 0 else {
+                throw POSIXError(.ENOTSOCK)
+            }
+            var shouldClose = true
+            defer {
+                if shouldClose {
+                    Darwin.close(localDescriptor)
+                }
+            }
+
+            var address = sockaddr_in()
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            address.sin_family = sa_family_t(AF_INET)
+            address.sin_port = 0
+            address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+            let bound = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.bind(
+                        localDescriptor,
+                        $0,
+                        socklen_t(MemoryLayout<sockaddr_in>.size)
+                    )
+                }
+            }
+            guard bound == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EADDRINUSE)
+            }
+            if protocolValue == .tcp {
+                guard Darwin.listen(localDescriptor, 1) == 0 else {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EADDRINUSE)
+                }
+            }
+
+            var selectedAddress = sockaddr_in()
+            var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let found = withUnsafeMutablePointer(to: &selectedAddress) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.getsockname(localDescriptor, $0, &length)
+                }
+            }
+            guard found == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            descriptor = localDescriptor
+            port = Int(in_port_t(bigEndian: selectedAddress.sin_port))
+            shouldClose = false
+        }
+
+        func close() {
+            Darwin.close(descriptor)
+        }
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/PortForwardingEditorTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/PortForwardingEditorTests.swift
@@ -1,0 +1,224 @@
+import AppKit
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Port forwarding editor interactions", .serialized)
+@MainActor
+struct PortForwardingEditorTests {
+    @Test("adds and saves an ordered TCP and UDP mapping list")
+    func addsAndSavesMappings() throws {
+        _ = NSApplication.shared
+        var saved: [PortForwardMapping]?
+        let editor = PortForwardingEditor(mappings: [], save: {
+            saved = $0
+            return nil
+        })
+        editor.show()
+        defer { editor.dismiss() }
+
+        let content = try #require(editor.window.contentView)
+        let add = try button("port-forward-add", in: content)
+        add.performClick(nil)
+        try enter(host: "8080", guest: "3000", row: 0, in: content, editor: editor)
+
+        add.performClick(nil)
+        try enter(host: "5353", guest: "5353", row: 1, in: content, editor: editor)
+        let protocolPicker = try #require(
+            descendant(withIdentifier: "port-forward-protocol-1", in: content) as? NSPopUpButton
+        )
+        protocolPicker.selectItem(withTitle: "UDP")
+        _ = protocolPicker.sendAction(protocolPicker.action, to: protocolPicker.target)
+
+        let save = try button("port-forward-save", in: content)
+        #expect(save.isEnabled)
+        save.performClick(nil)
+
+        #expect(saved == [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+        ])
+    }
+
+    @Test("removes one mapping without disturbing the surrounding rows")
+    func removesMiddleMapping() throws {
+        _ = NSApplication.shared
+        let initial = [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            PortForwardMapping(hostPort: 2222, guestPort: 22, protocol: .tcp),
+            PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+        ]
+        var saved: [PortForwardMapping]?
+        let editor = PortForwardingEditor(mappings: initial, save: {
+            saved = $0
+            return nil
+        })
+        editor.show()
+        defer { editor.dismiss() }
+
+        let content = try #require(editor.window.contentView)
+        try button("port-forward-remove-1", in: content).performClick(nil)
+        #expect(descendant(withIdentifier: "port-forward-row-2", in: content) == nil)
+
+        let newSecondHost = try #require(
+            descendant(withIdentifier: "port-forward-host-1", in: content) as? NSTextField
+        )
+        #expect(newSecondHost.stringValue == "5353")
+        #expect(newSecondHost.accessibilityLabel() == "Mac port for mapping 2")
+        #expect(newSecondHost.currentEditor() === editor.window.firstResponder)
+        try button("port-forward-save", in: content).performClick(nil)
+
+        #expect(saved == [initial[0], initial[2]])
+    }
+
+    @Test("invalid and duplicate ports explain the problem and cannot be saved")
+    func validatesDraftsLive() throws {
+        _ = NSApplication.shared
+        let editor = PortForwardingEditor(mappings: [], save: { _ in nil })
+        editor.show()
+        defer { editor.dismiss() }
+        let content = try #require(editor.window.contentView)
+        let add = try button("port-forward-add", in: content)
+
+        add.performClick(nil)
+        try enter(host: "70000", guest: "3000", row: 0, in: content, editor: editor)
+        let save = try button("port-forward-save", in: content)
+        let validation = try #require(
+            descendant(withIdentifier: "port-forward-validation", in: content) as? NSTextField
+        )
+        #expect(!save.isEnabled)
+        #expect(validation.stringValue.contains("1 to 65535"))
+        #expect(validation.textColor == .systemRed)
+
+        try enter(host: "8080", guest: "3000", row: 0, in: content, editor: editor)
+        add.performClick(nil)
+        try enter(host: "8080", guest: "4000", row: 1, in: content, editor: editor)
+        #expect(!save.isEnabled)
+        #expect(validation.stringValue == "Mac TCP port 8080 is already mapped.")
+
+        let protocolPicker = try #require(
+            descendant(withIdentifier: "port-forward-protocol-1", in: content) as? NSPopUpButton
+        )
+        protocolPicker.selectItem(withTitle: "UDP")
+        _ = protocolPicker.sendAction(protocolPicker.action, to: protocolPicker.target)
+        #expect(save.isEnabled)
+        #expect(validation.stringValue.isEmpty)
+        #expect(validation.isHidden)
+    }
+
+    @Test("many mappings stay inside a vertically scrollable list")
+    func longListsScroll() throws {
+        _ = NSApplication.shared
+        let mappings = (0..<12).map {
+            PortForwardMapping(hostPort: 8_000 + $0, guestPort: 3_000 + $0, protocol: .tcp)
+        }
+        let editor = PortForwardingEditor(mappings: mappings, save: { _ in nil })
+        editor.show()
+        defer { editor.dismiss() }
+
+        let content = try #require(editor.window.contentView)
+        content.layoutSubtreeIfNeeded()
+        let scroll = try #require(
+            descendant(withIdentifier: "port-forward-scroll", in: content) as? NSScrollView
+        )
+        let document = try #require(scroll.documentView)
+        document.layoutSubtreeIfNeeded()
+        #expect(document.frame.height > scroll.contentView.bounds.height)
+        #expect(descendant(withIdentifier: "port-forward-row-11", in: document) != nil)
+
+        let maximumOffset = document.frame.height - scroll.contentView.bounds.height
+        #expect(maximumOffset > 0)
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: maximumOffset))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        #expect(scroll.contentView.bounds.minY > 0)
+    }
+
+    @Test("repeated adds focus and reveal the newest row up to the limit")
+    func repeatedAddsReachLimit() throws {
+        _ = NSApplication.shared
+        let editor = PortForwardingEditor(mappings: [], save: { _ in nil })
+        editor.show()
+        defer { editor.dismiss() }
+
+        let content = try #require(editor.window.contentView)
+        let add = try button("port-forward-add", in: content)
+        for _ in 0..<PortForwardPolicy.maximumMappings {
+            add.performClick(nil)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.005))
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        let lastIndex = PortForwardPolicy.maximumMappings - 1
+        let lastHost = try #require(
+            descendant(withIdentifier: "port-forward-host-\(lastIndex)", in: content)
+                as? NSTextField
+        )
+        let scroll = try #require(
+            descendant(withIdentifier: "port-forward-scroll", in: content) as? NSScrollView
+        )
+        #expect(lastHost.currentEditor() === editor.window.firstResponder)
+        #expect(lastHost.accessibilityLabel() == "Mac port for mapping 32")
+        #expect(!add.isEnabled)
+        add.performClick(nil)
+        #expect(descendant(withIdentifier: "port-forward-row-32", in: content) == nil)
+        #expect(scroll.contentView.bounds.minY > 0)
+    }
+
+    @Test("empty state and unchanged content do not offer a meaningless save")
+    func emptyState() throws {
+        _ = NSApplication.shared
+        let editor = PortForwardingEditor(mappings: [], save: { _ in nil })
+        editor.show()
+        defer { editor.dismiss() }
+
+        let content = try #require(editor.window.contentView)
+        #expect(descendant(withIdentifier: "port-forward-empty", in: content) != nil)
+        #expect(!(try button("port-forward-save", in: content)).isEnabled)
+        let explanation = try #require(
+            descendant(withIdentifier: "port-forward-explanation", in: content) as? NSTextField
+        )
+        let validation = try #require(
+            descendant(withIdentifier: "port-forward-validation", in: content) as? NSTextField
+        )
+        #expect(explanation.stringValue == "Mac → Omarchy mappings expose guest services on Mac localhost. For Omarchy → Mac, connect to 10.0.2.2.")
+        #expect(validation.stringValue.isEmpty)
+        #expect(validation.isHidden)
+        let footer = try #require(validation.superview as? NSStackView)
+        #expect(footer.orientation == .vertical)
+        #expect(footer.arrangedSubviews == [try button("port-forward-add", in: content), validation])
+        #expect(editor.window.frame.width == 540)
+        #expect(editor.window.frame.height <= 470)
+    }
+
+    private func enter(
+        host: String,
+        guest: String,
+        row: Int,
+        in content: NSView,
+        editor: PortForwardingEditor
+    ) throws {
+        let hostField = try #require(
+            descendant(withIdentifier: "port-forward-host-\(row)", in: content) as? NSTextField
+        )
+        let guestField = try #require(
+            descendant(withIdentifier: "port-forward-guest-\(row)", in: content) as? NSTextField
+        )
+        hostField.stringValue = host
+        editor.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: hostField))
+        guestField.stringValue = guest
+        editor.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: guestField))
+    }
+
+    private func button(_ identifier: String, in root: NSView) throws -> NSButton {
+        try #require(descendant(withIdentifier: identifier, in: root) as? NSButton)
+    }
+
+    private func descendant(withIdentifier value: String, in root: NSView) -> NSView? {
+        if root.identifier?.rawValue == value { return root }
+        for child in root.subviews {
+            if let match = descendant(withIdentifier: value, in: child) {
+                return match
+            }
+        }
+        return nil
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/PortForwardingTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/PortForwardingTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Port forwarding policy")
+struct PortForwardPolicyTests {
+    @Test("accepts both inclusive port boundaries")
+    func acceptsPortBoundaries() throws {
+        let mappings = [
+            PortForwardMapping(hostPort: 1, guestPort: 65_535, protocol: .tcp),
+            PortForwardMapping(hostPort: 65_535, guestPort: 1, protocol: .udp),
+        ]
+
+        try PortForwardPolicy.validate(mappings)
+        #expect(try PortForwardPolicy.encodedEnvironmentValue(for: mappings)
+            == "tcp:1:65535;udp:65535:1")
+    }
+
+    @Test("rejects host and guest ports outside the valid range")
+    func rejectsInvalidPorts() {
+        #expect(throws: PortForwardPolicyError.invalidHostPort(0)) {
+            try PortForwardPolicy.validate(.init(hostPort: 0, guestPort: 80, protocol: .tcp))
+        }
+        #expect(throws: PortForwardPolicyError.invalidHostPort(65_536)) {
+            try PortForwardPolicy.validate(.init(hostPort: 65_536, guestPort: 80, protocol: .tcp))
+        }
+        #expect(throws: PortForwardPolicyError.invalidGuestPort(0)) {
+            try PortForwardPolicy.validate(.init(hostPort: 8080, guestPort: 0, protocol: .tcp))
+        }
+        #expect(throws: PortForwardPolicyError.invalidGuestPort(65_536)) {
+            try PortForwardPolicy.validate(.init(hostPort: 8080, guestPort: 65_536, protocol: .tcp))
+        }
+    }
+
+    @Test("host-port uniqueness is scoped to the protocol")
+    func duplicateSemantics() throws {
+        try PortForwardPolicy.validate([
+            .init(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            .init(hostPort: 8080, guestPort: 3000, protocol: .udp),
+        ])
+
+        #expect(throws: PortForwardPolicyError.duplicateHostPort(.tcp, 8080)) {
+            try PortForwardPolicy.validate([
+                .init(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+                .init(hostPort: 8080, guestPort: 4000, protocol: .tcp),
+            ])
+        }
+    }
+
+    @Test("encoding is canonical and preserves the user's order")
+    func canonicalEncodingPreservesOrder() throws {
+        let mappings = [
+            PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            PortForwardMapping(hostPort: 2222, guestPort: 22, protocol: .tcp),
+        ]
+
+        #expect(try PortForwardPolicy.encodedEnvironmentValue(for: mappings)
+            == "udp:5353:5353;tcp:8080:3000;tcp:2222:22")
+        #expect(try PortForwardPolicy.encodedEnvironmentValue(for: []) == nil)
+    }
+
+    @Test("the mapping limit is inclusive")
+    func mappingLimit() throws {
+        let maximum = makeMappings(count: PortForwardPolicy.maximumMappings)
+        try PortForwardPolicy.validate(maximum)
+
+        #expect(throws: PortForwardPolicyError.tooManyMappings(maximum: 32)) {
+            try PortForwardPolicy.validate(makeMappings(count: PortForwardPolicy.maximumMappings + 1))
+        }
+    }
+
+    private func makeMappings(count: Int) -> [PortForwardMapping] {
+        (0..<count).map {
+            PortForwardMapping(hostPort: 10_000 + $0, guestPort: 20_000 + $0, protocol: .tcp)
+        }
+    }
+}
+
+@Suite("Port forwarding preferences")
+struct PortForwardingPreferenceStoreTests {
+    @Test("an ordered mapping list survives a relaunch")
+    func roundTripPreservesOrder() throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+        let expected = [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+        ]
+
+        #expect(fixture.store.load().isEmpty)
+        try fixture.store.save(expected)
+
+        #expect(PortForwardingPreferenceStore(defaults: fixture.defaults).load() == expected)
+    }
+
+    @Test("invalid saves do not replace the last valid value")
+    func rejectsInvalidSave() throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+        let valid = [PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp)]
+        try fixture.store.save(valid)
+
+        #expect(throws: PortForwardPolicyError.invalidHostPort(0)) {
+            try fixture.store.save([.init(hostPort: 0, guestPort: 3000, protocol: .tcp)])
+        }
+        #expect(fixture.store.load() == valid)
+    }
+
+    @Test("corrupt, future-schema, and policy-invalid values fail closed")
+    func invalidPersistedValuesFailClosed() {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+        let invalidValues = [
+            Data("not-json".utf8),
+            Data(#"{"schemaVersion":99,"mappings":[]}"#.utf8),
+            Data(#"{"schemaVersion":1,"mappings":[{"hostPort":0,"guestPort":80,"protocol":"tcp"}]}"#.utf8),
+            Data(#"{"schemaVersion":1,"mappings":[{"hostPort":8080,"guestPort":80,"protocol":"tcp"},{"hostPort":8080,"guestPort":81,"protocol":"tcp"}]}"#.utf8),
+            Data(#"{"schemaVersion":1,"mappings":[{"hostPort":8080,"guestPort":80,"protocol":"sctp"}]}"#.utf8),
+        ]
+
+        for data in invalidValues {
+            fixture.defaults.set(data, forKey: PortForwardingPreferenceStore.key)
+            #expect(fixture.store.load().isEmpty)
+            #expect(fixture.defaults.data(forKey: PortForwardingPreferenceStore.key) == data)
+        }
+    }
+
+    @Test("the store accepts 32 mappings and fails closed on a persisted 33rd")
+    func persistedMaximumCount() throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanUp() }
+        let maximum = makeMappings(count: PortForwardPolicy.maximumMappings)
+        try fixture.store.save(maximum)
+        #expect(fixture.store.load() == maximum)
+
+        let tooManyJSON = """
+        {"schemaVersion":1,"mappings":[\(mappingObjects(count: PortForwardPolicy.maximumMappings + 1))]}
+        """
+        fixture.defaults.set(Data(tooManyJSON.utf8), forKey: PortForwardingPreferenceStore.key)
+        #expect(fixture.store.load().isEmpty)
+    }
+
+    private func makeMappings(count: Int) -> [PortForwardMapping] {
+        (0..<count).map {
+            PortForwardMapping(hostPort: 10_000 + $0, guestPort: 20_000 + $0, protocol: .tcp)
+        }
+    }
+
+    private func mappingObjects(count: Int) -> String {
+        (0..<count).map {
+            #"{"hostPort":\#(10_000 + $0),"guestPort":\#(20_000 + $0),"protocol":"tcp"}"#
+        }.joined(separator: ",")
+    }
+
+    private final class DefaultsFixture {
+        let suiteName = "dev.tryomarchy.native.tests.\(UUID().uuidString)"
+        let defaults: UserDefaults
+        let store: PortForwardingPreferenceStore
+
+        init() {
+            defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            store = PortForwardingPreferenceStore(defaults: defaults)
+        }
+
+        func cleanUp() {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}
+
+@Suite("Port forwarding launch configuration")
+struct PortForwardLaunchConfigurationTests {
+    @Test("valid mappings replace an inherited value with canonical encoding")
+    func emitsValidatedMappings() {
+        let mappings = [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+            PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+        ]
+
+        let configuration = PortForwardLaunchConfiguration.make(
+            baseEnvironment: [
+                "KEEP_ME": "yes",
+                PortForwardPolicy.environmentKey: "tcp:1:1;injected",
+            ],
+            mappings: mappings
+        )
+
+        #expect(configuration.mappings == mappings)
+        #expect(configuration.environment["KEEP_ME"] == "yes")
+        #expect(configuration.environment[PortForwardPolicy.environmentKey]
+            == "tcp:8080:3000;udp:5353:5353")
+    }
+
+    @Test("empty or invalid mappings strip inherited forwarding and fail closed")
+    func stripsInheritedValue() {
+        let inherited = [
+            "KEEP_ME": "yes",
+            PortForwardPolicy.environmentKey: "tcp:9000:9000",
+        ]
+
+        let empty = PortForwardLaunchConfiguration.make(
+            baseEnvironment: inherited,
+            mappings: []
+        )
+        #expect(empty.mappings.isEmpty)
+        #expect(empty.environment == ["KEEP_ME": "yes"])
+
+        let invalid = PortForwardLaunchConfiguration.make(
+            baseEnvironment: inherited,
+            mappings: [
+                .init(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+                .init(hostPort: 0, guestPort: 4000, protocol: .tcp),
+            ]
+        )
+        #expect(invalid.mappings.isEmpty)
+        #expect(invalid.environment == ["KEEP_ME": "yes"])
+    }
+}
+
+@Suite("Port forwarding startup failure")
+struct PortForwardStartupFailureTests {
+    private let mappings = [
+        PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+        PortForwardMapping(hostPort: 5353, guestPort: 5353, protocol: .udp),
+    ]
+
+    @Test("identifies the mapping in QEMU's authoritative bind failure")
+    func identifiesFailedMapping() {
+        let message = PortForwardStartupFailure.message(
+            standardError: "qemu: Could not set up host forwarding rule 'udp:127.0.0.1:5353-:5353'",
+            mappings: mappings
+        )
+
+        #expect(message?.contains("UDP port 5353") == true)
+        #expect(message?.contains("Port Forwarding") == true)
+    }
+
+    @Test("falls back safely when QEMU omits the matching rule")
+    func genericBindFailure() {
+        let message = PortForwardStartupFailure.message(
+            standardError: "Could not set up host forwarding rule",
+            mappings: mappings
+        )
+
+        #expect(message == "A configured Mac port couldn’t be opened. Review Port Forwarding and try another Mac port.")
+    }
+
+    @Test("does not relabel unrelated startup errors")
+    func ignoresUnrelatedErrors() {
+        #expect(PortForwardStartupFailure.message(
+            standardError: "QEMU exited before creating its private QMP socket",
+            mappings: mappings
+        ) == nil)
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -73,6 +73,87 @@ struct QEMUGPULaunchRequestTests {
 
 }
 
+@Suite("QEMU runtime environment")
+struct QEMUGPURuntimeEnvironmentTests {
+    @Test("ordinary launches strip build-only controls")
+    func sanitizesLaunch() {
+        let environment = QEMUGPURuntimeEnvironment.sanitizedForLaunch([
+            "KEEP_ME": "yes",
+            QEMUGPURuntimeEnvironment.inspectOnlyKey: "1",
+            QEMUGPURuntimeEnvironment.dryRunKey: "1",
+        ])
+
+        #expect(environment == ["KEEP_ME": "yes"])
+    }
+
+    @Test("storage reset ignores inherited integration settings")
+    func sanitizesReset() {
+        let controlledKeys = [
+            AudioLaunchConfiguration.inheritedSDLDeviceNameKey,
+            AudioLaunchConfiguration.outputDeviceNameKey,
+            AudioLaunchConfiguration.inputDeviceNameKey,
+            SharedFolderPolicy.environmentKey,
+            PortForwardPolicy.environmentKey,
+            QEMUGPURuntimeEnvironment.inspectOnlyKey,
+            QEMUGPURuntimeEnvironment.dryRunKey,
+        ]
+        var inherited = ["KEEP_ME": "yes"]
+        for key in controlledKeys {
+            inherited[key] = "untrusted inherited value"
+        }
+
+        #expect(QEMUGPURuntimeEnvironment.sanitizedForReset(inherited)
+            == ["KEEP_ME": "yes"])
+    }
+}
+
+@Suite("QEMU standard-error drain")
+struct QEMUStandardErrorDrainTests {
+    @Test("drains a bounded tail without waiting for EOF and restores descriptor flags")
+    func boundedNonblockingDrain() throws {
+        let pipe = Pipe()
+        var writerClosed = false
+        defer {
+            pipe.fileHandleForReading.closeFile()
+            if !writerClosed {
+                pipe.fileHandleForWriting.closeFile()
+            }
+        }
+
+        let payload = Data("trailing QEMU diagnostic".utf8)
+        try pipe.fileHandleForWriting.write(contentsOf: payload)
+        let descriptor = pipe.fileHandleForReading.fileDescriptor
+        let originalFlags = Darwin.fcntl(descriptor, F_GETFL)
+        #expect(originalFlags >= 0)
+
+        let first = QEMUGPUProcessSupervisor.drainAvailableStandardError(
+            from: pipe.fileHandleForReading,
+            maximumBytes: 8
+        )
+        #expect(first.data == Data(payload.prefix(8)))
+        #expect(!first.reachedEnd)
+        #expect(Darwin.fcntl(descriptor, F_GETFL) == originalFlags)
+
+        let second = QEMUGPUProcessSupervisor.drainAvailableStandardError(
+            from: pipe.fileHandleForReading,
+            maximumBytes: 1_024
+        )
+        #expect(second.data == Data(payload.dropFirst(8)))
+        #expect(!second.reachedEnd)
+        #expect(Darwin.fcntl(descriptor, F_GETFL) == originalFlags)
+
+        pipe.fileHandleForWriting.closeFile()
+        writerClosed = true
+        let end = QEMUGPUProcessSupervisor.drainAvailableStandardError(
+            from: pipe.fileHandleForReading,
+            maximumBytes: 1_024
+        )
+        #expect(end.data.isEmpty)
+        #expect(end.reachedEnd)
+        #expect(Darwin.fcntl(descriptor, F_GETFL) == originalFlags)
+    }
+}
+
 @Suite("QEMU storage-space estimate")
 struct QEMUGPUStorageSpaceEstimateTests {
     @Test("shows the app data folder while keeping the VM layout versioned")

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowTests.swift
@@ -31,6 +31,14 @@ struct StartMenuWindowTests {
         )
         content.layoutSubtreeIfNeeded()
 
+        let menuScroll = try #require(
+            descendant(withIdentifier: "start-menu-scroll", in: content) as? NSScrollView
+        )
+        let menuDocument = try #require(menuScroll.documentView)
+        menuDocument.layoutSubtreeIfNeeded()
+        #expect(menuScroll.hasVerticalScroller)
+        #expect(menuDocument.frame.height >= menuScroll.contentView.bounds.height)
+
         let accessibilityAction = try #require(
             descendant(withIdentifier: "permission-action-accessibility", in: content)
         )
@@ -55,6 +63,60 @@ struct StartMenuWindowTests {
         let labelFrame = launchLabel.convert(launchLabel.bounds, to: launchButton)
         #expect(abs(labelFrame.midX - launchButton.bounds.midX) <= 0.5)
         #expect(abs(labelFrame.midY - launchButton.bounds.midY) <= 0.5)
+    }
+
+    @Test("a reduced-height menu preserves its scroll position across refresh")
+    func reducedHeightPreservesScrollPosition() throws {
+        _ = NSApplication.shared
+        var microphoneState = MicrophoneAuthorizationState.notDetermined
+        let menu = StartMenuWindow(
+            accessibilityStatus: { false },
+            microphoneStatus: { microphoneState },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(false) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            launch: {}
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let window = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })
+        )
+        window.setContentSize(NSSize(width: 600, height: 480))
+        let content = try #require(window.contentView)
+        content.layoutSubtreeIfNeeded()
+
+        let originalScroll = try #require(
+            descendant(withIdentifier: "start-menu-scroll", in: content) as? NSScrollView
+        )
+        let originalDocument = try #require(originalScroll.documentView)
+        originalDocument.layoutSubtreeIfNeeded()
+        let maximumOffset = originalDocument.frame.height
+            - originalScroll.contentView.bounds.height
+        #expect(maximumOffset > 100)
+        let expectedOffset = min(140, maximumOffset)
+        originalScroll.contentView.scroll(to: NSPoint(x: 0, y: expectedOffset))
+        originalScroll.reflectScrolledClipView(originalScroll.contentView)
+        #expect(abs(originalScroll.contentView.bounds.minY - expectedOffset) < 0.5)
+
+        microphoneState = .denied
+        menu.refreshPermissionStatus()
+        content.layoutSubtreeIfNeeded()
+
+        let refreshedScroll = try #require(
+            descendant(withIdentifier: "start-menu-scroll", in: content) as? NSScrollView
+        )
+        refreshedScroll.documentView?.layoutSubtreeIfNeeded()
+        #expect(refreshedScroll !== originalScroll)
+        #expect(abs(refreshedScroll.contentView.bounds.minY - expectedOffset) < 0.5)
     }
 
     @Test("shared folder paths keep separate compact lines and actions stay aligned")
@@ -132,6 +194,198 @@ struct StartMenuWindowTests {
         try expectPermissionColumnsAligned(in: content)
     }
 
+    @Test("port forwarding stays summarized while add, save, reopen, and remove happen in a sheet")
+    func portForwardingUsesFocusedEditor() throws {
+        _ = NSApplication.shared
+        var mappings: [PortForwardMapping] = []
+        let menu = StartMenuWindow(
+            accessibilityStatus: { true },
+            microphoneStatus: { .authorized },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(true) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            portForwardingStatus: { mappings },
+            savePortForwarding: {
+                mappings = $0
+                return nil
+            },
+            launch: {}
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let mainWindow = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })
+        )
+        let content = try #require(mainWindow.contentView)
+        content.layoutSubtreeIfNeeded()
+        let initialStatus = try #require(
+            descendant(withIdentifier: "permission-status-network", in: content) as? NSTextField
+        )
+        #expect(initialStatus.stringValue == "○  Off")
+
+        let configure = try #require(
+            descendant(withIdentifier: "permission-action-network", in: content) as? NSButton
+        )
+        configure.performClick(nil)
+        let editorContent = try #require(menu.portForwardingEditor?.window.contentView)
+        let add = try #require(
+            descendant(withIdentifier: "port-forward-add", in: editorContent) as? NSButton
+        )
+        add.performClick(nil)
+
+        let host = try #require(
+            descendant(withIdentifier: "port-forward-host-0", in: editorContent) as? NSTextField
+        )
+        let guest = try #require(
+            descendant(withIdentifier: "port-forward-guest-0", in: editorContent) as? NSTextField
+        )
+        let editor = try #require(host.delegate as? PortForwardingEditor)
+        host.stringValue = "8080"
+        editor.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: host))
+        guest.stringValue = "3000"
+        editor.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: guest))
+        let save = try #require(
+            descendant(withIdentifier: "port-forward-save", in: editorContent) as? NSButton
+        )
+        #expect(save.isEnabled)
+        save.performClick(nil)
+
+        #expect(mappings == [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+        ])
+        settleUI()
+        menu.refreshPermissionStatus()
+        content.layoutSubtreeIfNeeded()
+        let macLine = try #require(
+            descendant(withIdentifier: "permission-detail-network-0", in: content) as? NSTextField
+        )
+        let guestLine = try #require(
+            descendant(withIdentifier: "permission-detail-network-1", in: content) as? NSTextField
+        )
+        let activeStatus = try #require(
+            descendant(withIdentifier: "permission-status-network", in: content) as? NSTextField
+        )
+        #expect(macLine.stringValue == "Mac: localhost:8080")
+        #expect(guestLine.stringValue == "Omarchy: port 3000 · TCP")
+        #expect(activeStatus.stringValue == "●  1 Port")
+
+        let reopenedConfigure = try #require(
+            descendant(withIdentifier: "permission-action-network", in: content) as? NSButton
+        )
+        reopenedConfigure.performClick(nil)
+        let reopenedContent = try #require(menu.portForwardingEditor?.window.contentView)
+        let remove = try #require(
+            descendant(withIdentifier: "port-forward-remove-0", in: reopenedContent) as? NSButton
+        )
+        remove.performClick(nil)
+        let saveRemoval = try #require(
+            descendant(withIdentifier: "port-forward-save", in: reopenedContent) as? NSButton
+        )
+        #expect(saveRemoval.isEnabled)
+        saveRemoval.performClick(nil)
+
+        #expect(mappings.isEmpty)
+        settleUI()
+        menu.refreshPermissionStatus()
+        let finalStatus = try #require(
+            descendant(withIdentifier: "permission-status-network", in: content) as? NSTextField
+        )
+        #expect(finalStatus.stringValue == "○  Off")
+    }
+
+    @Test("a launch failure restores the menu and permits a second attempt")
+    func launchFailureIsRecoverable() throws {
+        _ = NSApplication.shared
+        let mappings = [
+            PortForwardMapping(hostPort: 8080, guestPort: 3000, protocol: .tcp),
+        ]
+        var launchCount = 0
+        let menu = StartMenuWindow(
+            accessibilityStatus: { true },
+            microphoneStatus: { .authorized },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(true) },
+            canResetStorage: false,
+            storageLocation: nil,
+            storageLocationURL: nil,
+            storageSpaceEstimate: { nil },
+            resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            portForwardingStatus: { mappings },
+            savePortForwarding: { _ in nil },
+            launch: { launchCount += 1 }
+        )
+        menu.show()
+        defer { menu.dismiss() }
+
+        let window = try #require(
+            NSApp.windows.first(where: { $0.isVisible && $0.title == "Try Omarchy" })
+        )
+        let content = try #require(window.contentView)
+        let firstLaunch = try #require(
+            descendant(withIdentifier: "launch-button", in: content) as? NSButton
+        )
+        firstLaunch.performClick(nil)
+        #expect(launchCount == 1)
+        #expect(!(try #require(
+            descendant(withIdentifier: "permission-action-network", in: content) as? NSButton
+        )).isEnabled)
+        #expect((try #require(
+            descendant(withIdentifier: "launch-button-label", in: content) as? NSTextField
+        )).stringValue == "Launching Omarchy…")
+
+        menu.launchDidFail(errorMessage: "Mac TCP port 8080 isn’t available.")
+        settleUI()
+        if let errorSheet = window.attachedSheet {
+            window.endSheet(errorSheet)
+            errorSheet.orderOut(nil)
+        }
+
+        let configure = try #require(
+            descendant(withIdentifier: "permission-action-network", in: content) as? NSButton
+        )
+        let restoredLaunch = try #require(
+            descendant(withIdentifier: "launch-button", in: content) as? NSButton
+        )
+        #expect(configure.isEnabled)
+        #expect(restoredLaunch.isEnabled)
+        #expect((try #require(
+            descendant(withIdentifier: "launch-button-label", in: content) as? NSTextField
+        )).stringValue == "Launch Omarchy")
+        #expect((try #require(
+            descendant(withIdentifier: "permission-status-network", in: content) as? NSTextField
+        )).stringValue == "●  1 Port")
+
+        configure.performClick(nil)
+        let editorContent = try #require(menu.portForwardingEditor?.window.contentView)
+        #expect((try #require(
+            descendant(withIdentifier: "port-forward-host-0", in: editorContent) as? NSTextField
+        )).stringValue == "8080")
+        menu.portForwardingEditor?.dismiss()
+
+        let retry = try #require(
+            descendant(withIdentifier: "launch-button", in: content) as? NSButton
+        )
+        retry.performClick(nil)
+        #expect(launchCount == 2)
+        menu.launchDidFail(errorMessage: "Retry failed for this test.")
+        settleUI()
+        if let retrySheet = window.attachedSheet {
+            window.endSheet(retrySheet)
+            retrySheet.orderOut(nil)
+        }
+    }
+
     private func expectPermissionColumnsAligned(in content: NSView) throws {
         let accessibilityRow = try #require(
             descendant(withIdentifier: "permission-row-accessibility", in: content)
@@ -195,5 +449,9 @@ struct StartMenuWindowTests {
             }
         }
         return nil
+    }
+
+    private func settleUI() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.08))
     }
 }

--- a/macos/Tests/qemu-port-forwarding.test.sh
+++ b/macos/Tests/qemu-port-forwarding.test.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "$0")" && pwd -P)
+native_dir=$(cd "$test_dir/.." && pwd -P)
+# shellcheck source=../qemu-port-forwarding.sh
+source "$native_dir/qemu-port-forwarding.sh"
+
+fail() {
+  printf 'qemu-port-forwarding.test: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  [[ $1 == "$2" ]] || fail "expected [$2], got [$1]"
+}
+
+assert_contains() {
+  [[ $1 == *"$2"* ]] || fail "expected [$1] to contain [$2]"
+}
+
+assert_rejected() {
+  local input=$1
+  local expected_error=${2:-}
+
+  if qemu_port_forwarding_configure "$input"; then
+    fail "configuration unexpectedly succeeded: [$input]"
+  fi
+  [[ -n $QEMU_PORT_FORWARDING_ERROR ]] || fail "rejection did not explain the error"
+  if [[ -n $expected_error ]]; then
+    assert_contains "$QEMU_PORT_FORWARDING_ERROR" "$expected_error"
+  fi
+  assert_eq "$QEMU_PORT_FORWARDING_NETDEV" 'user,id=omarchy-net'
+  assert_eq "$QEMU_PORT_FORWARDING_CANONICAL" ''
+  assert_eq "$QEMU_PORT_FORWARDING_SUMMARY" disabled
+  assert_eq "$QEMU_PORT_FORWARDING_RULE_COUNT" 0
+}
+
+qemu_port_forwarding_configure ''
+assert_eq "$QEMU_PORT_FORWARDING_NETDEV" 'user,id=omarchy-net'
+assert_eq "$QEMU_PORT_FORWARDING_CANONICAL" ''
+assert_eq "$QEMU_PORT_FORWARDING_SUMMARY" disabled
+assert_eq "$QEMU_PORT_FORWARDING_RULE_COUNT" 0
+assert_eq "$QEMU_PORT_FORWARDING_ERROR" ''
+
+qemu_port_forwarding_configure 'tcp:8080:3000'
+assert_eq \
+  "$QEMU_PORT_FORWARDING_NETDEV" \
+  'user,id=omarchy-net,hostfwd=tcp:127.0.0.1:8080-:3000'
+assert_eq "$QEMU_PORT_FORWARDING_CANONICAL" 'tcp:8080:3000'
+assert_eq \
+  "$QEMU_PORT_FORWARDING_SUMMARY" \
+  'tcp 127.0.0.1:8080 -> guest:3000'
+assert_eq "$QEMU_PORT_FORWARDING_RULE_COUNT" 1
+
+qemu_port_forwarding_configure 'udp:5353:5353;tcp:2222:22;udp:2222:22'
+assert_eq \
+  "$QEMU_PORT_FORWARDING_NETDEV" \
+  'user,id=omarchy-net,hostfwd=udp:127.0.0.1:5353-:5353,hostfwd=tcp:127.0.0.1:2222-:22,hostfwd=udp:127.0.0.1:2222-:22'
+assert_eq \
+  "$QEMU_PORT_FORWARDING_CANONICAL" \
+  'udp:5353:5353;tcp:2222:22;udp:2222:22'
+assert_eq "$QEMU_PORT_FORWARDING_RULE_COUNT" 3
+
+qemu_port_forwarding_configure 'tcp:1:65535;udp:65535:1'
+assert_eq "$QEMU_PORT_FORWARDING_CANONICAL" 'tcp:1:65535;udp:65535:1'
+
+for invalid in \
+  'TCP:80:80' \
+  'sctp:80:80' \
+  'tcp:0:80' \
+  'tcp:80:0' \
+  'tcp:65536:80' \
+  'tcp:80:65536' \
+  'tcp:-1:80' \
+  'tcp:+1:80' \
+  'tcp:01:80' \
+  'tcp:80:01' \
+  'tcp:000001:80' \
+  'tcp: 80:80' \
+  'tcp:80 :80' \
+  'tcp:80:80 ' \
+  'tcp:x80:80' \
+  'tcp:80:80x' \
+  'tcp:80' \
+  'tcp:80:80:90'; do
+  assert_rejected "$invalid" 'rule 1'
+done
+
+assert_rejected ';tcp:80:80' 'rule 1 is empty'
+assert_rejected 'tcp:80:80;' 'rule 2 is empty'
+assert_rejected 'tcp:80:80;;udp:53:53' 'rule 2 is empty'
+assert_rejected 'tcp:80:80;tcp:80:81' 'duplicates tcp host port 80'
+
+rules=''
+for ((port = 1; port <= QEMU_PORT_FORWARDING_MAX_RULES; port++)); do
+  [[ -z $rules ]] || rules="$rules;"
+  rules="${rules}tcp:$port:$port"
+done
+qemu_port_forwarding_configure "$rules"
+assert_eq "$QEMU_PORT_FORWARDING_RULE_COUNT" "$QEMU_PORT_FORWARDING_MAX_RULES"
+assert_contains \
+  "$QEMU_PORT_FORWARDING_NETDEV" \
+  "hostfwd=tcp:127.0.0.1:$QEMU_PORT_FORWARDING_MAX_RULES-:$QEMU_PORT_FORWARDING_MAX_RULES"
+assert_rejected "${rules};tcp:33:33" "more than $QEMU_PORT_FORWARDING_MAX_RULES rules"
+
+oversized=''
+for ((index = 0; index <= QEMU_PORT_FORWARDING_MAX_INPUT_BYTES; index++)); do
+  oversized="${oversized}x"
+done
+assert_rejected "$oversized" "exceeds $QEMU_PORT_FORWARDING_MAX_INPUT_BYTES bytes"
+
+# A valid call after failures must replace the reset failure state completely.
+qemu_port_forwarding_configure 'udp:53:53'
+assert_eq \
+  "$QEMU_PORT_FORWARDING_NETDEV" \
+  'user,id=omarchy-net,hostfwd=udp:127.0.0.1:53-:53'
+assert_eq "$QEMU_PORT_FORWARDING_ERROR" ''
+
+printf 'qemu-port-forwarding.test: PASS\n'

--- a/macos/build-app.sh
+++ b/macos/build-app.sh
@@ -158,6 +158,8 @@ install -m 0755 "$zstd_bin" "$contents/Resources/runtime/bin/zstd"
 install -m 0755 "$macos_dir/run-qemu-gpu.sh" "$contents/Resources/scripts/run-qemu-gpu.sh"
 install -m 0644 "$macos_dir/qemu-persistent-storage.sh" \
   "$contents/Resources/scripts/qemu-persistent-storage.sh"
+install -m 0644 "$macos_dir/qemu-port-forwarding.sh" \
+  "$contents/Resources/scripts/qemu-port-forwarding.sh"
 for guest_resource in \
   LICENSE.omarchy \
   SHA256SUMS \

--- a/macos/qemu-port-forwarding.sh
+++ b/macos/qemu-port-forwarding.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# Strict port-forwarding configuration for run-qemu-gpu.sh.
+#
+# The launcher passes the complete value of OMARCHY_QEMU_GPU_PORT_FORWARDS to
+# qemu_port_forwarding_configure. On success, the exported values below are
+# safe to pass to QEMU as one -netdev argument and to include in launch logs.
+# No partially parsed configuration is exposed when validation fails.
+
+QEMU_PORT_FORWARDING_MAX_RULES=32
+QEMU_PORT_FORWARDING_MAX_INPUT_BYTES=4096
+
+QEMU_PORT_FORWARDING_NETDEV='user,id=omarchy-net'
+QEMU_PORT_FORWARDING_CANONICAL=''
+QEMU_PORT_FORWARDING_SUMMARY='disabled'
+QEMU_PORT_FORWARDING_RULE_COUNT=0
+QEMU_PORT_FORWARDING_ERROR=''
+
+_qpf_fail() {
+  QEMU_PORT_FORWARDING_ERROR=$1
+  return 1
+}
+
+qemu_port_forwarding_configure() {
+  local qpf_input=${1-}
+  local LC_ALL=C
+  local qpf_remaining=''
+  local qpf_rule=''
+  local qpf_protocol=''
+  local qpf_host_text=''
+  local qpf_guest_text=''
+  local qpf_host_port=0
+  local qpf_guest_port=0
+  local qpf_rule_count=0
+  local qpf_final_rule=0
+  local qpf_key=''
+  local qpf_seen='|'
+  local qpf_netdev='user,id=omarchy-net'
+  local qpf_canonical=''
+  local qpf_summary=''
+
+  QEMU_PORT_FORWARDING_NETDEV='user,id=omarchy-net'
+  QEMU_PORT_FORWARDING_CANONICAL=''
+  QEMU_PORT_FORWARDING_SUMMARY='disabled'
+  QEMU_PORT_FORWARDING_RULE_COUNT=0
+  QEMU_PORT_FORWARDING_ERROR=''
+
+  if ((${#qpf_input} > QEMU_PORT_FORWARDING_MAX_INPUT_BYTES)); then
+    _qpf_fail \
+      "port-forwarding configuration exceeds $QEMU_PORT_FORWARDING_MAX_INPUT_BYTES bytes"
+    return 1
+  fi
+  [[ -n $qpf_input ]] || return 0
+
+  qpf_remaining=$qpf_input
+  while :; do
+    qpf_rule_count=$((qpf_rule_count + 1))
+    if ((qpf_rule_count > QEMU_PORT_FORWARDING_MAX_RULES)); then
+      _qpf_fail \
+        "port-forwarding configuration has more than $QEMU_PORT_FORWARDING_MAX_RULES rules"
+      return 1
+    fi
+
+    if [[ $qpf_remaining == *';'* ]]; then
+      qpf_rule=${qpf_remaining%%;*}
+      qpf_remaining=${qpf_remaining#*;}
+      qpf_final_rule=0
+    else
+      qpf_rule=$qpf_remaining
+      qpf_remaining=''
+      qpf_final_rule=1
+    fi
+
+    if [[ -z $qpf_rule ]]; then
+      _qpf_fail "port-forwarding rule $qpf_rule_count is empty"
+      return 1
+    fi
+    if [[ ! $qpf_rule =~ ^(tcp|udp):([0-9]+):([0-9]+)$ ]]; then
+      _qpf_fail \
+        "port-forwarding rule $qpf_rule_count must use protocol:host-port:guest-port"
+      return 1
+    fi
+
+    qpf_protocol=${BASH_REMATCH[1]}
+    qpf_host_text=${BASH_REMATCH[2]}
+    qpf_guest_text=${BASH_REMATCH[3]}
+    if [[ $qpf_host_text == 0?* || $qpf_guest_text == 0?* ]]; then
+      _qpf_fail \
+        "port-forwarding rule $qpf_rule_count ports must use canonical decimal without leading zeroes"
+      return 1
+    fi
+    if ((${#qpf_host_text} > 5)); then
+      _qpf_fail "port-forwarding rule $qpf_rule_count host port must be 1...65535"
+      return 1
+    fi
+    if ((${#qpf_guest_text} > 5)); then
+      _qpf_fail "port-forwarding rule $qpf_rule_count guest port must be 1...65535"
+      return 1
+    fi
+    qpf_host_port=$((10#$qpf_host_text))
+    qpf_guest_port=$((10#$qpf_guest_text))
+    if ((qpf_host_port < 1 || qpf_host_port > 65535)); then
+      _qpf_fail "port-forwarding rule $qpf_rule_count host port must be 1...65535"
+      return 1
+    fi
+    if ((qpf_guest_port < 1 || qpf_guest_port > 65535)); then
+      _qpf_fail "port-forwarding rule $qpf_rule_count guest port must be 1...65535"
+      return 1
+    fi
+
+    qpf_key="$qpf_protocol:$qpf_host_port"
+    case "$qpf_seen" in
+      *"|$qpf_key|"*)
+        _qpf_fail \
+          "port-forwarding rule $qpf_rule_count duplicates $qpf_protocol host port $qpf_host_port"
+        return 1
+        ;;
+    esac
+    qpf_seen="${qpf_seen}${qpf_key}|"
+
+    qpf_netdev="$qpf_netdev,hostfwd=$qpf_protocol:127.0.0.1:$qpf_host_port-:$qpf_guest_port"
+    if [[ -n $qpf_canonical ]]; then
+      qpf_canonical="$qpf_canonical;"
+      qpf_summary="$qpf_summary; "
+    fi
+    qpf_canonical="$qpf_canonical$qpf_protocol:$qpf_host_port:$qpf_guest_port"
+    qpf_summary="$qpf_summary$qpf_protocol 127.0.0.1:$qpf_host_port -> guest:$qpf_guest_port"
+
+    ((qpf_final_rule)) && break
+  done
+
+  QEMU_PORT_FORWARDING_NETDEV=$qpf_netdev
+  QEMU_PORT_FORWARDING_CANONICAL=$qpf_canonical
+  QEMU_PORT_FORWARDING_SUMMARY=$qpf_summary
+  QEMU_PORT_FORWARDING_RULE_COUNT=$qpf_rule_count
+}

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -40,12 +40,7 @@ guest_input=${1:-"$resources_dir/guest"}
 qemu_bin="$resources_dir/runtime/bin/Try Omarchy"
 native_bridge="$contents_dir/MacOS/omarchy-vm-helper"
 storage_library="$script_dir/qemu-persistent-storage.sh"
-
-[[ -f $storage_library && ! -L $storage_library ]] || {
-  fail "persistent-storage library is missing or unsafe: $storage_library"
-}
-# shellcheck source=qemu-persistent-storage.sh
-source "$storage_library"
+port_forwarding_library="$script_dir/qemu-port-forwarding.sh"
 
 [[ $(uname -m) == arm64 ]] || fail "requires an ARM64 Mac"
 [[ $(uname -s) == Darwin ]] || fail "requires macOS"
@@ -56,11 +51,15 @@ for command in codesign file getconf id mktemp ps stat sysctl; do
   command -v "$command" >/dev/null || fail "$command is required"
 done
 
-if [[ ${OMARCHY_QEMU_GPU_INSPECT_ONLY:-0} != 1 ]]; then
-  codesign --verify --deep --strict "$app_bundle" >/dev/null 2>&1 || {
-    fail "the installed app is damaged or has an invalid code signature"
-  }
-fi
+case ${OMARCHY_QEMU_GPU_INSPECT_ONLY:-0} in
+  0)
+    codesign --verify --deep --strict "$app_bundle" >/dev/null 2>&1 || {
+      fail "the installed app is damaged or has an invalid code signature"
+    }
+    ;;
+  1) ;;
+  *) fail "OMARCHY_QEMU_GPU_INSPECT_ONLY must be 0 or 1" ;;
+esac
 
 [[ -f $qemu_bin && -x $qemu_bin ]] || {
   fail "missing bundled GPU QEMU runtime at $qemu_bin"
@@ -674,14 +673,31 @@ IFS=$'\t' read -r bundle_identity source_disk_sha source_disk_bytes compressed_d
 [[ $expanded_disk_bytes =~ ^[1-9][0-9]*$ ]] || fail "validated working-disk size is invalid"
 (( expanded_disk_bytes >= source_disk_bytes )) || fail "working disk cannot be smaller than its source"
 [[ -n $kernel_command_line ]] || fail "validated kernel command line is empty"
-case ${OMARCHY_QEMU_GPU_INSPECT_ONLY:-0} in
-  1)
-    printf '%s\n' "$bundle_validation"
-    exit 0
-    ;;
-  0) ;;
-  *) fail "OMARCHY_QEMU_GPU_INSPECT_ONLY must be 0 or 1" ;;
-esac
+if [[ ${OMARCHY_QEMU_GPU_INSPECT_ONLY:-0} == 1 ]]; then
+  printf '%s\n' "$bundle_validation"
+  exit 0
+fi
+
+[[ -f $storage_library && ! -L $storage_library ]] || {
+  fail "persistent-storage library is missing or unsafe: $storage_library"
+}
+[[ -f $port_forwarding_library && ! -L $port_forwarding_library ]] || {
+  fail "port-forwarding library is missing or unsafe: $port_forwarding_library"
+}
+
+# These libraries are sealed resources in normal app launches. The complete
+# app bundle was verified above before either file can execute. Inspect-only is
+# a build-time path and exits without sourcing any shell library.
+# shellcheck source=qemu-persistent-storage.sh
+source "$storage_library"
+# shellcheck source=qemu-port-forwarding.sh
+source "$port_forwarding_library"
+
+if ! qemu_port_forwarding_configure "${OMARCHY_QEMU_GPU_PORT_FORWARDS:-}"; then
+  fail "$QEMU_PORT_FORWARDING_ERROR"
+fi
+qemu_netdev=$QEMU_PORT_FORWARDING_NETDEV
+port_forwarding_summary=$QEMU_PORT_FORWARDING_SUMMARY
 
 host_cpu_count=$(
   sysctl -n hw.logicalcpu 2>/dev/null ||
@@ -930,7 +946,7 @@ qemu_args=(
   -m 4G
   -nodefaults
   -no-reboot
-  -netdev 'user,id=omarchy-net'
+  -netdev "$qemu_netdev"
   -device 'virtio-net-pci,netdev=omarchy-net,mac=52:54:00:12:34:56,romfile='
   -audiodev 'sdl,id=omarchy-audio'
   -device 'intel-hda,id=omarchy-hda,romfile='
@@ -998,6 +1014,7 @@ if [[ ${OMARCHY_QEMU_GPU_DRY_RUN:-0} == 1 ]]; then
   else
     printf '\n[qemu-gpu] shared folder: disabled' >&2
   fi
+  printf '\n[qemu-gpu] port forwarding: %s' "$port_forwarding_summary" >&2
   printf '\n' >&2
   exit 0
 fi
@@ -1014,6 +1031,7 @@ fi
 if [[ -n $shared_folder ]]; then
   echo "[qemu-gpu] Shared folder: $shared_folder (guest ~/$shared_folder_name)" >&2
 fi
+echo "[qemu-gpu] Port forwarding: $port_forwarding_summary" >&2
 "$qemu_bin" "${qemu_args[@]}" &
 qemu_pid=$!
 printf '%s\n' "$qemu_pid" >"$work_dir/.qemu.pid"


### PR DESCRIPTION
## Summary

- Add port forwarding configuration and editor support to the macOS VM helper
- Integrate port mappings into QEMU GPU launch and startup scripts
- Document port forwarding behavior and update build/development targets
- Add Swift and shell test coverage for port mapping and related UI flows

## Testing

- Added unit tests for port forwarding, availability checks, editor behavior, launcher integration, and start-menu flows
- Added shell tests for QEMU port-forwarding configuration
- Not run (not requested)