### PR TITLE
Fix guest initramfs to build with uncompressed cpio

### DIFF
--- a/guest/factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf
+++ b/guest/factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf
@@ -3,4 +3,4 @@ MODULES=(virtio_pci virtio_mmio virtio_blk virtio_gpu virtio_input virtio_consol
 BINARIES=()
 FILES=()
 HOOKS=(base udev modconf kms keyboard keymap consolefont block filesystems fsck)
-COMPRESSION="zstd"
+COMPRESSION="cat"  # run-qemu-gpu.sh requires a raw mkinitcpio newc archive (070701/070702 magic); zstd broke that check and saved <0.1% anyway since modules are already .ko.zst


### PR DESCRIPTION
## Summary

- `guest/factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf` sets
  `COMPRESSION="zstd"`, so `mkinitcpio` produces a zstd-compressed
  initramfs — but `macos/run-qemu-gpu.sh`'s bundle validation requires
  the raw cpio "newc" magic (`070701`/`070702`) and rejects anything
  else, so `make app` fails with `initramfs-linux.img is not a
  mkinitcpio newc archive` on a from-scratch guest build.
- Confirmed against the currently shipped, working app: its bundled
  initramfs is raw newc, not zstd-compressed, so the validator is
  correct and the compression setting is the bug.
- Compression also wasn't buying anything: the two initramfs sizes are
  nearly identical (27,974,972 vs 27,964,732 bytes, a 0.04% difference),
  since the guest's kernel modules are already individually
  `.ko.zst`-compressed.
- Switches `COMPRESSION` to `"cat"` (mkinitcpio's no-compression
  setting), restoring the raw newc format the launcher expects.

## Test plan

- [x] `guest/test` (full guest contract suite) passes
- [x] Fresh `make guest` produces an `initramfs-linux.img` starting
      with the `070701` newc magic
- [x] `make app` succeeds against that guest output
- [x] App boots a VM from the resulting bundle

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014LHCLwYmLr6YrJh9mKA4Pz