### PR TITLE
Add a configurable guest memory choice to the start menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ test:
 	@cd $(ROOT)/macos && SWIFT_MODULECACHE_PATH=$(ROOT)/macos/.build/module-cache/swift CLANG_MODULE_CACHE_PATH=$(ROOT)/macos/.build/module-cache/clang swift test --disable-sandbox
 	@$(ROOT)/macos/Tests/qemu-port-forwarding.test.sh
 	@$(ROOT)/macos/Tests/run-qemu-ssh-contract.test.sh
+	@$(ROOT)/macos/Tests/qemu-memory-contract.test.sh
 	@$(ROOT)/macos/Tests/qemu-power-actions.test.sh
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
 	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/macos/Tests/resize-vm-disk.test.py"

--- a/README.md
+++ b/README.md
@@ -291,6 +291,25 @@ or changing the enrolled Touch ID fingerprint set requires re-pairing. Disabling
 removes the guest enrollment and, while the host bridge is available, its wrapped
 Secure Enclave key representation.
 
+## Giving Omarchy more memory
+
+Use **Memory** on the start menu to pick how much of the Mac's RAM the guest
+boots with. The default is 4 GiB, and the menu only offers larger allocations
+(6, 8, 12, or 16 GiB) that leave macOS at least 8 GiB for itself, so an 8 GiB
+Mac shows the default alone. The choice is not tied to installation: change it
+before any launch, and it applies the next time Omarchy starts. Memory is a
+boot-time QEMU setting, never part of the guest image or VM data, so switching
+allocations never needs a reset and never touches your files. A stored choice
+that no longer fits the Mac it runs on falls back to the default.
+
+Scripted launches can set `OMARCHY_QEMU_GPU_MEMORY_MIB` (a whole number of
+MiB) instead. The launcher's own rule is looser than the menu's: it refuses
+values below the guest's 2048 MiB minimum, and values above the 4096 default
+that would leave the host under 4 GiB. The default itself always boots, and
+an environment value the menu would not offer (say 12 GiB on a 16 GiB Mac)
+is still accepted — the menu is deliberately conservative, the launcher is a
+safety floor.
+
 ## Requirements
 
 - Apple Silicon Mac (`arm64`)

--- a/macos/README.md
+++ b/macos/README.md
@@ -87,6 +87,16 @@ variable still wins, so the development and test override keeps working
 unchanged. Reset composes its environment exactly as a launch does, so it
 always erases the workspace the user is actually running.
 
+Guest memory follows the same preference pattern: the start menu's **Memory**
+row stores its choice in `UserDefaults` and publishes it to the launcher as
+`OMARCHY_QEMU_GPU_MEMORY_MIB`. The app only ever exports a value it resolved
+against this host (non-default choices must leave macOS 8 GiB), while the
+launcher independently enforces the guest's 2048 MiB manifest minimum and, for
+values above the 4096 default, a 4 GiB host floor — so a hand-set environment
+value gets the loose safety rule, not the menu's conservative one. Storage
+resets strip the variable like the other integration settings; memory is a
+boot-time `-m` allocation and never part of the guest image or VM data.
+
 Port forwarding is one versioned generic mapping list. The editor's **Add SSH**
 action only inserts the ordinary TCP `2222 → 22` preset; users may edit it like
 any other mapping. The signed shell parser remains the sole QEMU `hostfwd`

