### PR TITLE
Fix grammar: parallelism error (behavioral or architecture -> architectural)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ project-built ARM64 virtual machine image.
 
 ## Before opening a pull request
 
-1. Open an issue for large behavioral or architecture changes.
+1. Open an issue for large behavioral or architectural changes.
 2. Keep changes within the current Apple Silicon, QEMU/HVF, and ARM64 guest
    architecture unless an architecture change has been discussed first.
 3. Run `make test`.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `CONTRIBUTING.md` (line 9).

## Problem

Parallelism error: 'behavioral' is an adjective while 'architecture' is a noun. In a coordinate structure, both should be adjectives.

The problematic text:

```markdown
large behavioral or architecture changes
```

## Fix

Replaced with:

```markdown
large behavioral or architectural changes
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text