### PR TITLE
Refresh package lock for harfbuzz 14.4.0

### DIFF
--- a/guest/packages.lock.json
+++ b/guest/packages.lock.json
@@ -130,7 +130,7 @@
     "gupnp-igd": "1.6.0-2",
     "gvfs": "1.60.2-3",
     "gzip": "1.14-2",
-    "harfbuzz": "14.3.1-1",
+    "harfbuzz": "14.4.0-1",
     "hicolor-icon-theme": "0.18-1",
     "hidapi": "0.15.0-1",
     "highway": "1.4.0-1",


### PR DESCRIPTION
`make build` currently fails its lock check on a clean tree:

```
package repository transaction differs from packages.lock.json; refresh and review the lock intentionally
harfbuzz: 14.3.1-1 -> 14.4.0-1
```

Upstream Arch moved harfbuzz, so the resolved empty-root transaction no longer
matches the committed lock. Regenerated with

```
guest/build-container.sh --refresh-package-lock <file>
```

harfbuzz is the only difference; nothing else in the transaction moved. `make build`
completes afterwards.