### PR TITLE
Fix ARM64 camera usage event decoding

### DIFF
--- a/guest/native-overlay/usr/local/bin/omarchy-native-camera-bridge
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-camera-bridge
@@ -96,10 +96,21 @@ class TimeSpec(ctypes.Structure):
     _fields_ = [("seconds", ctypes.c_long), ("nanoseconds", ctypes.c_long)]
 
 
+class V4L2EventData(ctypes.Union):
+    # The UAPI union contains struct v4l2_event_ctrl, whose signed 64-bit
+    # value64 member makes the union eight-byte aligned on aarch64. Without
+    # this explicit alignment, ctypes places the payload at offset 4 and the
+    # client count is read from padding instead of the event data at offset 8.
+    _fields_ = [
+        ("raw_data", ctypes.c_uint8 * 64),
+        ("alignment", ctypes.c_int64),
+    ]
+
+
 class V4L2Event(ctypes.Structure):
     _fields_ = [
         ("type", ctypes.c_uint32),
-        ("data", ctypes.c_uint8 * 64),
+        ("data", V4L2EventData),
         ("pending", ctypes.c_uint32),
         ("sequence", ctypes.c_uint32),
         ("timestamp", TimeSpec),
@@ -230,7 +241,7 @@ def dequeue_client_count(descriptor: int) -> int:
     fcntl.ioctl(descriptor, VIDIOC_DQEVENT, event, True)
     if event.type != V4L2_EVENT_PRI_CLIENT_USAGE:
         raise RuntimeError("v4l2loopback returned an unexpected event")
-    return int.from_bytes(bytes(event.data[:4]), sys.byteorder)
+    return int.from_bytes(bytes(event.data.raw_data[:4]), sys.byteorder)
 
 
 def handle_status(payload: bytes) -> None:

--- a/guest/tests/test_native_camera_bridge.py
+++ b/guest/tests/test_native_camera_bridge.py
@@ -66,10 +66,29 @@ class NativeCameraBridgeTests(unittest.TestCase):
         self.assertEqual(ctypes.sizeof(bridge.V4L2Format), 208)
         self.assertEqual(ctypes.sizeof(bridge.V4L2EventSubscription), 32)
         self.assertEqual(ctypes.sizeof(bridge.V4L2Event), 136)
+        self.assertEqual(bridge.V4L2Event.data.offset, 8)
+        self.assertEqual(bridge.V4L2Event.pending.offset, 72)
+        self.assertEqual(bridge.V4L2Event.sequence.offset, 76)
+        self.assertEqual(bridge.V4L2Event.timestamp.offset, 80)
         self.assertEqual(bridge.VIDIOC_S_FMT, 0xC0D05605)
         self.assertEqual(bridge.VIDIOC_DQEVENT, 0x80885659)
         self.assertEqual(bridge.VIDIOC_SUBSCRIBE_EVENT, 0x4020565A)
         self.assertEqual(bridge.V4L2_EVENT_SUB_FL_SEND_INITIAL, 0x0001)
+
+    def test_dequeue_client_count_reads_aligned_event_union(self) -> None:
+        def fill_event(_descriptor, request, event, mutate) -> None:
+            self.assertEqual(request, bridge.VIDIOC_DQEVENT)
+            self.assertTrue(mutate)
+            event.type = bridge.V4L2_EVENT_PRI_CLIENT_USAGE
+            count = ctypes.c_uint32(1)
+            ctypes.memmove(
+                ctypes.addressof(event) + bridge.V4L2Event.data.offset,
+                ctypes.byref(count),
+                ctypes.sizeof(count),
+            )
+
+        with mock.patch.object(bridge.fcntl, "ioctl", side_effect=fill_event):
+            self.assertEqual(bridge.dequeue_client_count(42), 1)
 
     def test_camera_subscription_requests_initial_client_usage(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- model the V4L2 event payload union with its required 8-byte ARM64 alignment
- decode client-usage counts from the real payload instead of padding
- add regression coverage for every ABI offset and a live count payload

## Verification

- python3 -m unittest guest.tests.test_native_camera_bridge
- make test
- live disposable VM: 60/60 1280x720 NV12 frames captured, 60 unique hashes, one expected black priming frame, FaceTime HD Camera activated
- producer restart while the consumer remained active recovered through SEND_INITIAL
