### PR TITLE
Honor the 4096-frame guest audio quantum

### DIFF
--- a/guest/native-overlay/usr/share/pipewire/pipewire.conf.d/90-try-omarchy-quantum.conf
+++ b/guest/native-overlay/usr/share/pipewire/pipewire.conf.d/90-try-omarchy-quantum.conf
@@ -16,4 +16,18 @@
 context.properties = {
     default.clock.quantum     = 4096
     default.clock.min-quantum = 4096
+    default.clock.max-quantum = 4096
 }
+
+# PipeWire's stock VM rule is evaluated after context.properties and lowers
+# min-quantum back to 1024. A later matching rule keeps the requested quantum
+# fixed at 4096 in the guest.
+context.properties.rules = [
+    {   matches = [ { cpu.vm.name = !null } ]
+        actions = {
+            update-props = {
+                default.clock.min-quantum = 4096
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Summary

- set `default.clock.max-quantum` to 4096 so PipeWire does not clamp the requested graph quantum to its 2048 default
- add a later VM property rule that restores `default.clock.min-quantum` to 4096 after PipeWire's stock VM rule lowers it to 1024

This follows up on #60.

## Testing

- `make test`