### PR TITLE
Fix start menu width expansion

### DIFF
--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -60,7 +60,7 @@ private final class LinkCursorTextField: NSTextField {
 
 @MainActor
 final class StartMenuWindow: NSObject, NSWindowDelegate {
-    private let window: NSWindow
+    private(set) var window: NSWindow
     private let content = NSView()
     private let accessibilityStatus: () -> Bool
     private let microphoneStatus: () -> MicrophoneAuthorizationState
@@ -196,8 +196,17 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     func show() {
+        prepareForPresentation(
+            visibleFrame: (window.screen ?? NSScreen.main)?.visibleFrame
+        )
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func prepareForPresentation(visibleFrame: NSRect?) {
         render()
-        if let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame {
+        if let visibleFrame {
             // The menu carries six rows once a resettable VM can choose where it
             // lives. At 690 the launch button cleared the bottom edge by 15pt,
             // which any difference in system font metrics turned into a button
@@ -205,9 +214,6 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             let availableHeight = max(480, visibleFrame.height - 32)
             window.setContentSize(NSSize(width: 600, height: min(760, availableHeight)))
         }
-        window.center()
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     func refreshPermissionStatus() {
@@ -744,6 +750,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             explanation.font = .systemFont(ofSize: 12)
             explanation.textColor = .secondaryLabelColor
             explanation.maximumNumberOfLines = 2
+            explanation.identifier = NSUserInterfaceItemIdentifier(
+                "permission-detail-\(symbolName)"
+            )
             explanations = [explanation]
         }
 
@@ -751,6 +760,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         labels.orientation = .vertical
         labels.alignment = .leading
         labels.spacing = 3
+        for explanation in explanations {
+            explanation.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            explanation.trailingAnchor.constraint(
+                lessThanOrEqualTo: labels.trailingAnchor
+            ).isActive = true
+        }
 
         let statusText = granted ? statusLabels.granted : statusLabels.denied
         let statusFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
@@ -867,6 +882,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         )
         button.toolTip = text
         button.identifier = NSUserInterfaceItemIdentifier(identifier)
+        button.cell?.lineBreakMode = .byTruncatingMiddle
         button.translatesAutoresizingMaskIntoConstraints = false
         button.heightAnchor.constraint(greaterThanOrEqualToConstant: 16).isActive = true
         return button

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuWindowWidthTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuWindowWidthTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Start menu width", .serialized)
+@MainActor
+struct StartMenuWindowWidthTests {
+    @Test("dynamic storage details cannot widen or escape the start menu")
+    func storageDetailsStayWithinMenuWidth() throws {
+        _ = NSApplication.shared
+        let pathSuffix = String(repeating: "a-very-long-folder-name/", count: 12)
+        let path = "/Users/test/Downloads/\(pathSuffix)"
+        let displayPath = "~/Downloads/\(pathSuffix)"
+        let warning = "Macintosh HD has 18.3 GB free. The VM disk grows as you use it "
+            + "and can need up to 25.8 GB."
+        var storageState = StorageLocationMenuState(
+            containerPath: path,
+            stateRoot: path,
+            displayPath: displayPath,
+            volumeName: "Macintosh HD",
+            isDefault: false,
+            isExternal: false,
+            problem: nil,
+            warning: warning,
+            isEnvironmentOverride: false
+        )
+        let menu = makeMenu(storageState: { storageState })
+        menu.prepareForPresentation(
+            visibleFrame: NSRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+        defer { menu.dismiss() }
+
+        try expectDetailsFit(
+            ["permission-detail-externaldrive-0", "permission-detail-externaldrive-1"],
+            in: menu
+        )
+        let content = try #require(menu.window.contentView)
+        let pathButton = try #require(
+            descendant(
+                withIdentifier: "permission-detail-externaldrive-0",
+                in: content
+            ) as? NSButton
+        )
+        #expect(pathButton.cell?.lineBreakMode == .byTruncatingMiddle)
+
+        storageState = StorageLocationMenuState(
+            containerPath: path,
+            stateRoot: nil,
+            displayPath: displayPath,
+            volumeName: nil,
+            isDefault: false,
+            isExternal: false,
+            problem: "This folder cannot be used because its workspace metadata is damaged: "
+                + path,
+            warning: nil,
+            isEnvironmentOverride: false
+        )
+        menu.prepareForPresentation(
+            visibleFrame: NSRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+        try expectDetailsFit(["permission-detail-externaldrive"], in: menu)
+    }
+
+    private func makeMenu(
+        storageState: @escaping () -> StorageLocationMenuState
+    ) -> StartMenuWindow {
+        StartMenuWindow(
+            accessibilityStatus: { true },
+            microphoneStatus: { .authorized },
+            cameraStatus: { .authorized },
+            requestAccessibility: {},
+            requestMicrophone: { completion in completion(true) },
+            requestCamera: { completion in completion(true) },
+            canResetStorage: true,
+            storageLocation: { storageState().displayPath },
+            storageLocationURL: {
+                storageState().containerPath.map { URL(fileURLWithPath: $0) }
+            },
+            storageSpaceEstimate: { nil },
+            storageLocationStatus: storageState,
+            validateStorageLocation: { _ in nil },
+            chooseStorageLocation: { _ in nil },
+            useDefaultStorageLocation: {},
+            resetStorage: {},
+            sharedFolderStatus: { .disabled },
+            chooseSharedFolder: { _ in nil },
+            setSharedFolderEnabled: { _ in },
+            portForwardingStatus: { [] },
+            immersiveMode: { true },
+            setImmersiveMode: { _ in },
+            launch: {}
+        )
+    }
+
+    private func expectDetailsFit(
+        _ identifiers: [String],
+        in menu: StartMenuWindow
+    ) throws {
+        let content = try #require(menu.window.contentView)
+        content.layoutSubtreeIfNeeded()
+        #expect(!menu.window.isVisible)
+        #expect(menu.window.frame.width == 600)
+        #expect(content.bounds.width == 600)
+
+        let row = try #require(
+            descendant(withIdentifier: "permission-row-externaldrive", in: content)
+        )
+        for identifier in identifiers {
+            let detail = try #require(descendant(withIdentifier: identifier, in: row))
+            let alignmentFrame = detail.alignmentRect(forFrame: detail.frame)
+            let frame = try #require(detail.superview).convert(alignmentFrame, to: row)
+            #expect(frame.minX >= row.bounds.minX)
+            #expect(frame.maxX <= row.bounds.maxX - 124 - 12 + 0.5)
+        }
+    }
+
+    private func descendant(withIdentifier identifier: String, in view: NSView) -> NSView? {
+        if view.identifier?.rawValue == identifier {
+            return view
+        }
+        for subview in view.subviews {
+            if let match = descendant(withIdentifier: identifier, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

- keep dynamic storage detail text within the fixed 600-point start-menu layout
- truncate clickable folder paths in the middle while preserving their full tooltip and accessibility value
- add an AppKit regression test for long paths, low-space warnings, and storage errors

## Testing

- swift test --disable-sandbox (161 tests across 40 suites)
- make app
- runtime visual verification with the active low-space warning: 600 x 760 points
- make test passes through the Swift and QEMU contract suites, then hits a pre-existing main-branch mismatch: qemu-persistent-storage.test.sh expects QEMU 10.2.50 while main stages QEMU 11.1.1