--- a/macos/Sources/OmarchyVMHelper/MemoryPreferences.swift
+++ b/macos/Sources/OmarchyVMHelper/MemoryPreferences.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// How much host RAM the guest boots with. The value is a boot-time QEMU
+/// setting (`-m`), so a change always applies on the next launch; it is never
+/// baked into the guest image or the persistent VM data.
+enum MemoryPolicy {
+    /// Matches `recommendedMemoryMiB` in the guest runtime manifest, which the
+    /// launcher verifies at build time.
+    static let defaultMemoryMiB = 4096
+
+    /// Matches `minimumMemoryMiB` in the guest runtime manifest.
+    static let minimumMemoryMiB = 2048
+
+    /// The fixed menu of allocations the start menu can offer. A short list
+    /// keeps the row a one-click choice instead of a text field that needs
+    /// validation feedback.
+    static let choicesMiB = [4096, 6144, 8192, 12288, 16384]
+
+    /// A non-default choice is offered only when it leaves the host this much
+    /// memory. macOS under ~8 GiB of headroom pushes the host into swapping,
+    /// which makes the guest slower, not faster.
+    static let hostHeadroomMiB = 8192
+
+    static let environmentKey = "OMARCHY_QEMU_GPU_MEMORY_MIB"
+
+    static func hostMemoryMiB() -> Int {
+        Int(ProcessInfo.processInfo.physicalMemory / (1024 * 1024))
+    }
+
+    /// The allocations the start menu offers on a host with this much RAM.
+    /// The default is always available, so the row never goes empty.
+    static func allowedChoicesMiB(hostMemoryMiB: Int) -> [Int] {
+        choicesMiB.filter {
+            $0 == defaultMemoryMiB || $0 + hostHeadroomMiB <= hostMemoryMiB
+        }
+    }
+
+    /// The allocation to actually launch with. A stored preference that no
+    /// longer fits this host (or was never a listed choice) falls back to the
+    /// default instead of failing the launch.
+    static func resolvedMemoryMiB(preferredMiB: Int, hostMemoryMiB: Int) -> Int {
+        allowedChoicesMiB(hostMemoryMiB: hostMemoryMiB).contains(preferredMiB)
+            ? preferredMiB
+            : defaultMemoryMiB
+    }
+
+    static func displayLabel(memoryMiB: Int) -> String {
+        memoryMiB % 1024 == 0
+            ? "\(memoryMiB / 1024) GiB"
+            : "\(memoryMiB) MiB"
+    }
+}
+
+struct MemoryPreferences: Equatable {
+    var memoryMiB: Int
+
+    static let defaults = Self(memoryMiB: MemoryPolicy.defaultMemoryMiB)
+}
+
+struct MemoryPreferenceStore {
+    static let key = "memoryPreferences"
+    static let schemaVersion = 1
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> MemoryPreferences {
+        guard let data = defaults.data(forKey: Self.key),
+              let payload = try? JSONDecoder().decode(Payload.self, from: data),
+              payload.schemaVersion == Self.schemaVersion else {
+            return .defaults
+        }
+        return MemoryPreferences(memoryMiB: payload.memoryMiB)
+    }
+
+    func save(_ preferences: MemoryPreferences) {
+        let payload = Payload(
+            schemaVersion: Self.schemaVersion,
+            memoryMiB: preferences.memoryMiB
+        )
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+
+    private struct Payload: Codable {
+        let schemaVersion: Int
+        let memoryMiB: Int
+    }
+}
+
+struct MemoryLaunchConfiguration: Equatable {
+    let environment: [String: String]
+
+    static func make(
+        baseEnvironment: [String: String],
+        preferences: MemoryPreferences,
+        hostMemoryMiB: Int
+    ) -> Self {
+        var environment = baseEnvironment
+        environment[MemoryPolicy.environmentKey] = String(
+            MemoryPolicy.resolvedMemoryMiB(
+                preferredMiB: preferences.memoryMiB,
+                hostMemoryMiB: hostMemoryMiB
+            )
+        )
+        return Self(environment: environment)
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
+++ b/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
@@ -37,6 +37,7 @@ enum QEMUGPURuntimeEnvironment {
             AudioLaunchConfiguration.inputDeviceNameKey,
             SharedFolderPolicy.environmentKey,
             PortForwardPolicy.environmentKey,
+            MemoryPolicy.environmentKey,
         ] {
             environment.removeValue(forKey: key)
         }

--- a/macos/Sources/OmarchyVMHelper/StartMenuPresentation.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuPresentation.swift
@@ -19,6 +19,17 @@ struct StartMenuSharedFolderPresentation: Equatable {
     let toggleActionTitle: String?
 }
 
+struct StartMenuMemoryPresentation: Equatable {
+    let detail: String
+    /// The MiB value behind each popup entry, in display order.
+    let choicesMiB: [Int]
+    let choiceTitles: [String]
+    let selectedIndex: Int
+    /// False when this Mac's RAM fits only the default, so the popup renders
+    /// disabled rather than offering a single-item "choice".
+    let isAdjustable: Bool
+}
+
 struct StartMenuPortForwardingPresentation: Equatable {
     let detail: String
     let compactDetailLines: [String]?
@@ -176,6 +187,32 @@ enum StartMenuPresentation {
             ],
             isGranted: true,
             grantedStatusLabel: "●  \(mappings.count) Ports"
+        )
+    }
+
+    static func memory(
+        preferredMiB: Int,
+        hostMemoryMiB: Int
+    ) -> StartMenuMemoryPresentation {
+        let choices = MemoryPolicy.allowedChoicesMiB(hostMemoryMiB: hostMemoryMiB)
+        let selected = MemoryPolicy.resolvedMemoryMiB(
+            preferredMiB: preferredMiB,
+            hostMemoryMiB: hostMemoryMiB
+        )
+        let titles = choices.map { choice in
+            choice == MemoryPolicy.defaultMemoryMiB
+                ? "\(MemoryPolicy.displayLabel(memoryMiB: choice)) · default"
+                : MemoryPolicy.displayLabel(memoryMiB: choice)
+        }
+        let isAdjustable = choices.count > 1
+        return StartMenuMemoryPresentation(
+            detail: isAdjustable
+                ? "Give Omarchy more of this Mac’s memory. Applies on the next launch."
+                : "This Mac’s memory fits the \(MemoryPolicy.displayLabel(memoryMiB: MemoryPolicy.defaultMemoryMiB)) default.",
+            choicesMiB: choices,
+            choiceTitles: titles,
+            selectedIndex: choices.firstIndex(of: selected) ?? 0,
+            isAdjustable: isAdjustable
         )
     }
 

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -191,6 +191,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private let savePortForwarding: ([PortForwardMapping]) -> String?
     private let immersiveMode: () -> Bool
     private let setImmersiveMode: (Bool) -> Void
+    private let memoryChoiceMiB: () -> Int
+    private let setMemoryChoiceMiB: (Int) -> Void
+    private let hostMemoryMiB: () -> Int
     private let launch: () -> Void
     private let canResetStorage: Bool
     private let storageLocation: () -> String?
@@ -271,6 +274,9 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         savePortForwarding: @escaping ([PortForwardMapping]) -> String? = { _ in nil },
         immersiveMode: @escaping () -> Bool = { true },
         setImmersiveMode: @escaping (Bool) -> Void = { _ in },
+        memoryChoiceMiB: @escaping () -> Int = { MemoryPolicy.defaultMemoryMiB },
+        setMemoryChoiceMiB: @escaping (Int) -> Void = { _ in },
+        hostMemoryMiB: @escaping () -> Int = { MemoryPolicy.hostMemoryMiB() },
         launch: @escaping () -> Void
     ) {
         self.accessibilityStatus = accessibilityStatus
@@ -295,10 +301,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         self.savePortForwarding = savePortForwarding
         self.immersiveMode = immersiveMode
         self.setImmersiveMode = setImmersiveMode
+        self.memoryChoiceMiB = memoryChoiceMiB
+        self.setMemoryChoiceMiB = setMemoryChoiceMiB
+        self.hostMemoryMiB = hostMemoryMiB
         self.launch = launch
 
         window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 760),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 832),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -324,12 +333,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     func prepareForPresentation(visibleFrame: NSRect?) {
         render()
         if let visibleFrame {
-            // The menu carries six rows once a resettable VM can choose where it
-            // lives. At 690 the launch button cleared the bottom edge by 15pt,
-            // which any difference in system font metrics turned into a button
-            // clipped off the window.
+            // The memory row added one 72pt row to the menu that previously
+            // fit at 760. At 690 the launch button cleared the bottom edge by
+            // 15pt, which any difference in system font metrics turned into a
+            // button clipped off the window; on displays shorter than the
+            // window the content scrolls rather than clips.
             let availableHeight = max(480, visibleFrame.height - 32)
-            window.setContentSize(NSSize(width: 600, height: min(760, availableHeight)))
+            window.setContentSize(NSSize(width: 600, height: min(832, availableHeight)))
         }
     }
 
@@ -560,6 +570,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         )
         let immersiveRow = immersiveSettingRow(isEnabled: immersiveMode())
 
