### PR TITLE
Raise the guest audio quantum for the emulated HDA device

### DIFF
--- a/guest/native-overlay/usr/share/pipewire/pipewire.conf.d/90-try-omarchy-quantum.conf
+++ b/guest/native-overlay/usr/share/pipewire/pipewire.conf.d/90-try-omarchy-quantum.conf
@@ -1,0 +1,19 @@
+# Try Omarchy: raise the graph quantum for the emulated HDA device.
+#
+# QEMU advances the emulated Intel HDA DMA position from its audio timer, in
+# 10 ms steps, so the reported position moves in coarse jumps rather than
+# continuously. ALSA derives elapsed frames from that counter, and at the
+# default quantum the jumps are large enough relative to a period that the
+# driver reports xruns even though the 682 ms ring is nowhere near empty.
+#
+# A larger quantum means fewer, bigger position checks, which the emulated
+# counter can satisfy. Audible dropouts stop; the cost is added latency, which
+# is irrelevant for desktop playback.
+#
+# This is the guest-side half of the problem. The host-side knob is
+# -audiodev sdl,timer-period=, which buys the same thing with CPU instead and
+# is deliberately left at its default.
+context.properties = {
+    default.clock.quantum     = 4096
+    default.clock.min-quantum = 4096
+}


### PR DESCRIPTION
## Problem

Audio playback in the guest has intermittent dropouts, and PipeWire reports a steadily climbing xrun count — while the ALSA ring buffer is nowhere near empty.

The cause is on the host side of the emulation. QEMU advances the emulated Intel HDA DMA position counter from its own audio timer, in 10 ms steps, so the position the guest reads moves in coarse jumps rather than continuously. ALSA derives elapsed frames from that counter. At the default quantum the jumps are large relative to a period, so the driver concludes it has missed a deadline and reports an xrun.

The buffer was never the constraint:

```
$ cat /proc/asound/card0/pcm0p/sub0/hw_params
period_size: 1024
buffer_size: 32768
```

That's a 682 ms ring reporting underruns. The frames are there; only the *reported position* is coarse.

## Change

One drop-in PipeWire config in the native overlay:

```
context.properties = {
    default.clock.quantum     = 4096
    default.clock.min-quantum = 4096
}
```

A larger quantum means fewer, bigger position checks — a granularity the emulated counter can actually satisfy.

Cost is added latency, which is irrelevant for desktop playback. It costs no CPU.

## Why here and not on the host

`-audiodev sdl,timer-period=` is the same knob seen from the host side. I tried it: `timer-period=2500` does reduce the xruns, but it buys the fix by running QEMU's audio timer 4× more often, on every playback, forever. The guest-side quantum gets the same result for free, so the host timer is deliberately left at its default.

`virtio-sound` would sidestep the emulated position counter entirely, but the guest kernel is built without `CONFIG_SND_VIRTIO`, so that isn't available today.

## Verification

- `pw-top` xrun counter **stops climbing** during sustained playback (it's cumulative, so "stops climbing" is the meaningful signal, not the absolute value).
- Audible dropouts gone.
- No measurable CPU change on host or guest.
- `./guest/test` passes.

Single new file under `guest/native-overlay/`, which `configure-rootfs.sh` copies wholesale — no build-script or spec change needed. There is no existing PipeWire config in the tree, so nothing is overridden.
