### PR TITLE
Add a VM backup before incompatible guest updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PACKAGE_NOTARY_PROFILE ?= $(RELEASE_NOTARY_PROFILE)
 FORCE ?= 0
 
 .DEFAULT_GOAL := help
-.PHONY: help doctor test guest runtime app build run run-ephemeral reset update-omarchy package package-preflight release release-preflight clean clean-all clean-guest
+.PHONY: help doctor test guest runtime app build run run-ephemeral reset backup update-omarchy package package-preflight release release-preflight clean clean-all clean-guest
 
 help:
 	@printf '%s\n' \
@@ -41,6 +41,8 @@ help:
 	  'Storage:' \
 	  '  make run-ephemeral  Run without retaining VM changes' \
 	  '  make reset          Open the confirmed factory-reset flow' \
+	  '  make backup DEST=/path/to/empty/folder' \
+	  '                      Copy the saved VM into DEST (APFS clone)' \
 	  '  make clean          Remove all project builds and build caches' \
 	  '  make clean-all      Also remove VM data and stale temporary files'
 
@@ -92,6 +94,10 @@ run-ephemeral: app
 
 reset: app
 	@$(ROOT)/macos/open-qemu-gpu.sh --reset-storage
+
+backup:
+	@[[ -n "$(strip $(DEST))" ]] || { echo 'error: DEST=/path/to/empty/folder is required' >&2; exit 1; }
+	@$(ROOT)/macos/backup-qemu-storage.sh "$(DEST)"
 
 update-omarchy:
 	@[[ -n "$(strip $(OMARCHY_RELEASE))" ]] || { echo 'error: OMARCHY_RELEASE=x.y.z is required' >&2; exit 1; }

--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ the same Mac; guest SSH authentication is still required.
 
 Normal launches keep one persistent VM under `~/Library/Application Support/Try Omarchy/VM/v1`. Removing the app does not remove this data. The start menu can reset it, and requires confirmation before replacing a disk that is incompatible with a new factory guest build.
 
+### Backing up before an update
+
+A new Try Omarchy guest build cannot boot an existing VM. The start menu then asks you to **Reset Omarchy**, which erases the disk. Automatic disk migration between releases is not reliable yet, so `v0.1.0` disks are not moved onto `v0.2.0`.
+
+**Keep your files.** Before resetting, copy anything you need out of Omarchy with the shared folder, or with SSH if you enabled it. Import those files into the new VM after Reset.
+
+**Keep the whole VM.** Quit Try Omarchy, then use **Backup…** on the start menu. The copy is an APFS clone of the working disk, so it stays sparse and is nearly instant on the same volume. The destination becomes a valid workspace: choose it later as **VM Location**. Restoring that copy still needs the **same** Try Omarchy version — it will not boot on a newer guest.
+
+From a checkout, the same copy is:
+
+```sh
+make backup DEST="$HOME/Backups/Try Omarchy"
+```
+
+`DEST` must be an empty folder on a local APFS volume, or a path that can be created as one. Do not copy the live folder in Finder: Finder copies can expand the sparse working disk to its full size (around 24 GB) and land the 0600 workspace marker as 0644, so the launcher then refuses to open it.
+
+Factory images under `images/` are not part of the backup. The matching Try Omarchy build rematerializes them.
+
 ### Choosing where the VM lives
 
 **Change…** on the start menu's **VM Location** row moves the VM to any folder
