### PR TITLE
Apply backports to bin commands promoted to /usr/bin

### DIFF
--- a/guest/scripts/apply-omarchy-backports.py
+++ b/guest/scripts/apply-omarchy-backports.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
+import shutil
 import subprocess
 from pathlib import Path, PurePosixPath
 
@@ -54,7 +56,43 @@ def verify_target(omarchy_root: Path, target: dict, digest_key: str, backport_id
         )
 
 
-def apply_backport(spec_dir: Path, omarchy_root: Path, backport: dict) -> None:
+def stage_promoted_targets(root: Path, omarchy_root: Path, targets: list) -> list:
+    # materialize-omarchy.sh installs bin/ commands at /usr/bin inside the
+    # staged root and leaves package-path symlinks in usr/share/omarchy/bin.
+    # git apply cannot patch through a symlink, so put the real file back for
+    # the patch and record the pair so the promotion can be redone afterwards.
+    promoted = []
+    for target in targets:
+        if not isinstance(target, dict):
+            continue
+        relative = str(target.get("path", ""))
+        logical = PurePosixPath(relative)
+        if logical.is_absolute() or ".." in logical.parts or logical.as_posix() != relative:
+            continue
+        candidate = omarchy_root.joinpath(*logical.parts)
+        if not candidate.is_symlink():
+            continue
+        real = root / "usr/bin" / logical.name
+        if (
+            os.readlink(candidate) != f"/usr/bin/{logical.name}"
+            or real.is_symlink()
+            or not real.is_file()
+        ):
+            fail(f"target is not a regular file: {relative}")
+        candidate.unlink()
+        shutil.copy2(real, candidate)
+        promoted.append((candidate, real))
+    return promoted
+
+
+def restore_promoted_targets(promoted: list) -> None:
+    for candidate, real in promoted:
+        shutil.copy2(candidate, real)
+        candidate.unlink()
+        candidate.symlink_to(f"/usr/bin/{real.name}")
+
+
+def apply_backport(spec_dir: Path, root: Path, omarchy_root: Path, backport: dict) -> None:
     if not isinstance(backport, dict):
         fail("backport metadata must contain JSON objects")
     backport_id = str(backport.get("id", ""))
@@ -76,6 +114,7 @@ def apply_backport(spec_dir: Path, omarchy_root: Path, backport: dict) -> None:
     targets = backport.get("targets")
     if not isinstance(targets, list) or not targets:
         fail(f"backport {backport_id} must declare at least one target")
+    promoted = stage_promoted_targets(root, omarchy_root, targets)
     for target in targets:
         verify_target(omarchy_root, target, "beforeSha256", backport_id)
 
@@ -93,6 +132,7 @@ def apply_backport(spec_dir: Path, omarchy_root: Path, backport: dict) -> None:
 
     for target in targets:
         verify_target(omarchy_root, target, "afterSha256", backport_id)
+    restore_promoted_targets(promoted)
     print(f"Applied Omarchy backport {backport_id}")
 
 
@@ -120,7 +160,7 @@ def main() -> None:
         fail("authenticity.backports must be an array")
 
     for backport in backports:
-        apply_backport(spec.parent, omarchy_root, backport)
+        apply_backport(spec.parent, args.root.resolve(), omarchy_root, backport)
 
 
 if __name__ == "__main__":

--- a/guest/scripts/write-provenance.py
+++ b/guest/scripts/write-provenance.py
@@ -40,6 +40,18 @@ def digest_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def installed_file(root: Path, omarchy: Path, relative: str) -> Path:
+    # bin/ commands are promoted to /usr/bin inside the staged root, leaving
+    # absolute symlinks that only resolve in the booted guest; rebase them.
+    installed = omarchy / relative
+    if installed.is_symlink():
+        link = os.readlink(installed)
+        if link.startswith("/"):
+            return root / link.lstrip("/")
+        return installed.parent / link
+    return installed
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", required=True, type=Path)
@@ -70,7 +82,7 @@ def main() -> None:
         if patch_digest != backport["patchSha256"]:
             raise SystemExit(f"backport patch digest mismatch: {backport['id']}")
         for target in backport["targets"]:
-            installed = omarchy / target["path"]
+            installed = installed_file(args.root, omarchy, target["path"])
             if digest_file(installed) != target["afterSha256"]:
                 raise SystemExit(f"backport target digest mismatch: {backport['id']} {target['path']}")
 


### PR DESCRIPTION
## What broke

Fresh `make build` runs on current main fail during the guest build:

```
apply-omarchy-backports: target is not a regular file: bin/omarchy-install-service-1password
```

#58 added the first backport that targets a `bin/` path. `materialize-omarchy.sh` installs every Omarchy `bin/` command at `/usr/bin` inside the staged root and leaves package-path symlinks in `usr/share/omarchy/bin`, and backports apply after materialization (guest/tests/verify.py asserts that ordering). So the target is always a symlink by the time `apply-omarchy-backports.py` sees it, `contained_file` rejects it, and `git apply` could not patch through it anyway. The spec's `beforeSha256` matches the pristine upstream file at the pinned commit, confirming the patch is meant for the real file content.

## The fix

- `apply-omarchy-backports.py`: when a target inside `usr/share/omarchy` is a materialization symlink to `/usr/bin/<name>`, swap it for the real staged file, run the existing digest verification and `git apply` unchanged, then write the patched content back to `/usr/bin/<name>` and restore the symlink. The materialized layout comes out identical; targets that are regular files (like the `default/` and `shell/` ones) take the existing path.
- `write-provenance.py` had the matching problem one step later: its per-target `afterSha256` check read through the restored symlink, whose absolute `/usr/bin` link only resolves in the booted guest, so it raised FileNotFoundError. It now rebases absolute symlinks into the staged root before hashing. `digest_path` already hashed symlinks by link text and is unchanged, so tree digests are unaffected.

## Verified

- `pytest guest/tests/test_apply_omarchy_backports.py guest/tests/test_write_provenance.py` passes.
- A full `make build` on an M3 Mac gets past the guest authenticity steps with both the `1password-arm64-installer` and `notification-screen-privacy` backports applied and hash-verified, where it previously died at each of the two points above.

https://claude.ai/code/session_016yj5T57GoMLSn6dZCErGat