+        let memoryPresentation = StartMenuPresentation.memory(
+            preferredMiB: memoryChoiceMiB(),
+            hostMemoryMiB: hostMemoryMiB()
+        )
+        let memoryRow = memorySettingRow(presentation: memoryPresentation)
+
         let storageStatus = storageLocationStatus()
         var storageRow: NSView?
         if let storagePath = storageLocation() {
@@ -616,7 +632,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         if let storageRow {
             integrationRowViews.append(storageRow)
         }
-        integrationRowViews.append(contentsOf: [portForwardingRow, immersiveRow])
+        integrationRowViews.append(contentsOf: [memoryRow, portForwardingRow, immersiveRow])
 
         var permissionRowsAndSeparators: [NSView] = []
         for (index, row) in permissionRowViews.enumerated() {
@@ -1146,6 +1162,83 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
         labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return row
+    }
+
+    private func memorySettingRow(presentation: StartMenuMemoryPresentation) -> NSView {
+        let symbol = NSImageView()
+        symbol.image = NSImage(systemSymbolName: "memorychip", accessibilityDescription: nil)
+        symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
+        symbol.contentTintColor = OmarchyStartMenuTheme.accent
+        symbol.identifier = NSUserInterfaceItemIdentifier("memory-symbol")
+        symbol.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            symbol.widthAnchor.constraint(equalToConstant: 26),
+            symbol.heightAnchor.constraint(equalToConstant: 26),
+        ])
+
+        let title = NSTextField(labelWithString: "Memory")
+        title.font = .monospacedSystemFont(ofSize: 13, weight: .bold)
+        title.textColor = OmarchyStartMenuTheme.foreground
+        title.identifier = NSUserInterfaceItemIdentifier("memory-title")
+
+        let detail = NSTextField(wrappingLabelWithString: presentation.detail)
+        detail.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+        detail.textColor = OmarchyStartMenuTheme.muted
+        detail.maximumNumberOfLines = 2
+        detail.identifier = NSUserInterfaceItemIdentifier("memory-caption")
+
+        let labels = NSStackView(views: [title, detail])
+        labels.orientation = .vertical
+        labels.alignment = .leading
+        labels.spacing = 3
+        labels.translatesAutoresizingMaskIntoConstraints = false
+
+        let popup = NSPopUpButton()
+        popup.addItems(withTitles: presentation.choiceTitles)
+        // Each item carries its own MiB value, so the selection callback needs
+        // no separate index-to-value state that a re-render could desync.
+        for (item, choiceMiB) in zip(popup.itemArray, presentation.choicesMiB) {
+            item.tag = choiceMiB
+        }
+        popup.selectItem(at: presentation.selectedIndex)
+        popup.target = self
+        popup.action = #selector(changeMemoryChoice(_:))
+        popup.isEnabled = presentation.isAdjustable
+            && !microphoneRequestInFlight
+            && !cameraRequestInFlight
+            && !launchInProgress
+            && !resetInProgress
+        popup.identifier = NSUserInterfaceItemIdentifier("memory-popup")
+        popup.setAccessibilityLabel("Memory")
+        popup.setAccessibilityTitleUIElement(title)
+        popup.setAccessibilityHelp(presentation.detail)
+        popup.translatesAutoresizingMaskIntoConstraints = false
+
+        let row = NSView()
+        row.identifier = NSUserInterfaceItemIdentifier("memory-row")
+        row.translatesAutoresizingMaskIntoConstraints = false
+        row.addSubview(symbol)
+        row.addSubview(labels)
+        row.addSubview(popup)
+        NSLayoutConstraint.activate([
+            row.heightAnchor.constraint(greaterThanOrEqualToConstant: 72),
+            symbol.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+            symbol.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.leadingAnchor.constraint(equalTo: symbol.trailingAnchor, constant: 12),
+            labels.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+            labels.trailingAnchor.constraint(lessThanOrEqualTo: popup.leadingAnchor, constant: -12),
+            popup.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+            popup.centerYAnchor.constraint(equalTo: row.centerYAnchor),
+        ])
+        labels.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        labels.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return row
+    }
+
+    @objc private func changeMemoryChoice(_ sender: NSPopUpButton) {
+        guard !launchInProgress, !resetInProgress else { return }
+        guard let choiceMiB = sender.selectedItem?.tag, choiceMiB > 0 else { return }
+        setMemoryChoiceMiB(choiceMiB)
     }
 
     @objc private func beginAccessibilityRequest() {

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -54,6 +54,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let sharedFolderStore: SharedFolderPreferenceStore
     private let portForwardingStore: PortForwardingPreferenceStore
     private let fullscreenPreferenceStore: FullscreenPreferenceStore
+    private let memoryPreferenceStore: MemoryPreferenceStore
     private let storageLocationStore: StorageLocationPreferenceStore
     private let volumeProbe: VolumeProbing
     private let volumeRootDetector: VolumeRootDetecting
@@ -92,6 +93,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         sharedFolderStore: SharedFolderPreferenceStore = SharedFolderPreferenceStore(),
         portForwardingStore: PortForwardingPreferenceStore = PortForwardingPreferenceStore(),
         fullscreenPreferenceStore: FullscreenPreferenceStore = FullscreenPreferenceStore(),
+        memoryPreferenceStore: MemoryPreferenceStore = MemoryPreferenceStore(),
         storageLocationStore: StorageLocationPreferenceStore = StorageLocationPreferenceStore(),
         volumeProbe: VolumeProbing = URLVolumeProbe(),
         volumeRootDetector: VolumeRootDetecting = FileManagerVolumeRootDetector(),
@@ -106,6 +108,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         self.sharedFolderStore = sharedFolderStore
         self.portForwardingStore = portForwardingStore
         self.fullscreenPreferenceStore = fullscreenPreferenceStore
+        self.memoryPreferenceStore = memoryPreferenceStore
         self.storageLocationStore = storageLocationStore
         self.volumeProbe = volumeProbe
         self.volumeRootDetector = volumeRootDetector
@@ -202,6 +205,15 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             setImmersiveMode: { [weak self] isImmersive in
                 self?.fullscreenPreferenceStore.save(
                     FullscreenPreferences(isImmersive: isImmersive)
+                )
+            },
+            memoryChoiceMiB: { [weak self] in
+                self?.memoryPreferenceStore.load().memoryMiB
+                    ?? MemoryPolicy.defaultMemoryMiB
+            },
+            setMemoryChoiceMiB: { [weak self] memoryMiB in
+                self?.memoryPreferenceStore.save(
+                    MemoryPreferences(memoryMiB: memoryMiB)
                 )
             },
             launch: { [weak self] in
@@ -413,8 +425,13 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             baseEnvironment: forwarding.environment,
             preferences: fullscreenPreferenceStore.load()
         )
-        let storage = StorageLocationLaunchConfiguration.make(
+        let memory = MemoryLaunchConfiguration.make(
             baseEnvironment: fullscreen.environment,
+            preferences: memoryPreferenceStore.load(),
+            hostMemoryMiB: MemoryPolicy.hostMemoryMiB()
+        )
+        let storage = StorageLocationLaunchConfiguration.make(
+            baseEnvironment: memory.environment,
             preference: storageLocationStore.load(),
             metrics: bundledMetrics,
             probe: volumeProbe,

--- a/macos/Tests/OmarchyVMHelperTests/MemoryPreferencesTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/MemoryPreferencesTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Memory policy")
+struct MemoryPolicyTests {
+    @Test("An 8 GiB host offers only the default")
+    func eightGiBHostOffersOnlyDefault() {
+        #expect(MemoryPolicy.allowedChoicesMiB(hostMemoryMiB: 8192) == [4096])
+    }
+
+    @Test("A 16 GiB host offers up to 8 GiB")
+    func sixteenGiBHostOffersUpToEight() {
+        #expect(
+            MemoryPolicy.allowedChoicesMiB(hostMemoryMiB: 16384) == [4096, 6144, 8192]
+        )
+    }
+
+    @Test("A 24 GiB host offers the complete menu")
+    func twentyFourGiBHostOffersEverything() {
+        #expect(
+            MemoryPolicy.allowedChoicesMiB(hostMemoryMiB: 24576)
+                == [4096, 6144, 8192, 12288, 16384]
+        )
+    }
+
+    @Test("Every non-default choice leaves the host its headroom")
+    func choicesLeaveHeadroom() {
+        for host in [8192, 12288, 16384, 24576, 32768, 65536] {
+            for choice in MemoryPolicy.allowedChoicesMiB(hostMemoryMiB: host)
+            where choice != MemoryPolicy.defaultMemoryMiB {
+                #expect(choice + MemoryPolicy.hostHeadroomMiB <= host)
+            }
+        }
+    }
+
+    @Test("A stored choice that fits this host is kept")
+    func resolutionKeepsAFittingChoice() {
+        #expect(
+            MemoryPolicy.resolvedMemoryMiB(preferredMiB: 6144, hostMemoryMiB: 16384)
+                == 6144
+        )
+    }
+
+    @Test("A stored choice that no longer fits falls back to the default")
+    func resolutionFallsBackWhenChoiceNoLongerFits() {
+        #expect(
+            MemoryPolicy.resolvedMemoryMiB(preferredMiB: 8192, hostMemoryMiB: 8192)
+                == MemoryPolicy.defaultMemoryMiB
+        )
+    }
+
+    @Test("A value that was never a listed choice falls back to the default")
+    func resolutionFallsBackForUnlistedValue() {
+        #expect(
+            MemoryPolicy.resolvedMemoryMiB(preferredMiB: 5000, hostMemoryMiB: 65536)
+                == MemoryPolicy.defaultMemoryMiB
+        )
+    }
+
+    @Test("Labels show whole GiB when exact, MiB otherwise")
+    func displayLabels() {
+        #expect(MemoryPolicy.displayLabel(memoryMiB: 6144) == "6 GiB")
+        #expect(MemoryPolicy.displayLabel(memoryMiB: 3000) == "3000 MiB")
+    }
+}
+
+@Suite("Memory preferences")
+struct MemoryPreferenceStoreTests {
+    @Test("The guest keeps the 4 GiB default until the user changes it")
+    func defaultsToRecommendedMemory() {
+        let fixture = DefaultsFixture()
+
+        #expect(fixture.store.load() == .defaults)
+        #expect(fixture.store.load().memoryMiB == MemoryPolicy.defaultMemoryMiB)
+    }
+
+    @Test("A memory choice persists")
+    func savesChoice() {
+        let fixture = DefaultsFixture()
+        fixture.store.save(MemoryPreferences(memoryMiB: 8192))
+
+        let reopened = MemoryPreferenceStore(defaults: fixture.defaults)
+        #expect(reopened.load() == MemoryPreferences(memoryMiB: 8192))
+    }
+
+    @Test("Invalid or future preferences fail safely")
+    func invalidPreferencesUseDefault() throws {
+        let fixture = DefaultsFixture()
+        fixture.defaults.set(Data("junk".utf8), forKey: MemoryPreferenceStore.key)
+        #expect(fixture.store.load() == .defaults)
+
+        let future = try JSONSerialization.data(withJSONObject: [
+            "schemaVersion": MemoryPreferenceStore.schemaVersion + 1,
+            "memoryMiB": 8192,
+        ])
+        fixture.defaults.set(future, forKey: MemoryPreferenceStore.key)
+        #expect(fixture.store.load() == .defaults)
+    }
+
+    private final class DefaultsFixture {
+        let suiteName = "MemoryPreferenceStoreTests.\(UUID().uuidString)"
+        let defaults: UserDefaults
+        let store: MemoryPreferenceStore
+
+        init() {
+            defaults = UserDefaults(suiteName: suiteName)!
+            defaults.removePersistentDomain(forName: suiteName)
+            store = MemoryPreferenceStore(defaults: defaults)
+        }
+
+        deinit {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+}
+
+@Suite("Memory launch configuration")
+struct MemoryLaunchConfigurationTests {
+    @Test("Publishes the resolved choice and replaces inherited values")
+    func publishesChoice() {
+        let inherited = [
+            "KEEP_ME": "yes",
+            MemoryPolicy.environmentKey: "99999",
+        ]
+
+        let chosen = MemoryLaunchConfiguration.make(
+            baseEnvironment: inherited,
+            preferences: MemoryPreferences(memoryMiB: 6144),
+            hostMemoryMiB: 16384
+        )
+        #expect(chosen.environment["KEEP_ME"] == "yes")
+        #expect(chosen.environment[MemoryPolicy.environmentKey] == "6144")
+    }
+
+    @Test("Never exports a choice this host cannot hold")
+    func neverExportsAnOversizedChoice() {
+        let configuration = MemoryLaunchConfiguration.make(
+            baseEnvironment: [:],
+            preferences: MemoryPreferences(memoryMiB: 16384),
+            hostMemoryMiB: 8192
+        )
+        #expect(configuration.environment[MemoryPolicy.environmentKey] == "4096")
+    }
+}
+
+@Suite("Memory start menu presentation")
+struct StartMenuMemoryPresentationTests {
+    @Test("Marks the default entry and selects the stored choice")
+    func marksDefaultAndSelectsChoice() {
+        let presentation = StartMenuPresentation.memory(
+            preferredMiB: 8192,
+            hostMemoryMiB: 16384
+        )
+        #expect(presentation.choiceTitles == ["4 GiB · default", "6 GiB", "8 GiB"])
+        #expect(presentation.choicesMiB == [4096, 6144, 8192])
+        #expect(presentation.selectedIndex == 2)
+        #expect(presentation.isAdjustable)
+    }
+
+    @Test("An 8 GiB host renders the row as informational")
+    func eightGiBHostIsNotAdjustable() {
+        let presentation = StartMenuPresentation.memory(
+            preferredMiB: 4096,
+            hostMemoryMiB: 8192
+        )
+        #expect(presentation.choicesMiB == [4096])
+        #expect(presentation.selectedIndex == 0)
+        #expect(!presentation.isAdjustable)
+        #expect(presentation.detail.contains("4 GiB"))
+    }
+
+    @Test("A stored choice that no longer fits presents as the default")
+    func staleChoicePresentsAsDefault() {
+        let presentation = StartMenuPresentation.memory(
+            preferredMiB: 16384,
+            hostMemoryMiB: 16384
+        )
+        #expect(
+            presentation.choicesMiB[presentation.selectedIndex]
+                == MemoryPolicy.defaultMemoryMiB
+        )
+    }
+}
+
+/// The memory contract is split across two languages: the app resolves and
+/// exports the value, the launcher re-validates it. Pin the shared constants
+/// to the shell source so neither side can drift silently; the launcher's
+/// semantics are exercised by qemu-memory-contract.test.sh.
+@Suite("Memory cross-language contract")
+struct MemoryShellContractTests {
+    @Test("the launcher uses the same key, default, and minimum")
+    func launcherAgreesOnConstants() throws {
+        let launcher = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("run-qemu-gpu.sh")
+        let source = try String(contentsOf: launcher, encoding: .utf8)
+
+        #expect(source.contains(
+            "${\(MemoryPolicy.environmentKey):-\(MemoryPolicy.defaultMemoryMiB)}"
+        ))
+        #expect(source.contains(
+            "memory_mib >= \(MemoryPolicy.minimumMemoryMiB)"
+        ))
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -108,6 +108,7 @@ struct QEMUGPURuntimeEnvironmentTests {
             AudioLaunchConfiguration.inputDeviceNameKey,
             SharedFolderPolicy.environmentKey,
             PortForwardPolicy.environmentKey,
+            MemoryPolicy.environmentKey,
             QEMUGPURuntimeEnvironment.inspectOnlyKey,
             QEMUGPURuntimeEnvironment.dryRunKey,
             QEMUGPURuntimeEnvironment.bootRecoveryConsentKey,

--- a/macos/Tests/qemu-memory-contract.test.sh
+++ b/macos/Tests/qemu-memory-contract.test.sh
@@ -1,0 +1,354 @@
+#!/bin/bash
+
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "$0")" && pwd -P)
+macos_dir=$(cd "$test_dir/.." && pwd -P)
+
+fail() {
+  printf 'qemu-memory-contract.test: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  [[ $1 == *"$2"* ]] || fail "expected output to contain [$2], got [$1]"
+}
+
+assert_line_pair() {
+  local file=$1
+  local first=$2
+  local second=$3
+  awk -v first="$first" -v second="$second" \
+    'previous == first && $0 == second { found = 1 } { previous = $0 } END { exit !found }' \
+    "$file" || fail "expected adjacent lines [$first] and [$second] in $file"
+}
+
+test_root=$(mktemp -d '/private/tmp/omarchy-qemu-memory-contract.XXXXXX')
+case "$test_root" in
+  /private/tmp/omarchy-qemu-memory-contract.??????) ;;
+  *) fail "unexpected test root: $test_root" ;;
+esac
+trap '/bin/rm -rf "$test_root"' EXIT HUP INT TERM
+
+app="$test_root/Try Omarchy.app"
+contents="$app/Contents"
+resources="$contents/Resources"
+shim_dir="$test_root/bin"
+mkdir -p \
+  "$contents/MacOS" \
+  "$resources/guest" \
+  "$resources/runtime/bin" \
+  "$resources/scripts" \
+  "$shim_dir"
+
+/bin/cp "$macos_dir/run-qemu-gpu.sh" "$resources/scripts/run-qemu-gpu.sh"
+/bin/cp "$macos_dir/qemu-port-forwarding.sh" "$resources/scripts/qemu-port-forwarding.sh"
+chmod 755 "$resources/scripts/run-qemu-gpu.sh"
+chmod 644 "$resources/scripts/qemu-port-forwarding.sh"
+
+cat >"$contents/MacOS/omarchy-vm-helper" <<'SH'
+#!/bin/bash
+set -euo pipefail
+if [[ ${1:-} == --bridge-native-audio \
+   || ${1:-} == --bridge-native-authentication \
+   || ${1:-} == --bridge-native-clipboard \
+   || ${1:-} == --bridge-native-camera ]]; then
+  while kill -0 "$2" 2>/dev/null; do
+    sleep 0.02
+  done
+fi
+exit 0
+SH
+chmod 755 "$contents/MacOS/omarchy-vm-helper"
+
+cat >"$resources/runtime/bin/Try Omarchy" <<'SH'
+#!/bin/bash
+# Identity markers validated by the production launcher:
+# TryOmarchy.icns
+# OMARCHY_SDL_AUDIO_CONTROL_DIRECTORY
+# OMARCHY_SDL_INPUT_DEVICE_NAME
+# OMARCHY_SDL_OUTPUT_DEVICE_NAME
+# guest_owner_uid guest_owner_gid
+# hv_vm_config_set_el2_enabled hv_gic_create
+case " $* " in
+  *' -accel help '*) printf '%s\n' hvf ;;
+  *' -machine help '*) printf '%s\n' 'virt                 ARM Virtual Machine' ;;
+  *' -cpu help '*) printf '%s\n' '  host' ;;
+  *' -display help '*) printf '%s\n' cocoa ;;
+  *' -device help '*)
+    for device in \
+      hda-micro intel-hda virtconsole virtserialport virtio-balloon-pci \
+      virtio-9p-pci virtio-blk-pci virtio-gpu-gl-pci virtio-keyboard-pci \
+      virtio-net-pci virtio-rng-pci virtio-serial-pci virtio-tablet-pci; do
+      printf 'name "%s"\n' "$device"
+    done
+    ;;
+  *' -help '*)
+    printf '%s\n' \
+      '-add-fd fd=fd,set=set[,opaque=opaque]' \
+      '-action reboot=reset|shutdown' \
+      '-action shutdown=poweroff|pause' \
+      'full-grab=on|off' \
+      'immersive=on|off'
+    ;;
+  *' -machine virt -netdev help '*) printf '%s\n' user ;;
+  *' -machine virt -audiodev help '*) printf '%s\n' sdl ;;
+  *' -device virtio-gpu-gl-pci,help '*) printf '%s\n' 'romfile=<str>' ;;
+  *' -machine virt,gic-version=3,virtualization=on '*' -qmp stdio '*)
+    exit "${FAKE_QEMU_NESTED_STATUS:-0}"
+    ;;
+  *)
+    exec /usr/bin/python3 - "$@" <<'PY'
+import os
+from pathlib import Path
+import socket
+import sys
+import time
+
+arguments = sys.argv[1:]
+Path(os.environ["FAKE_QEMU_LOG"]).write_text("\n".join(arguments) + "\n")
+socket_paths = []
+for argument in arguments:
+    if argument.startswith("unix:"):
+        socket_paths.append(argument[5:].split(",", 1)[0])
+    elif argument.startswith("socket,"):
+        for field in argument.split(","):
+            if field.startswith("path="):
+                socket_paths.append(field[5:])
+
+servers = []
+if os.environ.get("FAKE_QEMU_SKIP_SOCKETS") != "1":
+    for path in socket_paths:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        server = socket.socket(socket.AF_UNIX)
+        server.bind(path)
+        server.listen(1)
+        servers.append(server)
+
+time.sleep(float(os.environ.get("FAKE_QEMU_LIFETIME", "0.20")))
+for server in servers:
+    server.close()
+raise SystemExit(int(os.environ.get("FAKE_QEMU_STATUS", "0")))
+PY
+    ;;
+esac
+SH
+chmod 755 "$resources/runtime/bin/Try Omarchy"
+
+cat >"$resources/scripts/qemu-persistent-storage.sh" <<'SH'
+#!/bin/bash
+QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS=78
+QEMU_PERSISTENT_STORAGE_MISSING_STATUS=79
+QEMU_PERSISTENT_STORAGE_QEMU_ADD_FD='fd=9,set=77,opaque=omarchy-persistent-lock'
+QEMU_SELECTED_DISK=''
+QEMU_SELECTED_STORAGE_MODE=''
+QEMU_PERSISTENT_STORAGE_DIRECTORY=''
+QEMU_PERSISTENT_STORAGE_IDENTITY=''
+QEMU_SELECTED_KERNEL=''
+QEMU_SELECTED_INITRAMFS=''
+QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+_qps_owner() { /usr/bin/stat -f '%u' "$1"; }
+_qps_permissions() { /usr/bin/stat -f '%Lp' "$1"; }
+_qps_lstat_kind() { /usr/bin/stat -f '%HT' "$1"; }
+_qps_size() { /usr/bin/stat -f '%z' "$1"; }
+qemu_persistent_storage_release_lock() { :; }
+qemu_persistent_storage_materialize_source() {
+  printf 'materialize\n' >>"$FAKE_STORAGE_LOG"
+  return 1
+}
+qemu_persistent_storage_select_existing() {
+  printf 'select-existing\n' >>"$FAKE_STORAGE_LOG"
+  QEMU_SELECTED_DISK="$FAKE_PERSISTENT_ROOT/rootfs.ext4"
+  if [[ ! -f $QEMU_SELECTED_DISK ]]; then
+    QEMU_SELECTED_DISK=''
+    return "$QEMU_PERSISTENT_STORAGE_MISSING_STATUS"
+  fi
+  printf 'reuse\n' >>"$FAKE_STORAGE_LOG"
+  QEMU_SELECTED_STORAGE_MODE=persistent
+  QEMU_PERSISTENT_STORAGE_DIRECTORY=$FAKE_PERSISTENT_ROOT
+  QEMU_PERSISTENT_STORAGE_IDENTITY=${FAKE_SAVED_IDENTITY:-saved-vm}
+  if [[ -f $FAKE_PERSISTENT_ROOT/boot/kernel && \
+        -f $FAKE_PERSISTENT_ROOT/boot/initramfs && \
+        -f $FAKE_PERSISTENT_ROOT/boot/command-line ]]; then
+    QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+    QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=$(<"$FAKE_PERSISTENT_ROOT/boot/command-line")
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+  else
+    QEMU_SELECTED_KERNEL=''
+    QEMU_SELECTED_INITRAMFS=''
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=1
+  fi
+}
+qemu_persistent_storage_stage_selected_boot_kit() {
+  printf 'stage-recovered-boot\n' >>"$FAKE_STORAGE_LOG"
+  mkdir -p "$FAKE_PERSISTENT_ROOT/boot"
+  /bin/cp "$1" "$FAKE_PERSISTENT_ROOT/boot/kernel"
+  /bin/cp "$2" "$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  printf '%s\n' "$3" >"$FAKE_PERSISTENT_ROOT/boot/command-line"
+  QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+  QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=$3
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+}
+qemu_persistent_storage_select() {
+  printf 'select %s\n' "$1" >>"$FAKE_STORAGE_LOG"
+  if [[ $1 == ephemeral ]]; then
+    mkdir -p "$6"
+    QEMU_SELECTED_DISK="$6/rootfs.ext4"
+    /bin/cp "$3" "$QEMU_SELECTED_DISK"
+    chmod 600 "$QEMU_SELECTED_DISK"
+    QEMU_SELECTED_STORAGE_MODE=ephemeral
+    QEMU_PERSISTENT_STORAGE_DIRECTORY=''
+    QEMU_PERSISTENT_STORAGE_IDENTITY=''
+    QEMU_SELECTED_KERNEL=$8
+    QEMU_SELECTED_INITRAMFS=$9
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=${10}
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+    return 0
+  fi
+  mkdir -p "$FAKE_PERSISTENT_ROOT"
+  QEMU_SELECTED_DISK="$FAKE_PERSISTENT_ROOT/rootfs.ext4"
+  if [[ $1 != reset && -f $QEMU_SELECTED_DISK ]]; then
+    printf 'reuse\n' >>"$FAKE_STORAGE_LOG"
+  else
+    printf 'factory\n' >"$QEMU_SELECTED_DISK"
+    printf 'create\n' >>"$FAKE_STORAGE_LOG"
+  fi
+  chmod 600 "$QEMU_SELECTED_DISK"
+  mkdir -p "$FAKE_PERSISTENT_ROOT/boot"
+  /bin/cp "$8" "$FAKE_PERSISTENT_ROOT/boot/kernel"
+  /bin/cp "$9" "$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  printf '%s\n' "${10}" >"$FAKE_PERSISTENT_ROOT/boot/command-line"
+  QEMU_SELECTED_STORAGE_MODE=persistent
+  QEMU_PERSISTENT_STORAGE_DIRECTORY=$FAKE_PERSISTENT_ROOT
+  QEMU_PERSISTENT_STORAGE_IDENTITY=${FAKE_SAVED_IDENTITY:-saved-vm}
+  QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+  QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=${10}
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+}
+SH
+chmod 644 "$resources/scripts/qemu-persistent-storage.sh"
+
+cat >"$shim_dir/codesign" <<'SH'
+#!/bin/bash
+for argument in "$@"; do
+  if [[ $argument == -d ]]; then
+    printf '%s\n' '<key>com.apple.security.hypervisor</key>' >&2
+  fi
+done
+exit 0
+SH
+cat >"$shim_dir/file" <<'SH'
+#!/bin/bash
+printf '%s: Mach-O 64-bit executable arm64\n' "$1"
+SH
+cat >"$shim_dir/sysctl" <<'SH'
+#!/bin/bash
+if [[ $# == 2 && $1 == -n && ($2 == hw.logicalcpu || $2 == hw.ncpu) ]]; then
+  printf '8\n'
+  exit 0
+fi
+if [[ $# == 2 && $1 == -n && $2 == hw.memsize ]]; then
+  # 16 GiB unless a scenario shrinks the host.
+  printf '%s\n' "${FAKE_HOST_MEMSIZE:-17179869184}"
+  exit 0
+fi
+exec /usr/sbin/sysctl "$@"
+SH
+chmod 755 "$shim_dir"/*
+
+guest="$resources/guest"
+printf 'kernel\n' >"$guest/vmlinuz-linux"
+printf 'initramfs\n' >"$guest/initramfs-linux.img"
+printf 'factory\n' >"$guest/rootfs.ext4"
+/usr/bin/plutil -create xml1 "$guest/launch.plist"
+/usr/bin/plutil -insert bundleIdentity -string "$(printf 'a%.0s' {1..64})" "$guest/launch.plist"
+/usr/bin/plutil -insert sourceDiskSHA256 -string "$(printf 'b%.0s' {1..64})" "$guest/launch.plist"
+/usr/bin/plutil -insert sourceDiskBytes -integer 8 "$guest/launch.plist"
+/usr/bin/plutil -insert compressedDiskBytes -integer 4 "$guest/launch.plist"
+/usr/bin/plutil -insert workingDiskBytes -integer 16 "$guest/launch.plist"
+/usr/bin/plutil -insert kernelCommandLine -string \
+  'root=/dev/vda rw rootwait console=tty0 console=hvc0 loglevel=4 systemd.show_status=false rd.systemd.show_status=false mitigations=off nowatchdog' \
+  "$guest/launch.plist"
+
+launcher="$resources/scripts/run-qemu-gpu.sh"
+persistent_root="$test_root/persistent"
+
+run_scenario() {
+  local scenario=$1
+  local expected_status=$2
+  shift 2
+  local scenario_dir="$test_root/$scenario"
+  local actual_status=0
+  mkdir -p "$scenario_dir"
+  if env \
+    PATH="$shim_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+    FAKE_STORAGE_LOG="$scenario_dir/storage.log" \
+    FAKE_PERSISTENT_ROOT="$persistent_root" \
+    FAKE_QEMU_LOG="$scenario_dir/qemu.log" \
+    "$@" \
+    "$launcher" \
+    >"$scenario_dir/stdout" 2>"$scenario_dir/stderr"; then
+    actual_status=0
+  else
+    actual_status=$?
+  fi
+  if [[ $actual_status != "$expected_status" ]]; then
+    /bin/cat "$scenario_dir/stderr" >&2 || true
+    fail "$scenario expected status $expected_status, got $actual_status"
+  fi
+}
+
+# The default allocation matches the guest manifest's recommendedMemoryMiB.
+run_scenario default 0
+assert_line_pair "$test_root/default/qemu.log" -m 4096M
+assert_contains "$(<"$test_root/default/stderr")" '4 GiB RAM'
+
+# A whole-GiB choice reaches QEMU verbatim and reads as GiB in the log.
+run_scenario six-gib 0 OMARCHY_QEMU_GPU_MEMORY_MIB=6144
+assert_line_pair "$test_root/six-gib/qemu.log" -m 6144M
+assert_contains "$(<"$test_root/six-gib/stderr")" '6 GiB RAM'
+
+# A fractional-GiB value is legal for the environment and logs in MiB.
+run_scenario odd-mib 0 OMARCHY_QEMU_GPU_MEMORY_MIB=2560
+assert_line_pair "$test_root/odd-mib/qemu.log" -m 2560M
+assert_contains "$(<"$test_root/odd-mib/stderr")" '2560 MiB RAM'
+
+# Malformed values fail loudly instead of booting a mis-sized guest.
+run_scenario malformed 1 OMARCHY_QEMU_GPU_MEMORY_MIB=6g
+assert_contains "$(<"$test_root/malformed/stderr")" 'whole number of MiB'
+
+# A leading zero must not be read as octal (bash) while QEMU reads decimal:
+# the value is normalized to base 10 before any check or use.
+run_scenario leading-zero 0 OMARCHY_QEMU_GPU_MEMORY_MIB=08192
+assert_line_pair "$test_root/leading-zero/qemu.log" -m 8192M
+
+# A value past 64-bit range must hit the launcher's own error, not wrap
+# silently through bash arithmetic into a bogus small number.
+run_scenario wraparound 1 OMARCHY_QEMU_GPU_MEMORY_MIB=18446744073709555712
+assert_contains "$(<"$test_root/wraparound/stderr")" 'whole number of MiB'
+
+# The guest manifest's minimumMemoryMiB is a hard floor.
+run_scenario too-small 1 OMARCHY_QEMU_GPU_MEMORY_MIB=1024
+assert_contains "$(<"$test_root/too-small/stderr")" 'at least 2048 MiB'
+
+# The host must keep enough memory to stay responsive: on an 8 GiB host an
+# 8 GiB guest is refused.
+run_scenario starved-host 1 \
+  FAKE_HOST_MEMSIZE=8589934592 OMARCHY_QEMU_GPU_MEMORY_MIB=8192
+assert_contains "$(<"$test_root/starved-host/stderr")" 'leave the host at least 4096 MiB'
+
+# The default must boot unconditionally, even on hosts too small to satisfy
+# the cap (CI runners have 7 GiB): 4096 + 4096 > 7168, so this scenario fails
+# if the host cap is ever applied to the default.
+run_scenario small-host-default 0 FAKE_HOST_MEMSIZE=7516192768
+assert_line_pair "$test_root/small-host-default/qemu.log" -m 4096M
+
+printf 'qemu-memory-contract.test: PASS\n'

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -1384,6 +1384,36 @@ else
   echo '[qemu-gpu] Nested virtualization is unavailable; using the compatible EL1 path.' >&2
 fi
 
+# Guest memory is a boot-time allocation. The Swift app resolves the user's
+# stored choice against this host before exporting it; re-check independently
+# here so a hand-set environment value can never start a guest below the
+# manifest's minimumMemoryMiB or starve the host. The 4096 default matches the
+# manifest's recommendedMemoryMiB, both verified at build time. The host cap
+# applies only above the default: 4096 has always booted unconditionally, and
+# hosts smaller than 8 GiB exist (CI runners), so gating the default on host
+# size would be a regression, not a safeguard.
+memory_mib=${OMARCHY_QEMU_GPU_MEMORY_MIB:-4096}
+# Seven digits bound the value below any real host while keeping the
+# arithmetic far from 64-bit wraparound; forcing base 10 stops bash from
+# reading a leading zero as octal while QEMU would read the same string as
+# decimal.
+[[ $memory_mib =~ ^[0-9]{1,7}$ ]] || fail "OMARCHY_QEMU_GPU_MEMORY_MIB must be a whole number of MiB"
+memory_mib=$((10#$memory_mib))
+(( memory_mib >= 2048 )) || fail "the ARM guest requires at least 2048 MiB of memory"
+if (( memory_mib > 4096 )); then
+  host_memory_bytes=$(sysctl -n hw.memsize 2>/dev/null) || fail "cannot determine the host memory size"
+  [[ $host_memory_bytes =~ ^[0-9]+$ ]] || fail "host memory size is invalid: $host_memory_bytes"
+  host_memory_mib=$((host_memory_bytes / 1048576))
+  (( memory_mib + 4096 <= host_memory_mib )) || {
+    fail "OMARCHY_QEMU_GPU_MEMORY_MIB must leave the host at least 4096 MiB (host has ${host_memory_mib} MiB)"
+  }
+fi
+if (( memory_mib % 1024 == 0 )); then
+  memory_display="$((memory_mib / 1024)) GiB"
+else
+  memory_display="${memory_mib} MiB"
+fi
+
 qemu_args=(
   -name 'Try Omarchy'
   "${qemu_virtualization_args[@]}"
@@ -1391,7 +1421,7 @@ qemu_args=(
   # one: Linux otherwise probes the dead device and prints a misleading failure.
   -cpu 'host,pmu=off'
   -smp "$vcpu_count,sockets=1,cores=$vcpu_count,threads=1"
-  -m 4G
+  -m "${memory_mib}M"
   -nodefaults
   # Reboot the guest inside this QEMU process, but let shutdown close the app.
   -action 'reboot=reset,shutdown=poweroff'
@@ -1481,10 +1511,10 @@ fi
 }
 
 if [[ $QEMU_SELECTED_STORAGE_MODE == persistent ]]; then
-  echo "[qemu-gpu] Starting the persistent ARM64 VirGL guest with $vcpu_count vCPUs and 4 GiB RAM." >&2
+  echo "[qemu-gpu] Starting the persistent ARM64 VirGL guest with $vcpu_count vCPUs and $memory_display RAM." >&2
   echo "[qemu-gpu] User data: $QEMU_PERSISTENT_STORAGE_DIRECTORY" >&2
 else
-  echo "[qemu-gpu] Starting a disposable ARM64 VirGL guest with $vcpu_count vCPUs and 4 GiB RAM." >&2
+  echo "[qemu-gpu] Starting a disposable ARM64 VirGL guest with $vcpu_count vCPUs and $memory_display RAM." >&2
 fi
 if [[ -n $shared_folder ]]; then
   echo "[qemu-gpu] Shared folder: $shared_folder (guest ~/$shared_folder_name)" >&2


### PR DESCRIPTION
Implements #81.

## What changed

The guest always booted with a hardcoded 4 GiB (`-m 4G` in
`macos/run-qemu-gpu.sh`). This adds a **Memory** row to the start menu so the
allocation is decided at setup and adjustable before any later launch, using
the same preference pattern as the other rows:

- `MemoryPreferences.swift`: `MemoryPolicy` (choices, host headroom rule,
  resolution), a `MemoryPreferenceStore` mirroring
  `FullscreenPreferenceStore`, and a `MemoryLaunchConfiguration` that exports
  `OMARCHY_QEMU_GPU_MEMORY_MIB`.
- Start menu: a Memory row (memorychip symbol + popup) between VM Location
  and Port forwarding. Choices are 4 (default) / 6 / 8 / 12 / 16 GiB,
  filtered so any non-default choice leaves the host at least 8 GiB; on an
  8 GiB Mac the row renders informational with the popup disabled. Each popup
  item carries its MiB value in its tag. A change applies on the next launch.
- `run-qemu-gpu.sh` re-validates the environment value independently: a
  whole number of MiB (1–7 digits, normalized to base 10 so a leading zero
  is never read as octal and a 20-digit value never wraps through 64-bit
  arithmetic), at least the guest manifest's 2048 MiB minimum, and — only
  above the default — small enough to leave the host 4 GiB. The value feeds
  `-m` and the two startup log lines.
- Reset launches strip the key like the other integration settings.
- The root README documents the row and the environment variable, including
  that the menu's 8 GiB headroom rule is deliberately more conservative than
  the launcher's 4 GiB safety floor; `macos/README.md` documents the
  UserDefaults → environment contract alongside the other settings.

## What deliberately did not change

- The default stays 4 GiB and still boots unconditionally, so existing
  installs and hosts under 8 GiB (including the 7 GB CI runners) behave
  exactly as before.
- No live resize: virtio-balloon cannot grow past the boot-time `-m`, and
  virtio-mem hot-plug is not worth the complexity here.
- A stored choice that no longer fits its host silently falls back to the
  default at launch, without rewriting the preference — move back to a
  bigger Mac and the choice returns.

## Tests

- `MemoryPreferencesTests.swift`: policy filtering/resolution, store
  round-trip and schema safety, launch configuration, and start menu
  presentation, in the existing Swift Testing style.
- `qemu-memory-contract.test.sh`: drives the real launcher with a fake QEMU
  and a shimmed `sysctl` — default `-m 4096M`, explicit 6144, fractional-GiB
  display, malformed value, below-minimum value, an oversized request on an
  8 GiB host, the default on a 7 GiB host (the CI-runner case, which fails
  if the host cap is ever applied to the default), a leading-zero value
  (octal-vs-decimal), and a past-64-bit value (wraparound).
- A cross-language contract test pins the environment key, default, and
  2048 MiB minimum between `MemoryPolicy` and the shell source.
- `QEMUGPULauncherTests` reset-sanitizer contract extended with the new key.
- Registered in the `make test` target.

## Review status

Reviewed and written from inside a running Try Omarchy guest (the ARM64
Arch VM this app boots — which is also why the feature exists: 4 GiB is
tight in here), against #81 and the surrounding launcher/start-menu/CI
paths. The guest has no Darwin toolchain, so `make test` was not run on a
Mac; GitHub `macos-15` will be the first Darwin execution of the new
Swift tests and `qemu-memory-contract.test.sh`. The shell validation was
exercised directly (bash octal/wraparound behavior confirmed by running
it), and both scripts pass `bash -n`.

The start menu, including Launch, is inside the existing scroll view, so
a short window should scroll rather than clip. Still worth a glance on a
13" to confirm Launch is visible without scrolling after the extra row
(760 → 832).

Headroom is installed RAM (`physicalMemory` / `hw.memsize`), not free
RAM, and does not count VirGL/Metal overhead on top of `-m`. That matches
#81. On a 16 GiB Mac the menu tops out at 8 GiB; the 12 GiB choice needs a
20 GiB host, so in practice it first appears on 24 GiB Macs.

## AI assistance

Developed with AI assistance, directed and reviewed by me:

- Research, implementation, and tests were drafted with Claude (Fable 5)
  via Claude Code, running inside the Try Omarchy guest.
- The diff was independently reviewed by Grok 4.6 and by a separate Claude
  multi-agent code-review pass; findings from both were verified before
  being applied or rejected — the octal/wraparound input hardening in
  `run-qemu-gpu.sh` came out of that review.
- I reviewed the full diff and take responsibility for the contribution.
  The commit carries a Co-Authored-By trailer.

## Reviewer notes

- `hostHeadroomMiB` (8 GiB for offering a choice) and the script's 4 GiB
  hard floor are judgment calls; happy to tune either.
- `qemu-memory-contract.test.sh` deliberately mirrors the self-contained
  harness of `run-qemu-ssh-contract.test.sh` rather than extracting a shared
  library, matching how each existing `*.test.sh` stands alone; happy to
  factor a common harness out if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