@@ -333,7 +351,7 @@ Run the complete contract and native test suite with:
 make test
 ```
 
-Run `make help` for component builds, persistent-storage reset, ephemeral mode, and cleanup commands.
+Run `make help` for component builds, persistent-storage reset, VM backup, ephemeral mode, and cleanup commands.
 
 To reclaim development build space, run:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,11 @@ disk remain unchanged. Normal user launches use one private writable disk under
 `~/Library/Application Support/Try Omarchy/VM/v1`. Its factory-image identity is immutable:
 the launcher never pairs a saved root filesystem with a different bundled kernel
 or initramfs. When a guest build changes, the start menu asks for an explicitly
-confirmed factory reset before creating the replacement disk. A compatible
+confirmed factory reset before creating the replacement disk. **Backup…** copies
+recognized persistent disks into an empty APFS folder with `cp -c`, preserving
+sparse allocation and the 0600/0700 modes the launcher requires. The copy is a
+valid workspace for the same guest identity; it does not make an older disk boot
+on a newer factory image. A compatible
 legacy identity-keyed disk can be migrated into the single workspace without
 discarding its contents. If several recognized legacy disks exist, normal launch
 stops at the start menu; confirmed reset safely removes them before publishing

--- a/macos/README.md
+++ b/macos/README.md
@@ -56,7 +56,9 @@ and specialized development runs can opt into identity-keyed parallel disks by
 setting `OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=1`; release behavior leaves it
 unset. The disk's guest-build identity is immutable so an older root filesystem
 can never boot with incompatible bundled kernel modules. A changed guest build
-requires the user-facing, confirmed Reset Omarchy flow.
+requires the user-facing, confirmed Reset Omarchy flow. **Backup…** (or
+`make backup DEST=…`) APFS-clones that workspace into an empty folder so the
+original can be restored with the matching app version after a reset.
 
 The start menu can move that workspace to any APFS folder the user picks; the
 folder is used exactly as chosen, never with a folder created inside it — a

--- a/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
+++ b/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
@@ -6,6 +6,7 @@ enum QEMUGPUStorageOption: String, Equatable {
     case ephemeral = "--ephemeral"
     case resetStorage = "--reset-storage"
     case resetStorageOnly = "--reset-storage-only"
+    case backupStorageOnly = "--backup-storage-only"
 }
 
 /// Build-only controls and user-facing integration values must never leak
@@ -13,11 +14,16 @@ enum QEMUGPUStorageOption: String, Equatable {
 enum QEMUGPURuntimeEnvironment {
     static let inspectOnlyKey = "OMARCHY_QEMU_GPU_INSPECT_ONLY"
     static let dryRunKey = "OMARCHY_QEMU_GPU_DRY_RUN"
+    /// Kept byte-identical to `QEMU_PERSISTENT_STORAGE_BACKUP_ROOT_ENV` in
+    /// qemu-persistent-storage.sh. Change one and you must change both;
+    /// StorageLocationContractTests pins them together.
+    static let backupRootKey = "OMARCHY_QEMU_GPU_BACKUP_ROOT"
 
     static func sanitizedForLaunch(_ base: [String: String]) -> [String: String] {
         var environment = base
         environment.removeValue(forKey: inspectOnlyKey)
         environment.removeValue(forKey: dryRunKey)
+        environment.removeValue(forKey: backupRootKey)
         return environment
     }
 
@@ -32,6 +38,15 @@ enum QEMUGPURuntimeEnvironment {
         ] {
             environment.removeValue(forKey: key)
         }
+        return environment
+    }
+
+    static func sanitizedForBackup(
+        _ base: [String: String],
+        destination: String
+    ) -> [String: String] {
+        var environment = sanitizedForReset(base)
+        environment[backupRootKey] = destination
         return environment
     }
 }

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -70,6 +70,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private let requestCamera: (@escaping (Bool) -> Void) -> Void
     private let storageSpaceEstimate: () -> String?
     private let resetStorage: () -> Void
+    private let backupStorage: (String) -> Void
+    private let validateBackupDestination: (String) -> String?
     private let sharedFolderStatus: () -> SharedFolderMenuState
     private let chooseSharedFolder: (String) -> String?
     private let setSharedFolderEnabled: (Bool) -> Void
@@ -89,7 +91,17 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     private var microphoneRequestInFlight = false
     private var cameraRequestInFlight = false
     private var resetInProgress = false
+    private var backupInProgress = false
     private var launchInProgress = false
+    private var pendingBackupPath: String?
+
+    private var isBusy: Bool {
+        launchInProgress
+            || resetInProgress
+            || backupInProgress
+            || microphoneRequestInFlight
+            || cameraRequestInFlight
+    }
     private var pendingResetSpaceEstimate: String?
     private weak var startMenuScrollView: NSScrollView?
     private(set) var portForwardingEditor: PortForwardingEditor?
@@ -100,6 +112,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             return self.window.isVisible
                 && !self.launchInProgress
                 && !self.resetInProgress
+                && !self.backupInProgress
                 && !self.microphoneRequestInFlight
                 && !self.cameraRequestInFlight
                 && self.window.attachedSheet == nil
@@ -149,6 +162,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         chooseStorageLocation: @escaping (String) -> String?,
         useDefaultStorageLocation: @escaping () -> Void,
         resetStorage: @escaping () -> Void,
+        backupStorage: @escaping (String) -> Void = { _ in },
+        validateBackupDestination: @escaping (String) -> String? = { _ in nil },
         sharedFolderStatus: @escaping () -> SharedFolderMenuState,
         chooseSharedFolder: @escaping (String) -> String?,
         setSharedFolderEnabled: @escaping (Bool) -> Void,
@@ -173,6 +188,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         self.chooseStorageLocation = chooseStorageLocation
         self.useDefaultStorageLocation = useDefaultStorageLocation
         self.resetStorage = resetStorage
+        self.backupStorage = backupStorage
+        self.validateBackupDestination = validateBackupDestination
         self.sharedFolderStatus = sharedFolderStatus
         self.chooseSharedFolder = chooseSharedFolder
         self.setSharedFolderEnabled = setSharedFolderEnabled
@@ -217,7 +234,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     func refreshPermissionStatus() {
-        guard window.isVisible, !launchInProgress, !resetInProgress else { return }
+        guard window.isVisible, !launchInProgress, !resetInProgress, !backupInProgress else { return }
         render()
     }
 
@@ -265,6 +282,46 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         alert.beginSheetModal(for: window)
     }
 
+    func backupDidFinish(errorMessage: String?) {
+        guard backupInProgress else { return }
+        backupInProgress = false
+        render()
+
+        let alert = NSAlert()
+        if let errorMessage {
+            alert.alertStyle = .critical
+            alert.messageText = "Omarchy couldn’t be backed up"
+            alert.informativeText = errorMessage
+        } else {
+            alert.alertStyle = .informational
+            alert.messageText = "Omarchy has been backed up"
+            if let path = pendingBackupPath {
+                alert.informativeText = """
+                    The VM was copied to \(path). To use it later, choose that \
+                    folder as VM Location. A newer Try Omarchy guest still cannot \
+                    boot this disk — copy files out through a shared folder or SSH \
+                    if you are updating.
+                    """
+            } else {
+                alert.informativeText = """
+                    The VM was copied. A newer Try Omarchy guest still cannot boot \
+                    this disk — copy files out through a shared folder or SSH if \
+                    you are updating.
+                    """
+            }
+        }
+        pendingBackupPath = nil
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window)
+    }
+
+    func backupDidAbort() {
+        guard backupInProgress else { return }
+        backupInProgress = false
+        pendingBackupPath = nil
+        render()
+    }
+
     /// Clears the launching state when the controller stopped before the
     /// launcher was ever started. The controller presents its own explanation.
     func launchDidAbort() {
@@ -291,7 +348,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Reset Omarchy to continue"
-        alert.informativeText = "This VM was created by a different Try Omarchy build. Reset Omarchy to use this version. Resetting permanently erases everything in the VM."
+        alert.informativeText = "This VM was created by a different Try Omarchy build. Reset Omarchy to use this version. Resetting permanently erases everything in the VM. Use Backup… first if you want a copy, or copy files out through a shared folder or SSH."
         alert.addButton(withTitle: "OK")
         alert.beginSheetModal(for: window)
     }
@@ -503,6 +560,18 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             permissionRows.bottomAnchor.constraint(equalTo: permissionCard.bottomAnchor, constant: -5),
         ])
 
+        let backup = NSButton(
+            title: backupInProgress ? "Backing up Omarchy…" : "Backup…",
+            target: self,
+            action: #selector(backupOmarchy)
+        )
+        backup.bezelStyle = .rounded
+        backup.controlSize = .small
+        backup.isEnabled = canResetStorage && !isBusy
+        backup.toolTip = canResetStorage
+            ? "Copy this VM to an empty folder without changing the original"
+            : "Backup is unavailable for a disposable VM"
+
         let reset = NSButton(
             title: resetInProgress ? "Resetting Omarchy…" : "Reset Omarchy",
             target: self,
@@ -511,16 +580,17 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         reset.bezelStyle = .rounded
         reset.controlSize = .small
         reset.contentTintColor = .systemRed
-        reset.isEnabled = canResetStorage
-            && !launchInProgress
-            && !resetInProgress
-            && !microphoneRequestInFlight
-            && !cameraRequestInFlight
+        reset.isEnabled = canResetStorage && !isBusy
         reset.toolTip = canResetStorage
             ? "Erase this VM and return it to factory settings"
             : "Reset is unavailable for a disposable VM"
 
-        let resetViews: [NSView] = [reset]
+        let storageActions = NSStackView(views: [backup, reset])
+        storageActions.orientation = .horizontal
+        storageActions.alignment = .centerY
+        storageActions.spacing = 8
+
+        let resetViews: [NSView] = [storageActions]
         let resetSection = NSStackView(views: resetViews)
         resetSection.orientation = .vertical
         resetSection.alignment = .leading
@@ -537,10 +607,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         launchButton.bezelStyle = .rounded
         launchButton.controlSize = .large
         launchButton.font = launchButtonFont
-        launchButton.isEnabled = !launchInProgress
-            && !resetInProgress
-            && !microphoneRequestInFlight
-            && !cameraRequestInFlight
+        launchButton.isEnabled = !isBusy
         launchButton.title = ""
         launchButton.identifier = NSUserInterfaceItemIdentifier("launch-button")
         let launchButtonLabel = MouseIgnoringTextField(labelWithString: launchButtonTitle)
@@ -800,9 +867,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             button.controlSize = .regular
             button.isEnabled = actionsEnabled
                 && !microphoneRequestInFlight
-                && !cameraRequestInFlight
-                && !launchInProgress
-                && !resetInProgress
+                && !isBusy
             let identifier = actions.count == 1
                 ? "permission-action-\(symbolName)"
                 : "permission-action-\(symbolName)-\(index)"
@@ -931,7 +996,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         toggle.state = isEnabled ? .on : .off
         toggle.target = self
         toggle.action = #selector(changeImmersiveMode(_:))
-        toggle.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
+        toggle.isEnabled = !isBusy
         toggle.identifier = NSUserInterfaceItemIdentifier("immersive-toggle")
         toggle.setAccessibilityLabel("Immersive mode")
         toggle.setAccessibilityTitleUIElement(title)
@@ -1062,8 +1127,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         confirmReset()
     }
 
+    @objc private func backupOmarchy() {
+        confirmBackup()
+    }
+
     @objc private func beginStorageLocationSelection() {
-        guard canResetStorage, !launchInProgress, !resetInProgress else { return }
+        guard canResetStorage, !isBusy else { return }
         permissionWindowRestorer.cancel()
         let panel = NSOpenPanel()
         panel.title = "Choose where to keep the Omarchy VM"
@@ -1119,14 +1188,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     @objc private func useDefaultStorageLocationAction() {
-        guard canResetStorage, !launchInProgress, !resetInProgress else { return }
+        guard canResetStorage, !isBusy else { return }
         useDefaultStorageLocation()
         render()
     }
 
     @objc private func beginSharedFolderSelection() {
-        guard !launchInProgress,
-              !resetInProgress,
+        guard !isBusy,
               !microphoneRequestInFlight,
               !cameraRequestInFlight else { return }
         permissionWindowRestorer.cancel()
@@ -1167,7 +1235,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     @objc private func beginPortForwardingConfiguration() {
-        guard !launchInProgress, !resetInProgress, portForwardingEditor == nil else { return }
+        guard !isBusy, portForwardingEditor == nil else { return }
         permissionWindowRestorer.cancel()
         let editor = PortForwardingEditor(
             mappings: portForwardingStatus(),
@@ -1188,7 +1256,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     @objc private func changeImmersiveMode(_ sender: NSSwitch) {
-        guard !launchInProgress, !resetInProgress else { return }
+        guard !isBusy else { return }
         let isEnabled = sender.state == .on
         setImmersiveMode(isEnabled)
         let detailText = StartMenuPresentation.immersiveDetail(isEnabled: isEnabled)
@@ -1205,17 +1273,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     private func confirmReset() {
-        guard canResetStorage,
-              !launchInProgress,
-              !resetInProgress,
-              !microphoneRequestInFlight,
-              !cameraRequestInFlight else { return }
+        guard canResetStorage, !isBusy else { return }
         permissionWindowRestorer.cancel()
         let estimate = storageSpaceEstimate()
         let alert = NSAlert()
         alert.alertStyle = .critical
         alert.messageText = "Reset Omarchy to factory settings?"
-        var detail = "This permanently erases everything in this Omarchy virtual machine, including apps, files, accounts, and settings. This cannot be undone or recovered."
+        var detail = "This permanently erases everything in this Omarchy virtual machine, including apps, files, accounts, and settings. This cannot be undone or recovered. Use Backup… first if you want a copy of this VM."
         // With a chosen data folder there can be more than one workspace on the
         // Mac, so say which one is about to be erased.
         let location = storageLocationStatus()
@@ -1248,9 +1312,55 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         resetStorage()
     }
 
+    private func confirmBackup() {
+        guard canResetStorage, !isBusy else { return }
+        permissionWindowRestorer.cancel()
+        let panel = NSOpenPanel()
+        panel.title = "Choose where to copy the Omarchy VM"
+        panel.message = "The copy goes straight into the folder you choose. Pick an empty folder on an APFS disk. On the same disk the copy is almost instant; on another disk it can take several minutes."
+        panel.prompt = "Backup"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.resolvesAliases = true
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        if let problem = validateBackupDestination(url.path) {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "That folder can’t hold a backup"
+            alert.informativeText = problem
+            alert.addButton(withTitle: "OK")
+            alert.beginSheetModal(for: window)
+            return
+        }
+
+        let destination = StorageLocationPolicy.stateRoot(forContainer: url.path)
+        let confirmation = NSAlert()
+        confirmation.alertStyle = .informational
+        confirmation.messageText = "Copy the Omarchy VM here?"
+        confirmation.informativeText = """
+            Omarchy will copy the VM into \(destination) without changing the \
+            original. The copy still belongs to this Try Omarchy version; a newer \
+            guest cannot boot it.
+            """
+        confirmation.addButton(withTitle: "Cancel")
+        confirmation.addButton(withTitle: "Backup")
+        guard confirmation.runModal() == .alertSecondButtonReturn else { return }
+
+        pendingBackupPath = StorageLocationPolicy.displayPath(
+            destination,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path
+        )
+        backupInProgress = true
+        render()
+        backupStorage(destination)
+    }
+
     @objc private func launchOmarchy() {
-        guard !launchInProgress,
-              !resetInProgress,
+        guard !isBusy,
               !microphoneRequestInFlight,
               !cameraRequestInFlight else { return }
         launchInProgress = true

--- a/macos/Sources/OmarchyVMHelper/StorageLocation.swift
+++ b/macos/Sources/OmarchyVMHelper/StorageLocation.swift
@@ -103,6 +103,8 @@ enum StorageLocationPolicyError: LocalizedError, Equatable {
     case unsafeRoot(String)
     case isVolumeRoot(String)
     case notEmpty(String)
+    case alreadyAWorkspace(String)
+    case isCurrentWorkspace(String)
     case invalidWorkspaceMarker(String)
     case volumeUnreadable(String)
     case notLocalVolume(String)
@@ -129,6 +131,10 @@ enum StorageLocationPolicyError: LocalizedError, Equatable {
             "Choose a folder inside \(path), not the drive itself. For example, create a folder named \"\(StorageLocationPolicy.workspaceDirectoryName)\" there and pick that."
         case .notEmpty(let path):
             "This folder already has files in it: \(path). Omarchy only uses an empty folder, so it never mixes its virtual machine with anything else stored there. Choose or create an empty folder instead."
+        case .alreadyAWorkspace(let path):
+            "That folder is already an Omarchy workspace: \(path). Choose an empty folder so the backup is not mixed with another VM."
+        case .isCurrentWorkspace(let path):
+            "Choose a different folder. That one is the live Omarchy VM: \(path)."
         case .invalidWorkspaceMarker(let path):
             "This folder looks like an Omarchy workspace, but its \"\(StorageLocationPolicy.rootMarkerName)\" file is damaged, so the VM here cannot be opened safely: \(path). Delete that file to reuse the folder as an empty one, or choose a different folder."
         case .volumeUnreadable(let path):
@@ -235,12 +241,23 @@ enum StorageLocationPolicy {
         return entries.allSatisfy { ignorableEntries.contains($0.lastPathComponent) }
     }
 
+    /// Whether a chosen folder may already be an Omarchy workspace.
+    enum WorkspaceAcceptance: Equatable {
+        /// Empty folder, or one this app has already used.
+        case emptyOrExisting
+        /// Empty folder only. Existing workspaces are refused so a backup
+        /// cannot mix with, or overwrite, another VM.
+        case emptyOnly
+    }
+
     static func validate(
         _ path: String,
         metrics: BundledGuestMetrics?,
         probe: VolumeProbing,
         volumeRootDetector: VolumeRootDetecting = FileManagerVolumeRootDetector(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        workspaceAcceptance: WorkspaceAcceptance = .emptyOrExisting,
+        currentStateRoot: String? = nil
     ) throws -> StorageLocationResolution {
         guard path.hasPrefix("/") else { throw StorageLocationPolicyError.notAbsolute }
         guard !path.contains("\n"), !path.contains("\r"), !path.utf8.contains(0) else {
@@ -271,7 +288,19 @@ enum StorageLocationPolicy {
         }
 
         let containerURL = URL(fileURLWithPath: container, isDirectory: true)
+        let root = stateRoot(forContainer: container)
+        if let currentStateRoot, !currentStateRoot.isEmpty {
+            let currentRoot = URL(fileURLWithPath: currentStateRoot, isDirectory: true)
+                .standardizedFileURL.path
+            if root == currentRoot {
+                throw StorageLocationPolicyError.isCurrentWorkspace(root)
+            }
+        }
+
         let isExistingWorkspace = hasValidRootMarker(in: containerURL)
+        if workspaceAcceptance == .emptyOnly, isExistingWorkspace {
+            throw StorageLocationPolicyError.alreadyAWorkspace(container)
+        }
         if !isExistingWorkspace, hasRootMarkerEntry(in: containerURL) {
             // The launcher would refuse this folder too, but only after the user
             // committed to it. Say so now, while they can still pick another.
@@ -290,7 +319,6 @@ enum StorageLocationPolicy {
                 throw StorageLocationPolicyError.notEmpty(container)
             }
         }
-        let root = stateRoot(forContainer: container)
 
         let capabilities: VolumeCapabilities
         do {
@@ -337,6 +365,30 @@ enum StorageLocationPolicy {
             stateRoot: root,
             capabilities: capabilities,
             spaceWarning: warning
+        )
+    }
+
+    /// An empty APFS folder that can receive a copy of the live VM.
+    ///
+    /// Existing workspaces are refused: a backup must not mix with, or
+    /// overwrite, another VM. The live workspace is refused for the same
+    /// reason. Factory-image space is not demanded here — backup copies the
+    /// working disk, not a new guest build.
+    static func validateBackupDestination(
+        _ path: String,
+        currentStateRoot: String?,
+        probe: VolumeProbing,
+        volumeRootDetector: VolumeRootDetecting = FileManagerVolumeRootDetector(),
+        fileManager: FileManager = .default
+    ) throws -> StorageLocationResolution {
+        try validate(
+            path,
+            metrics: nil,
+            probe: probe,
+            volumeRootDetector: volumeRootDetector,
+            fileManager: fileManager,
+            workspaceAcceptance: .emptyOnly,
+            currentStateRoot: currentStateRoot
         )
     }
 

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -135,6 +135,12 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             resetStorage: { [weak self] in
                 self?.resetVirtualMachine()
             },
+            backupStorage: { [weak self] path in
+                self?.backupVirtualMachine(to: path)
+            },
+            validateBackupDestination: { [weak self] path in
+                self?.validateBackupDestination(path)
+            },
             sharedFolderStatus: { [weak self] in
                 self?.sharedFolderMenuState() ?? SharedFolderMenuState.disabled
             },
@@ -209,11 +215,12 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
 
     private func launchArguments() -> [String] {
         var arguments = initialArguments
-        let resetOptions = [
+        let storageOnlyOptions = [
             QEMUGPUStorageOption.resetStorage.rawValue,
             QEMUGPUStorageOption.resetStorageOnly.rawValue,
+            QEMUGPUStorageOption.backupStorageOnly.rawValue,
         ]
-        if let first = arguments.first, resetOptions.contains(first) {
+        if let first = arguments.first, storageOnlyOptions.contains(first) {
             arguments.removeFirst()
         }
         return arguments
@@ -222,6 +229,12 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private func resetArguments() -> [String] {
         var arguments = launchArguments()
         arguments.insert(QEMUGPUStorageOption.resetStorageOnly.rawValue, at: 0)
+        return arguments
+    }
+
+    private func backupArguments() -> [String] {
+        var arguments = launchArguments()
+        arguments.insert(QEMUGPUStorageOption.backupStorageOnly.rawValue, at: 0)
         return arguments
     }
 
@@ -271,6 +284,54 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         } else {
             startMenuWindow?.resetDidFinish(
                 errorMessage: "The VM disk could not be reset. Try again, or reinstall the latest Try Omarchy app."
+            )
+        }
+    }
+
+    private func backupVirtualMachine(to path: String) {
+        guard resolveStorageLocationAvailability() == .available else {
+            startMenuWindow?.backupDidAbort()
+            return
+        }
+        do {
+            let context = childLaunchContext()
+            guard context.storageUnavailableReason == nil else {
+                startMenuWindow?.backupDidFinish(
+                    errorMessage: context.storageUnavailableReason
+                )
+                return
+            }
+            activeStateRoot = context.stateRoot
+            try supervisor.start(
+                executableURL: launcherURL,
+                arguments: backupArguments(),
+                environment: QEMUGPURuntimeEnvironment.sanitizedForBackup(
+                    context.environment,
+                    destination: path
+                )
+            ) { [weak self] status in
+                self?.backupDidExit(status: status)
+            }
+            childRunning = true
+        } catch {
+            startMenuWindow?.backupDidFinish(errorMessage: error.localizedDescription)
+        }
+    }
+
+    private func backupDidExit(status: Int32) {
+        guard childRunning else { return }
+        childRunning = false
+        let wasStopping = lifecycle.isStopping
+        lifecycle.childExited()
+        if applicationTerminationPending {
+            NSApp.reply(toApplicationShouldTerminate: true)
+        } else if wasStopping {
+            finish(status: status)
+        } else if status == 0 {
+            startMenuWindow?.backupDidFinish(errorMessage: nil)
+        } else {
+            startMenuWindow?.backupDidFinish(
+                errorMessage: "The VM disk could not be copied. Quit Try Omarchy if it is still running elsewhere, then try again."
             )
         }
     }
@@ -435,6 +496,24 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             _ = try StorageLocationPolicy.validate(
                 path,
                 metrics: bundledMetrics,
+                probe: volumeProbe,
+                volumeRootDetector: volumeRootDetector
+            )
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    /// Returns an error message when the folder cannot receive a VM copy.
+    private func validateBackupDestination(_ path: String) -> String? {
+        do {
+            _ = try StorageLocationPolicy.validateBackupDestination(
+                path,
+                currentStateRoot: QEMUGPUStorageSpaceEstimate.storageRootURL(
+                    environment: baseEnvironment,
+                    preference: storageLocationStore.load()
+                )?.path,
                 probe: volumeProbe,
                 volumeRootDetector: volumeRootDetector
             )

--- a/macos/Sources/OmarchyVMHelper/main.swift
+++ b/macos/Sources/OmarchyVMHelper/main.swift
@@ -5,7 +5,7 @@ import Foundation
 private var terminationSignalSources: [DispatchSourceSignal] = []
 
 private func usage() -> Never {
-    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY | --bridge-native-camera QEMU_PID SOCKET | --bridge-native-clipboard QEMU_PID SOCKET\n", stderr)
+    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only | --backup-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY | --bridge-native-camera QEMU_PID SOCKET | --bridge-native-clipboard QEMU_PID SOCKET\n", stderr)
     exit(64)
 }
 

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -24,6 +24,10 @@ struct QEMUGPULaunchRequestTests {
             storageOption: .resetStorageOnly,
             guestDirectoryPath: guest
         ))
+        #expect(QEMUGPULaunchRequest(arguments: ["--backup-storage-only", guest]) == QEMUGPULaunchRequest(
+            storageOption: .backupStorageOnly,
+            guestDirectoryPath: guest
+        ))
         #expect(QEMUGPULaunchRequest(arguments: [guest]) == QEMUGPULaunchRequest(
             storageOption: nil,
             guestDirectoryPath: guest
@@ -81,6 +85,7 @@ struct QEMUGPURuntimeEnvironmentTests {
             "KEEP_ME": "yes",
             QEMUGPURuntimeEnvironment.inspectOnlyKey: "1",
             QEMUGPURuntimeEnvironment.dryRunKey: "1",
+            QEMUGPURuntimeEnvironment.backupRootKey: "/private/tmp/backup",
         ])
 
         #expect(environment == ["KEEP_ME": "yes"])
@@ -96,6 +101,7 @@ struct QEMUGPURuntimeEnvironmentTests {
             PortForwardPolicy.environmentKey,
             QEMUGPURuntimeEnvironment.inspectOnlyKey,
             QEMUGPURuntimeEnvironment.dryRunKey,
+            QEMUGPURuntimeEnvironment.backupRootKey,
         ]
         var inherited = ["KEEP_ME": "yes"]
         for key in controlledKeys {
@@ -104,6 +110,24 @@ struct QEMUGPURuntimeEnvironmentTests {
 
         #expect(QEMUGPURuntimeEnvironment.sanitizedForReset(inherited)
             == ["KEEP_ME": "yes"])
+    }
+
+    @Test("storage backup publishes only the chosen destination")
+    func sanitizesBackup() {
+        let environment = QEMUGPURuntimeEnvironment.sanitizedForBackup(
+            [
+                "KEEP_ME": "yes",
+                QEMUGPURuntimeEnvironment.backupRootKey: "/private/tmp/stale",
+                QEMUGPURuntimeEnvironment.inspectOnlyKey: "1",
+                SharedFolderPolicy.environmentKey: "/Users/me/Work",
+            ],
+            destination: "/private/tmp/omarchy-backup"
+        )
+
+        #expect(environment == [
+            "KEEP_ME": "yes",
+            QEMUGPURuntimeEnvironment.backupRootKey: "/private/tmp/omarchy-backup",
+        ])
     }
 }
 

--- a/macos/Tests/OmarchyVMHelperTests/StorageLocationContractTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StorageLocationContractTests.swift
@@ -37,6 +37,18 @@ struct StorageLocationContractTests {
         #expect(library.contains("[[ $(_qps_owner \"$qps_file\") == $(id -u) ]]"))
     }
 
+    @Test("the backup destination environment key matches the launcher")
+    func backupDestinationEnvironmentKey() throws {
+        let library = try source(named: "qemu-persistent-storage.sh")
+        #expect(
+            library.contains(
+                "QEMU_PERSISTENT_STORAGE_BACKUP_ROOT_ENV='\(QEMUGPURuntimeEnvironment.backupRootKey)'"
+            )
+        )
+        let launcher = try source(named: "run-qemu-gpu.sh")
+        #expect(launcher.contains("backup_root=${OMARCHY_QEMU_GPU_BACKUP_ROOT:-}"))
+    }
+
     @Test("the default state root the launcher falls back to is still the documented one")
     func defaultStateRoot() throws {
         let library = try source(named: "qemu-persistent-storage.sh")

--- a/macos/Tests/OmarchyVMHelperTests/StorageLocationTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StorageLocationTests.swift
@@ -144,6 +144,48 @@ struct StorageLocationPolicyTests {
         #expect(resolution.stateRoot == container.path)
     }
 
+    @Test("a backup destination must be empty, not an existing workspace")
+    func backupRejectsExistingWorkspace() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+
+        #expect(throws: StorageLocationPolicyError.alreadyAWorkspace(container.path)) {
+            try StorageLocationPolicy.validateBackupDestination(
+                container.path,
+                currentStateRoot: nil,
+                probe: FakeVolumeProbe(result: volume())
+            )
+        }
+    }
+
+    @Test("a backup destination cannot be the live workspace")
+    func backupRejectsCurrentWorkspace() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+
+        #expect(throws: StorageLocationPolicyError.isCurrentWorkspace(container.path)) {
+            try StorageLocationPolicy.validateBackupDestination(
+                container.path,
+                currentStateRoot: container.path,
+                probe: FakeVolumeProbe(result: volume())
+            )
+        }
+    }
+
+    @Test("an empty APFS folder is accepted as a backup destination")
+    func backupAcceptsEmptyFolder() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+
+        let resolution = try StorageLocationPolicy.validateBackupDestination(
+            container.path,
+            currentStateRoot: "/private/tmp/other-workspace",
+            probe: FakeVolumeProbe(result: volume())
+        )
+        #expect(resolution.stateRoot == container.path)
+    }
+
     /// Each of these is a marker the launcher's `_qps_validate_root_marker`
     /// refuses. The picker must refuse them too, or it hands the user a folder
     /// that only fails once QEMU is already starting.

--- a/macos/Tests/qemu-persistent-storage.test.sh
+++ b/macos/Tests/qemu-persistent-storage.test.sh
@@ -730,4 +730,90 @@ export OMARCHY_QEMU_GPU_STATE_ROOT=$marker_root
 assert_fails _qps_prepare_state_root
 export OMARCHY_QEMU_GPU_STATE_ROOT=$saved_marker_state_root
 
+# Backup copies the live workspace into an empty folder with the same private
+# modes the launcher requires. Finder copies land the marker as 0644 and can
+# expand the sparse disk; this path must not.
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/backup-source"
+export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=0
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" ''
+backup_source_disk=$QEMU_SELECTED_DISK
+printf 'backup-user-data' | dd of="$backup_source_disk" bs=1 seek=256 conv=notrunc >/dev/null 2>&1
+qemu_persistent_storage_release_lock
+
+backup_dest="$test_root/backup-dest"
+mkdir "$backup_dest"
+chmod 755 "$backup_dest"
+qemu_persistent_storage_backup "$backup_dest"
+assert_eq "$QEMU_PERSISTENT_STORAGE_BACKUP_ROOT" "$(cd "$backup_dest" && pwd -P)"
+assert _qps_validate_root_marker "$backup_dest/.omarchy-qemu-storage"
+assert_eq "$(/usr/bin/stat -f '%Lp' "$backup_dest")" 700
+assert_eq "$(/usr/bin/stat -f '%Lp' "$backup_dest/disks")" 700
+assert_eq "$(/usr/bin/stat -f '%Lp' "$backup_dest/disks/current")" 700
+assert_eq "$(/usr/bin/stat -f '%Lp' "$backup_dest/disks/current/metadata.json")" 600
+assert_eq "$(/usr/bin/stat -f '%Lp' "$backup_dest/disks/current/rootfs.ext4")" 600
+assert_eq \
+  "$(dd if="$backup_dest/disks/current/rootfs.ext4" bs=1 skip=256 count=16 2>/dev/null)" \
+  backup-user-data
+assert cmp -s \
+  "$backup_source_disk" \
+  "$backup_dest/disks/current/rootfs.ext4"
+assert test \
+  "$(_qps_file_identity "$backup_source_disk")" != \
+  "$(_qps_file_identity "$backup_dest/disks/current/rootfs.ext4")"
+assert test ! -e "$backup_dest/locks"
+assert test ! -e "$backup_dest/images"
+assert_eq \
+  "$(dd if="$backup_source_disk" bs=1 skip=256 count=16 2>/dev/null)" \
+  backup-user-data
+
+# The copy is a workspace the launcher will actually boot, and it still holds
+# the user bytes after the original is reset.
+export OMARCHY_QEMU_GPU_STATE_ROOT=$backup_dest
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" ''
+assert_eq "$QEMU_SELECTED_DISK" "$backup_dest/disks/current/rootfs.ext4"
+assert_eq \
+  "$(dd if="$QEMU_SELECTED_DISK" bs=1 skip=256 count=16 2>/dev/null)" \
+  backup-user-data
+qemu_persistent_storage_release_lock
+
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/backup-source"
+qemu_persistent_storage_select \
+  reset "$identity_a" "$source_disk" "$source_sha" "$source_bytes" ''
+assert cmp -s "$QEMU_SELECTED_DISK" "$source_disk"
+qemu_persistent_storage_release_lock
+assert_eq \
+  "$(dd if="$backup_dest/disks/current/rootfs.ext4" bs=1 skip=256 count=16 2>/dev/null)" \
+  backup-user-data
+
+# Refusals: live workspace, existing workspace, nonempty folder, missing VM.
+assert_fails qemu_persistent_storage_backup "$test_root/backup-source"
+assert_fails qemu_persistent_storage_backup "$backup_dest"
+nonempty_dest="$test_root/backup-nonempty"
+mkdir "$nonempty_dest"
+printf 'notes\n' >"$nonempty_dest/notes.txt"
+assert_fails qemu_persistent_storage_backup "$nonempty_dest"
+assert test -f "$nonempty_dest/notes.txt"
+empty_workspace="$test_root/backup-empty-source"
+mkdir -p "$empty_workspace/disks" "$empty_workspace/images" "$empty_workspace/locks"
+chmod 700 "$empty_workspace" "$empty_workspace/disks" "$empty_workspace/images" \
+  "$empty_workspace/locks"
+_qps_write_root_marker "$empty_workspace/.omarchy-qemu-storage"
+export OMARCHY_QEMU_GPU_STATE_ROOT=$empty_workspace
+fresh_dest="$test_root/backup-fresh-dest"
+mkdir "$fresh_dest"
+assert_fails qemu_persistent_storage_backup "$fresh_dest"
+assert test ! -e "$fresh_dest/disks"
+assert test ! -e "$fresh_dest/.omarchy-qemu-storage"
+
+# A .DS_Store in the destination is still empty enough, matching the picker.
+finder_dest="$test_root/backup-finder-dest"
+mkdir "$finder_dest"
+: >"$finder_dest/.DS_Store"
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/backup-source"
+qemu_persistent_storage_backup "$finder_dest"
+assert _qps_validate_root_marker "$finder_dest/.omarchy-qemu-storage"
+assert test -f "$finder_dest/.DS_Store"
+
 printf 'qemu-persistent-storage.test: PASS\n'

--- a/macos/backup-qemu-storage.sh
+++ b/macos/backup-qemu-storage.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copy the saved Omarchy VM into an empty APFS folder.
+#
+# The copy is a valid workspace: the start menu can open it via VM Location.
+# Factory images are not copied; the matching Try Omarchy build rematerializes
+# them. Quit Try Omarchy first so the workspace lock is free.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: macos/backup-qemu-storage.sh DEST" >&2
+  echo "DEST must be an empty folder on a local APFS volume, or a path that can be created as one." >&2
+  exit 64
+}
+
+fail() {
+  echo "backup-qemu-storage: $*" >&2
+  exit 1
+}
+
+(( $# == 1 )) || usage
+dest=$1
+[[ $dest != *$'\n'* && $dest != *$'\r'* && -n $dest ]] || {
+  fail 'destination must be a single-line path'
+}
+if [[ $dest != /* ]]; then
+  dest="$PWD/$dest"
+fi
+
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+storage_library="$script_dir/qemu-persistent-storage.sh"
+[[ -f $storage_library && ! -L $storage_library ]] || {
+  fail "persistent-storage library is missing or unsafe: $storage_library"
+}
+
+if [[ ! -e $dest && ! -L $dest ]]; then
+  mkdir -p "$dest" || fail "cannot create backup destination: $dest"
+  chmod 700 "$dest" || fail "cannot protect backup destination: $dest"
+fi
+
+# shellcheck source=qemu-persistent-storage.sh
+source "$storage_library"
+qemu_persistent_storage_backup "$dest"
+echo "Backup complete: $QEMU_PERSISTENT_STORAGE_BACKUP_ROOT"

--- a/macos/qemu-persistent-storage.sh
+++ b/macos/qemu-persistent-storage.sh
@@ -17,6 +17,9 @@ QEMU_PERSISTENT_STORAGE_QEMU_ADD_FD='fd=9,set=77,opaque=omarchy-persistent-lock'
 QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS=78
 # Room the guest needs beyond whatever the workspace itself costs to create.
 QEMU_PERSISTENT_STORAGE_HEADROOM_BYTES=1073741824
+# Destination folder for `--backup-storage-only`. Kept byte-identical to
+# `QEMUGPURuntimeEnvironment.backupRootKey` in QEMUGPULauncher.swift.
+QEMU_PERSISTENT_STORAGE_BACKUP_ROOT_ENV='OMARCHY_QEMU_GPU_BACKUP_ROOT'
 
 QEMU_SELECTED_DISK=''
 QEMU_SELECTED_STORAGE_MODE=''
@@ -24,6 +27,7 @@ QEMU_PERSISTENT_STORAGE_DIRECTORY=''
 QEMU_PERSISTENT_STORAGE_IDENTITY=''
 QEMU_PERSISTENT_STORAGE_LOCK_PATH=''
 QEMU_PERSISTENT_STORAGE_WORKING_BYTES=''
+QEMU_PERSISTENT_STORAGE_BACKUP_ROOT=''
 QEMU_IMMUTABLE_SOURCE_DISK=''
 QPS_LEGACY_LOCK_PATH=''
 QPS_METADATA_SCHEMA=''
@@ -1378,4 +1382,314 @@ qemu_persistent_storage_select() {
       "$qps_mode" "$qps_identity" "$qps_source" "$qps_source_sha" \
       "$qps_source_bytes" "$qps_working_bytes"
   fi
+}
+
+_qps_allocated_bytes() {
+  local qps_blocks=''
+
+  qps_blocks=$(/usr/bin/stat -f '%b' "$1" 2>/dev/null) || return 1
+  [[ $qps_blocks =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$((qps_blocks * 512))"
+}
+
+# `df -P` puts the mount point in field 6 onward, so a volume named
+# "My Disk" is recovered by joining the remainder of the line.
+_qps_volume_mount_point() {
+  local qps_path=$1
+
+  /bin/df -P "$qps_path" 2>/dev/null | awk 'NR == 2 {
+    mount = $6
+    for (i = 7; i <= NF; i++) mount = mount " " $i
+    print mount
+  }'
+}
+
+_qps_is_volume_root() {
+  local qps_path=$1
+  local qps_mount=''
+
+  qps_mount=$(_qps_volume_mount_point "$qps_path")
+  [[ -n $qps_mount && $qps_path == "$qps_mount" ]]
+}
+
+# Finder-owned entries that do not count as real content when deciding whether
+# a picked folder is empty enough to receive a backup. Kept in agreement with
+# `StorageLocationPolicy.ignorableEntries`.
+_qps_directory_is_effectively_empty() {
+  local qps_directory=$1
+  local qps_entry=''
+
+  shopt -s nullglob dotglob
+  for qps_entry in "$qps_directory"/*; do
+    case ${qps_entry##*/} in
+      .DS_Store|.localized|'Icon'$'\r') ;;
+      *)
+        shopt -u nullglob dotglob
+        return 1
+        ;;
+    esac
+  done
+  shopt -u nullglob dotglob
+  return 0
+}
+
+# Resolve the live workspace without creating one. Backup must not initialize
+# an empty Application Support folder just to report that there is nothing in
+# it.
+_qps_open_existing_state_root() {
+  local qps_configured_root=''
+  local qps_root=''
+  local qps_marker=''
+  local qps_child=''
+
+  if [[ -n ${OMARCHY_QEMU_GPU_STATE_ROOT:-} ]]; then
+    qps_configured_root=$OMARCHY_QEMU_GPU_STATE_ROOT
+  else
+    [[ -n ${HOME:-} ]] || {
+      _qps_fail 'HOME is unavailable; cannot locate Application Support'
+      return 1
+    }
+    qps_configured_root="$HOME/Library/Application Support/Try Omarchy/VM/v1"
+  fi
+  _qps_assert_safe_root_path "$qps_configured_root" || return 1
+  [[ -d $qps_configured_root && ! -L $qps_configured_root ]] || {
+    _qps_fail "there is no saved Omarchy VM to back up at $qps_configured_root"
+    return 1
+  }
+  _qps_assert_volume_supported "$qps_configured_root" || return 1
+  _qps_assert_private_directory "$qps_configured_root" 'state root' || return 1
+  qps_root=$(cd "$qps_configured_root" && pwd -P) || {
+    _qps_fail "cannot resolve state root: $qps_configured_root"
+    return 1
+  }
+  _qps_assert_safe_root_path "$qps_root" || return 1
+
+  qps_marker="$qps_root/.omarchy-qemu-storage"
+  _qps_validate_root_marker "$qps_marker" || return 1
+  for qps_child in disks images locks; do
+    _qps_assert_private_directory "$qps_root/$qps_child" "state $qps_child directory" || return 1
+  done
+
+  QEMU_PERSISTENT_STORAGE_ROOT=$qps_root
+  QEMU_PERSISTENT_STORAGE_DISKS_ROOT="$qps_root/disks"
+  QEMU_PERSISTENT_STORAGE_IMAGES_ROOT="$qps_root/images"
+  QEMU_PERSISTENT_STORAGE_LOCKS_ROOT="$qps_root/locks"
+}
+
+_qps_prepare_backup_destination() {
+  local qps_dest=$1
+  local qps_resolved=''
+
+  QEMU_PERSISTENT_STORAGE_BACKUP_ROOT=''
+  _qps_assert_safe_root_path "$qps_dest" || return 1
+  [[ -d $qps_dest && ! -L $qps_dest ]] || {
+    _qps_fail "backup destination is not a direct directory: $qps_dest"
+    return 1
+  }
+  [[ $(_qps_lstat_kind "$qps_dest") == Directory ]] || {
+    _qps_fail "backup destination has an unsafe file type: $qps_dest"
+    return 1
+  }
+  [[ $(_qps_owner "$qps_dest") == $(id -u) ]] || {
+    _qps_fail "backup destination is not owned by the current user: $qps_dest"
+    return 1
+  }
+  qps_resolved=$(cd "$qps_dest" && pwd -P) || {
+    _qps_fail "cannot resolve backup destination: $qps_dest"
+    return 1
+  }
+  _qps_assert_safe_root_path "$qps_resolved" || return 1
+  [[ $qps_resolved != "$QEMU_PERSISTENT_STORAGE_ROOT" ]] || {
+    _qps_fail 'backup destination cannot be the live Omarchy workspace'
+    return 1
+  }
+  if _qps_is_volume_root "$qps_resolved"; then
+    _qps_fail "choose a folder inside $qps_resolved, not the drive itself"
+    return 1
+  fi
+  _qps_assert_volume_supported "$qps_resolved" || return 1
+  if [[ -e $qps_resolved/.omarchy-qemu-storage || -L $qps_resolved/.omarchy-qemu-storage ]]; then
+    _qps_fail "backup destination is already an Omarchy workspace: $qps_resolved"
+    return 1
+  fi
+  _qps_directory_is_effectively_empty "$qps_resolved" || {
+    _qps_fail "backup destination already has files in it: $qps_resolved"
+    return 1
+  }
+  chmod 700 "$qps_resolved" 2>/dev/null
+  _qps_assert_private_directory "$qps_resolved" 'backup destination' || return 1
+  QEMU_PERSISTENT_STORAGE_BACKUP_ROOT=$qps_resolved
+}
+
+_qps_backup_cleanup_destination() {
+  local qps_dest=$1
+
+  [[ -n $qps_dest ]] || return 0
+  /bin/rm -rf \
+    "$qps_dest/disks" \
+    "$qps_dest/images" \
+    "$qps_dest/locks" \
+    "$qps_dest/.omarchy-qemu-storage"
+}
+
+_qps_collect_backup_stores() {
+  local qps_candidate=''
+  local qps_name=''
+
+  QPS_BACKUP_STORES=()
+  if [[ -d $QEMU_PERSISTENT_STORAGE_DISKS_ROOT/current && \
+        ! -L $QEMU_PERSISTENT_STORAGE_DISKS_ROOT/current ]] && \
+    _qps_validate_recorded_workspace "$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/current"; then
+    QPS_BACKUP_STORES+=("$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/current")
+  fi
+  for qps_candidate in "$QEMU_PERSISTENT_STORAGE_DISKS_ROOT"/*; do
+    [[ -d $qps_candidate && ! -L $qps_candidate ]] || continue
+    qps_name=${qps_candidate##*/}
+    [[ $qps_name == current ]] && continue
+    [[ $qps_name =~ ^[0-9a-f]{64}$ ]] || continue
+    if _qps_validate_recorded_workspace "$qps_candidate" && \
+      [[ $QPS_METADATA_IDENTITY == "$qps_name" ]]; then
+      QPS_BACKUP_STORES+=("$qps_candidate")
+    else
+      _qps_error "leaving unrecognized workspace untouched during backup: $qps_name"
+    fi
+  done
+}
+
+_qps_backup_store() {
+  local qps_source=$1
+  local qps_dest=$2
+  local qps_existing_bytes=''
+  local qps_identity=''
+  local qps_schema=''
+  local qps_source_sha=''
+  local qps_source_bytes=''
+
+  _qps_validate_recorded_workspace "$qps_source" || return 1
+  qps_existing_bytes=$QPS_RECORDED_EXISTING_BYTES
+  qps_identity=$QPS_METADATA_IDENTITY
+  qps_schema=$QPS_METADATA_SCHEMA
+  qps_source_sha=$QPS_METADATA_SOURCE_SHA
+  qps_source_bytes=$QPS_METADATA_SOURCE_BYTES
+
+  mkdir "$qps_dest" || {
+    _qps_fail "cannot create backup store directory: $qps_dest"
+    return 1
+  }
+  chmod 700 "$qps_dest" || return 1
+  _qps_assert_private_directory "$qps_dest" 'backup store directory' || return 1
+  /bin/cp "$qps_source/metadata.json" "$qps_dest/metadata.json" || {
+    _qps_fail 'cannot copy persistent-disk metadata'
+    return 1
+  }
+  chmod 600 "$qps_dest/metadata.json" || return 1
+  if ! _qps_clone_disk "$qps_source/rootfs.ext4" "$qps_dest/rootfs.ext4" "$qps_existing_bytes"; then
+    return 1
+  fi
+  _qps_validate_store_directory \
+    "$qps_dest" "$qps_identity" "$qps_source_sha" "$qps_source_bytes" \
+    "$qps_existing_bytes" 0 "$qps_schema"
+}
+
+# Copy every recognized persistent disk into an empty APFS folder.
+#
+# The destination becomes a valid workspace: choosing it as VM Location boots
+# the same disk. Factory images under images/ are not copied — the matching
+# Try Omarchy build rematerializes them. Locks are not copied. Finder copies
+# are not a substitute: they expand the sparse working disk and land the
+# 0600 marker as 0644, which the launcher then refuses.
+#
+# Arguments:
+#   1. absolute path of an empty directory on a local APFS volume
+qemu_persistent_storage_backup() {
+  local qps_dest=${1:-}
+  local qps_store=''
+  local qps_name=''
+  local qps_disks=''
+  local qps_required=$QEMU_PERSISTENT_STORAGE_HEADROOM_BYTES
+  local qps_allocated=0
+  local qps_file_allocated=''
+  local qps_source_device=''
+  local qps_dest_device=''
+  local qps_status=0
+
+  QPS_BACKUP_STORES=()
+  [[ -n $qps_dest ]] || {
+    _qps_fail 'backup destination is required'
+    return 1
+  }
+
+  _qps_open_existing_state_root || return 1
+  _qps_prepare_backup_destination "$qps_dest" || return 1
+  qps_dest=$QEMU_PERSISTENT_STORAGE_BACKUP_ROOT
+
+  _qps_acquire_lock current || return 1
+
+  _qps_collect_backup_stores
+  if (( ${#QPS_BACKUP_STORES[@]} == 0 )); then
+    qemu_persistent_storage_release_lock
+    _qps_fail 'there is no saved Omarchy VM to back up'
+    return 1
+  fi
+
+  qps_source_device=$(_qps_file_identity "$QEMU_PERSISTENT_STORAGE_ROOT" | sed 's/:.*//')
+  qps_dest_device=$(_qps_file_identity "$qps_dest" | sed 's/:.*//')
+  if [[ $qps_source_device != "$qps_dest_device" ]]; then
+    for qps_store in "${QPS_BACKUP_STORES[@]}"; do
+      qps_file_allocated=$(_qps_allocated_bytes "$qps_store/rootfs.ext4") || {
+        qemu_persistent_storage_release_lock
+        _qps_fail "cannot measure $qps_store/rootfs.ext4"
+        return 1
+      }
+      qps_allocated=$((qps_allocated + qps_file_allocated))
+    done
+    qps_required=$((qps_allocated + QEMU_PERSISTENT_STORAGE_HEADROOM_BYTES))
+  fi
+  if ! _qps_assert_free_space "$qps_dest" "$qps_required"; then
+    qemu_persistent_storage_release_lock
+    return 1
+  fi
+
+  qps_disks="$qps_dest/disks"
+  if ! mkdir "$qps_disks" || ! chmod 700 "$qps_disks"; then
+    qemu_persistent_storage_release_lock
+    _qps_backup_cleanup_destination "$qps_dest"
+    _qps_fail "cannot create backup disks directory: $qps_disks"
+    return 1
+  fi
+
+  for qps_store in "${QPS_BACKUP_STORES[@]}"; do
+    qps_name=${qps_store##*/}
+    if [[ $qps_name != current ]]; then
+      if ! _qps_acquire_legacy_lock "$qps_name"; then
+        qemu_persistent_storage_release_lock
+        _qps_backup_cleanup_destination "$qps_dest"
+        return 1
+      fi
+    fi
+    if ! _qps_backup_store "$qps_store" "$qps_disks/$qps_name"; then
+      qps_status=$?
+      if [[ $qps_name != current ]]; then
+        _qps_release_legacy_lock
+      fi
+      qemu_persistent_storage_release_lock
+      _qps_backup_cleanup_destination "$qps_dest"
+      return "$qps_status"
+    fi
+    if [[ $qps_name != current ]]; then
+      _qps_release_legacy_lock
+    fi
+  done
+
+  if ! _qps_write_root_marker "$qps_dest/.omarchy-qemu-storage" || \
+    ! _qps_validate_root_marker "$qps_dest/.omarchy-qemu-storage" || \
+    ! _qps_fsync "$qps_dest"; then
+    qemu_persistent_storage_release_lock
+    _qps_backup_cleanup_destination "$qps_dest"
+    _qps_fail "cannot finish the backup at $qps_dest"
+    return 1
+  fi
+
+  qemu_persistent_storage_release_lock
+  _qps_error "backed up the Omarchy VM to $qps_dest"
 }

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: macos/run-qemu-gpu.sh [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR]" >&2
+  echo "Usage: macos/run-qemu-gpu.sh [--ephemeral | --reset-storage | --reset-storage-only | --backup-storage-only] [GUEST_DIR]" >&2
   exit 64
 }
 
@@ -26,6 +26,10 @@ case ${1:-} in
   --reset-storage-only)
     storage_mode=reset
     reset_only=1
+    shift
+    ;;
+  --backup-storage-only)
+    storage_mode=backup
     shift
     ;;
   --*) usage ;;
@@ -784,6 +788,15 @@ fi
 # a build-time path and exits without sourcing any shell library.
 # shellcheck source=qemu-persistent-storage.sh
 source "$storage_library"
+
+if [[ $storage_mode == backup ]]; then
+  backup_root=${OMARCHY_QEMU_GPU_BACKUP_ROOT:-}
+  [[ -n $backup_root ]] || fail "$QEMU_PERSISTENT_STORAGE_BACKUP_ROOT_ENV is required for --backup-storage-only"
+  qemu_persistent_storage_backup "$backup_root" || fail "could not back up the Omarchy VM"
+  echo "[qemu-gpu] Backup complete." >&2
+  exit 0
+fi
+
 # shellcheck source=qemu-port-forwarding.sh
 source "$port_forwarding_library"
 


### PR DESCRIPTION
## Why

A new Try Omarchy guest build still cannot boot an existing disk. Reset is required, and the v0.2.0 notes already warn that `v0.1.0` disks are not migrated. Copying `~/Library/Application Support/Try Omarchy/VM/v1` in Finder is the wrong workaround: the working disk is a sparse ~24 GB file that Finder can inflate, and the 0600 workspace marker lands as 0644, which the launcher then refuses.

## What

- **Backup…** on the start menu copies recognized persistent disks into an empty APFS folder with `cp -c`, keeping sparse allocation and the 0700/0600 modes the launcher requires.
- The destination is a valid workspace for the **same** guest identity (choose it later as VM Location). It is not a migration onto a newer factory image.
- `make backup DEST=/path/to/empty/folder` does the same copy without rebuilding the app.
- Reset / incompatible-guest alerts tell you to back up first.
- README documents the two real update paths: export files (shared folder or SSH) for a new guest, or keep the whole VM for rollback to the matching app version.

Factory images under `images/` are not copied; the matching build rematerializes them.

## Tests

- `macos/Tests/qemu-persistent-storage.test.sh`
- Swift suites for launch flags, backup destination policy, and the start menu
- `macos/Tests/run-qemu-ssh-contract.test.sh`