### PR TITLE
Fix 1Password installation on ARM64 guests

### DIFF
--- a/guest/patches/omarchy/1password-arm64-installer.patch
+++ b/guest/patches/omarchy/1password-arm64-installer.patch
@@ -1,0 +1,72 @@
+diff --git a/bin/omarchy-install-service-1password b/bin/omarchy-install-service-1password
+index f59cab9..570f576 100755
+--- a/bin/omarchy-install-service-1password
++++ b/bin/omarchy-install-service-1password
+@@ -9,6 +9,54 @@ EXTENSION_ID="aeblfdkhhhdcdjpifhhbdiojplfjncoa"
+ EXTENSION_DIR="/usr/share/chromium/extensions"
+ EXTENSION_FILE="$EXTENSION_DIR/$EXTENSION_ID.json"
+ WEBSTORE_UPDATE_URL="https://clients2.google.com/service/update2/crx"
++ONEPASSWORD_ARM_URL="https://downloads.1password.com/linux/tar/stable/aarch64/1password-latest.tar.gz"
++ONEPASSWORD_KEY_URL="https://downloads.1password.com/linux/keys/1password.asc"
++ONEPASSWORD_SIGNING_FINGERPRINT="3FEF9748469ADBE15DA7CA80AC2D62742012EA22"
++ONEPASSWORD_WORK_DIR=""
++
++cleanup() {
++  [[ -z $ONEPASSWORD_WORK_DIR ]] || rm -rf -- "$ONEPASSWORD_WORK_DIR"
++}
++
++trap cleanup EXIT
++
++download() {
++  curl --fail --location --proto '=https' --tlsv1.2 --silent --show-error "$@"
++}
++
++install_1password_arm64() {
++  local archive signature signing_key extracted_dir
++  ONEPASSWORD_WORK_DIR=$(mktemp -d)
++  archive="$ONEPASSWORD_WORK_DIR/1password.tar.gz"
++  signature="$archive.sig"
++  signing_key="$ONEPASSWORD_WORK_DIR/1password.asc"
++
++  download --output "$archive" "$ONEPASSWORD_ARM_URL"
++  download --output "$signature" "$ONEPASSWORD_ARM_URL.sig"
++  download --output "$signing_key" "$ONEPASSWORD_KEY_URL"
++
++  if ! gpg --batch --show-keys --with-colons "$signing_key" |
++    grep -Fqx "fpr:::::::::$ONEPASSWORD_SIGNING_FINGERPRINT:"; then
++    echo "The downloaded 1Password signing key has an unexpected fingerprint." >&2
++    return 1
++  fi
++
++  gpg --batch --import "$signing_key"
++  gpg --batch --verify "$signature" "$archive"
++  tar -xzf "$archive" -C "$ONEPASSWORD_WORK_DIR"
++
++  extracted_dir=$(find "$ONEPASSWORD_WORK_DIR" -mindepth 1 -maxdepth 1 -type d -name '1password-*.arm64' -print -quit)
++  if [[ -z $extracted_dir ]]; then
++    echo "The 1Password archive did not contain the expected ARM64 application directory." >&2
++    return 1
++  fi
++
++  sudo mkdir -p /opt/1Password
++  sudo cp -a "$extracted_dir"/. /opt/1Password/
++  sudo /opt/1Password/after-install.sh
++
++  yay -S --noconfirm --needed 1password-cli
++}
+
+ install_chromium_extension() {
+   if omarchy-cmd-missing chromium; then
+@@ -22,7 +70,11 @@ install_chromium_extension() {
+ }
+
+ echo "Installing 1Password..."
+-omarchy-pkg-add 1password 1password-cli
++if [[ $(uname -m) == aarch64 ]]; then
++  install_1password_arm64
++else
++  omarchy-pkg-add 1password 1password-cli
++fi
+
+ echo "Installing 1Password extension for Chromium..."
+ install_chromium_extension

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -126,16 +126,30 @@
   "authenticity": {
     "verbatimRuntimeTrees": [
       "applications",
-      "bin",
       "config",
       "default",
       "install",
       "migrations"
     ],
     "backportedRuntimeTrees": [
+      "bin",
       "shell"
     ],
     "backports": [
+      {
+        "id": "1password-arm64-installer",
+        "description": "Install 1Password from its signed ARM64 release when Omarchy's x86_64 packages are unavailable.",
+        "reference": "https://github.com/basecamp/omarchy/issues/87",
+        "patch": "patches/omarchy/1password-arm64-installer.patch",
+        "patchSha256": "0697806fa417b5842ac2205526427a5a927855bdba7854a859e6de7ef6ddc571",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-service-1password",
+            "beforeSha256": "5d5a5a9b3cf87579b4232067c9f7c78091cecf250111b802ffffa49c607f52d7",
+            "afterSha256": "fdc935ec8c13ff0e4d718bf04c307a47e3296c07e46d4e1f949098147bff4ff7"
+          }
+        ]
+      },
       {
         "id": "notification-hover-close",
         "description": "Restore the upstream hover-revealed notification dismiss control omitted from v4.0.1.",
@@ -173,6 +187,7 @@
     "requiredPaths": [
       "LICENSE",
       "bin/omarchy",
+      "bin/omarchy-install-service-1password",
       "bin/omarchy-launch-shell",
       "bin/omarchy-menu",
       "bin/omarchy-provision-owner",

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -68,16 +68,20 @@ def main() -> None:
     verbatim_trees = authenticity["verbatimRuntimeTrees"]
     backported_trees = authenticity["backportedRuntimeTrees"]
     check(
-        "shell" not in verbatim_trees
-        and backported_trees == ["shell"]
+        not {"bin", "shell"} & set(verbatim_trees)
+        and backported_trees == ["bin", "shell"]
         and not set(verbatim_trees) & set(backported_trees),
-        "patched shell tree is separated from verbatim upstream runtime trees",
+        "patched bin and shell trees are separated from verbatim upstream runtime trees",
     )
     backports = authenticity["backports"]
     check(
         [backport.get("id") for backport in backports]
-        == ["notification-hover-close", "notification-screen-privacy"],
-        "notification backports are explicitly ordered and identified",
+        == [
+            "1password-arm64-installer",
+            "notification-hover-close",
+            "notification-screen-privacy",
+        ],
+        "Omarchy backports are explicitly ordered and identified",
     )
     for backport in backports:
         patch_path = GUEST / backport["patch"]
@@ -892,6 +896,23 @@ HOTPLUG=1
                         == target["afterSha256"],
                         f"backport produces reviewed postimage: {backport['id']} {target['path']}",
                     )
+
+            onepassword_installer_path = (
+                staged_omarchy / "bin/omarchy-install-service-1password"
+            )
+            subprocess.run(["bash", "-n", str(onepassword_installer_path)], check=True)
+            onepassword_installer = read(onepassword_installer_path)
+            check(
+                "[[ $(uname -m) == aarch64 ]]" in onepassword_installer
+                and "downloads.1password.com/linux/tar/stable/aarch64/1password-latest.tar.gz"
+                in onepassword_installer
+                and "3FEF9748469ADBE15DA7CA80AC2D62742012EA22" in onepassword_installer
+                and 'gpg --batch --verify "$signature" "$archive"' in onepassword_installer
+                and "curl --fail --location --proto '=https' --tlsv1.2" in onepassword_installer
+                and "yay -S --noconfirm --needed 1password-cli" in onepassword_installer
+                and "omarchy-pkg-add 1password 1password-cli" in onepassword_installer,
+                "1Password uses signed ARM64 releases and preserves the upstream package path",
+            )
 
             notification_card = read(
                 staged_omarchy / "shell/plugins/notifications/components/NotificationCard.qml"


### PR DESCRIPTION
## Summary

- install the official signed 1Password ARM64 tarball when the guest is `aarch64`
- verify the vendor signing-key fingerprint and archive signature before installation
- install the ARM-capable `1password-cli` AUR package while preserving Omarchy’s existing package path for other architectures
- register the installer as a hash-pinned Omarchy backport and cover it in the source-backed guest contract

## Testing

- `guest/test --source /tmp/try-omarchy-upstream.Woj9LX`
- verified the current official ARM64 archive against fingerprint `3FEF9748469ADBE15DA7CA80AC2D62742012EA22`
- confirmed the current `1password-cli` AUR recipe declares `aarch64` support
- `git diff --check`

Full `make test` cannot run inside the Linux guest because the repository’s native test targets require macOS/Swift tooling.

Related upstream context: basecamp/omarchy#87