### PR TITLE
Preserve older VM disks across app updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,31 @@ the same Mac; guest SSH authentication is still required.
 
 ## Data and updates
 
-Normal launches keep one persistent VM under `~/Library/Application Support/Try Omarchy/VM/v1`. Removing the app does not remove this data. The start menu can reset it, and requires confirmation before replacing a disk that is incompatible with a new factory guest build.
+Normal launches keep one persistent VM under
+`~/Library/Application Support/Try Omarchy/VM/v1`. Removing or updating the app
+does not remove or replace this data. An existing VM keeps both its writable
+disk and the exact kernel, initramfs, and base command line that were paired
+with that disk. A newer app's bundled factory image is used only to create a
+new VM, after a confirmed **Reset Omarchy**, or for an ephemeral launch.
+
+VMs created before paired boot files were introduced are preserved too. On the
+first launch that needs them, Try Omarchy explains the transition in a
+**Continue** / **Cancel** dialog before starting recovery. Continue performs a
+one-time recovery boot: it mounts the saved disk read-only, copies the installed
+kernel and initramfs from `/boot` into private VM storage, validates them, and
+then shuts the recovery boot down. It does not start the saved userspace with
+the newer app's kernel, reset the VM, or upgrade Omarchy. Cancel returns to the
+start menu. Reset is still required when the saved storage or boot format
+itself cannot be safely read.
+
+Use Omarchy's built-in updater for the updates it supports inside this ARM
+guest. Ordinary guest packages can advance without replacing the VM, but Try
+Omarchy currently pins its direct-boot kernel and headers, packaged
+`try-omarchy-runtime`, and reviewed compatibility backports in a prioritized
+local repository. Installing a newer Try Omarchy app therefore does not apply
+all of that app's factory-image changes to an existing VM, and an in-guest
+update should not be assumed to reproduce them. A confirmed reset is the
+deliberate, destructive way to start again from the newest bundled factory.
 
 ### Choosing where the VM lives
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,11 @@ graphics, audio, keyboard, and pointer devices. Because both the Mac and the
 guest are ARM64, Apple Hypervisor Framework runs the guest CPU instructions on
 the Apple Silicon processor. QEMU provides the virtual devices around that CPU.
 
-Linux then boots normally from the bundled kernel and disk, and Omarchy runs
-inside Linux. Graphics travel from Linux through virtio-gpu and VirGL to the
+Linux then boots from the selected VM disk and its paired kernel and initramfs,
+and Omarchy runs inside Linux. For a new, reset, or ephemeral VM, that pair and
+the disk originate in the current app's bundled factory. An existing persistent
+VM instead keeps the boot pair created with its disk, even after the app bundle
+is updated. Graphics travel from Linux through virtio-gpu and VirGL to the
 native Cocoa window. Storage, networking, audio, and input use their matching
 QEMU virtual devices and host backends.
 
@@ -116,15 +119,38 @@ creates the account on first boot.
 
 Nothing is overwritten while the app runs. The app bundle and packaged factory
 disk remain unchanged. Normal user launches use one private writable disk under
-`~/Library/Application Support/Try Omarchy/VM/v1`. Its factory-image identity is immutable:
-the launcher never pairs a saved root filesystem with a different bundled kernel
-or initramfs. When a guest build changes, the start menu asks for an explicitly
-confirmed factory reset before creating the replacement disk. A compatible
+`~/Library/Application Support/Try Omarchy/VM/v1`. The disk metadata retains
+the identity of the factory that created it, and `boot/<identity>/` retains a
+validated copy of that VM's kernel, initramfs, and base command line. Normal
+launch selects those saved boot files instead of combining an older root
+filesystem with a newer bundled kernel. Consequently, a new app release can
+launch the existing VM without decompressing, cloning, expanding, or charging
+free space for its new factory disk.
+
+The current bundled factory applies only when no persistent VM exists, after an
+explicitly confirmed reset, or in ephemeral mode. New and reset VMs atomically
+stage the current factory's boot kit with the new writable disk. A compatible
 legacy identity-keyed disk can be migrated into the single workspace without
-discarding its contents. If several recognized legacy disks exist, normal launch
-stops at the start menu; confirmed reset safely removes them before publishing
-one fresh workspace. Unrecognized host files are always left untouched.
-Ephemeral mode uses a disposable disk.
+discarding its contents. If several recognized legacy disks exist, normal
+launch stops at the start menu; confirmed reset safely removes them before
+publishing one fresh workspace. Unrecognized host files are always left
+untouched.
+
+Older schema-2 VMs predate saved boot kits. Their first preserving launch uses
+an authoritative two-pass consent handshake. The storage launcher selects and
+locks the old disk, notices the missing kit, and exits before QEMU starts. The
+Mac app explains the preserving transition and offers **Cancel** or
+**Continue**; only Continue retries with a one-launch recovery authorization.
+Inherited environment values are stripped so they cannot bypass this dialog.
+The authorized retry uses the current factory initramfs in a narrowly scoped
+recovery mode: the old root disk is attached read-only, its installed
+`/boot/Image` and
+`/boot/initramfs-linux.img` are exported over a private virtio-9p share, and the
+recovery environment powers off without switching into the old userspace. The
+host accepts the pair only after validating its type, size, hashes, ownership,
+and boot ABI, then stores it atomically for subsequent launches. Cancel does
+not start recovery, reset the VM, or alter its disk contents. Unsupported
+storage or boot ABIs still require a confirmed reset.
 
 The workspace does not have to live in Application Support. The start menu can
 put it in any folder the user picks, including one on an external drive, and the
@@ -152,13 +178,26 @@ unrecognized host files stay untouched, as everywhere else here.
 
 ## Trust model
 
-The app validates the exact guest file set, JSON schemas, hashes, sizes, pinned
-upstream identity, runtime contract, kernel command line, architecture, and
-factory profile before QEMU starts. Guest provenance separates verbatim runtime
-trees from backported trees and records each reviewed patch with its input and
-output hashes. The app also verifies the app signature and required QEMU
-features. Updates to a pinned dependency should update its digest, contract
-tests, notices, and review evidence together.
+The app validates the bundled factory's exact file set, JSON schemas, hashes,
+sizes, pinned upstream identity, runtime contract, kernel command line,
+architecture, and factory profile. For an existing VM it independently
+validates the saved boot kit's ABI, metadata, ownership, sizes, and hashes
+before QEMU starts. Guest provenance separates verbatim runtime trees from
+backported trees and records each reviewed patch with its input and output
+hashes. The app also verifies the app signature and required QEMU features.
+Updates to a pinned dependency should update its digest, contract tests,
+notices, and review evidence together.
+
+App releases and guest updates are deliberately separate channels. Omarchy's
+built-in updater may advance ordinary packages supported by this ARM guest,
+but the direct-boot kernel and matching headers, the packaged
+`try-omarchy-runtime`, and reviewed compatibility backports remain pinned in
+Try Omarchy's prioritized local repository. Reusing a disk therefore does not
+silently import a newer app's factory contents, and running the in-guest updater
+must not be described as reproducing every factory-image change. Delivering
+new Try Omarchy runtime or backport revisions to existing disks requires an
+explicitly designed in-guest migration channel; today a factory reset is the
+way to opt into the complete new factory.
 
 Optional, user-initiated installers run after the factory image has been built
 and are a separate trust boundary. They may resolve a mutable current release

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -52,11 +52,29 @@ make release \
    restart preserves the persistent VM, and the documented endpoint-specific
    host-key recovery works after Reset/ephemeral replacement. Inspect the
    factory image to confirm it contains no SSH host private keys.
-4. Verify the app and DMG signatures with Apple's tools and confirm notarization.
-5. Audit `THIRD_PARTY_NOTICES.md`, the bundle's license material, the guest
+4. Install the release over a provisioned VM created by a different guest
+   build. Confirm launch preserves its disk and user data, selects the saved
+   boot kit instead of the release's bundled kernel/initramfs, and does not
+   materialize or charge free space for the new factory disk. For a schema-2 VM
+   without a boot kit, confirm the one-time read-only `/boot` export completes,
+   but only after the pre-launch dialog appears. Confirm **Cancel** starts no
+   QEMU process and changes no disk contents; confirm **Continue** performs the
+   recovery, the environment powers off without entering the old userspace,
+   and later launches do not repeat it. Separately confirm that new, reset, and
+   ephemeral VMs use the current factory.
+5. Verify the app and DMG signatures with Apple's tools and confirm notarization.
+6. Audit `THIRD_PARTY_NOTICES.md`, the bundle's license material, the guest
    package lock, and QEMU corresponding-source obligations.
-6. Record SHA-256 digests for the final app archive/DMG and publish them with the
+7. State in release notes that installing the app preserves existing VM
+   contents. Do not claim that the built-in updater reproduces factory changes:
+   the direct-boot kernel and headers, `try-omarchy-runtime`, and reviewed
+   backports remain pinned until an explicit in-guest migration channel exists.
+8. Record SHA-256 digests for the final app archive/DMG and publish them with the
    release notes.
 
 Never publish generated artifacts from an unreviewed or locally modified build
 input.
+
+The saved boot-kit ABI is a compatibility boundary. Do not change it or remove
+support for an existing value without a reviewed preserving migration or an
+explicitly confirmed reset path.

--- a/guest/README.md
+++ b/guest/README.md
@@ -39,13 +39,28 @@ When updating Hyprland, first test the unpatched package through the same
 Virtio/VirGL guest path. Remove the local patch and package hold if upstream is
 clean; otherwise rebase the patch and update every source, patch, toolchain,
 binary, package, and launcher identity together. In either case, run the full
-tests and verify a fresh factory image rather than updating a persistent VM in
-place.
+tests and verify the newly built factory artifact. Installing a new app does
+not rewrite existing persistent VMs, so they are not evidence that the new
+factory contents are correct.
 
 The output includes the kernel, initramfs, raw and compressed ext4 image,
 provenance, package inventory, licenses, manifest, and SHA-256 sums. Generated
 output belongs under the repository's ignored `dist/` directory and must not be
 committed.
+
+The factory is a seed, not an update payload. A new or reset persistent VM and
+every ephemeral VM use the current output. An existing persistent VM keeps its
+writable disk and a validated copy of the kernel and initramfs originally paired
+with that disk, so a later app release does not replace its guest files. VMs
+from before paired boot kits are migrated once by a recovery initramfs that
+reads their `/boot` directory with the root disk mounted read-only.
+
+Omarchy's built-in updater remains available for updates supported by this ARM
+guest, but it is not equivalent to installing a new Try Omarchy factory. The
+direct-boot kernel and matching headers are held, while the packaged
+`try-omarchy-runtime` and reviewed backports resolve from the immutable local
+repository. A separate migration channel is required before those
+Try-Omarchy-specific revisions can advance on an existing disk without reset.
 
 OpenSSH is an explicit factory package. A systemd generator requests the vendor
 `sshd.service` only for a boot carrying the exact
@@ -55,6 +70,6 @@ systemd's runtime generator directory; it does not enable sshd persistently or
 change authentication policy under `/etc`.
 
 The vendor service generates missing host keys on the writable guest disk. A
-compatible persistent VM therefore keeps its identity across restarts, while a
-Factory Reset or a fresh ephemeral VM gets a new identity. The factory image
-must never contain shared SSH host private keys.
+persistent VM therefore keeps its identity across restarts and app updates,
+while a Factory Reset or a fresh ephemeral VM gets a new identity. The factory
+image must never contain shared SSH host private keys.

--- a/guest/factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf
+++ b/guest/factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf
@@ -2,5 +2,5 @@
 MODULES=(virtio_pci virtio_mmio virtio_blk virtio_gpu virtio_input virtio_console virtio_rng virtio_net usbhid hid_generic)
 BINARIES=()
 FILES=()
-HOOKS=(base udev modconf kms keyboard keymap consolefont block filesystems fsck)
-COMPRESSION="cat"  # run-qemu-gpu.sh requires a raw mkinitcpio newc archive (070701/070702 magic); zstd broke that check and saved <0.1% anyway since modules are already .ko.zst
+HOOKS=(base udev modconf kms keyboard keymap consolefont block filesystems fsck try-omarchy-boot-export)
+COMPRESSION="cat"  # Keep current bundles as a directly inspectable newc archive; compression saved <0.1% because modules are already .ko.zst (the launcher also accepts legacy zstd initramfs files)

--- a/guest/native-overlay/usr/lib/initcpio/hooks/try-omarchy-boot-export
+++ b/guest/native-overlay/usr/lib/initcpio/hooks/try-omarchy-boot-export
@@ -1,0 +1,138 @@
+#!/usr/bin/ash
+
+try_omarchy_boot_export_requested() (
+  command_line=""
+  IFS= read -r command_line </proc/cmdline || exit 1
+
+  # Kernel options are whitespace-separated. Disable pathname expansion so a
+  # malformed option can never turn into an initramfs filename.
+  set -f
+  for argument in $command_line; do
+    [ "$argument" = tryomarchy.export_boot=1 ] && exit 0
+  done
+  exit 1
+)
+
+try_omarchy_boot_export_poweroff() {
+  err "$1"
+  poweroff -f
+  # poweroff only returns if the shutdown failed. Do not let the recovery boot
+  # pivot into the installed userspace in that case.
+  return 1
+}
+
+try_omarchy_boot_export_size_is_safe() (
+  source_path=$1
+  minimum_bytes=$2
+  maximum_bytes=$3
+  source_bytes=$(/usr/bin/stat -c '%s' -- "$source_path") || exit 1
+  case "$source_bytes" in
+    ''|*[!0-9]*) exit 1 ;;
+  esac
+  [ "$source_bytes" -ge "$minimum_bytes" ] \
+    && [ "$source_bytes" -le "$maximum_bytes" ]
+)
+
+run_latehook() {
+  try_omarchy_boot_export_requested || return 0
+
+  # mkinitcpio's base init mounts the selected root filesystem at /new_root
+  # before late hooks run.
+  old_root=/new_root
+  boot_directory=$old_root/boot
+  kernel_source=$boot_directory/Image
+  initramfs_source=$boot_directory/initramfs-linux.img
+  build_spec_source=$old_root/usr/share/try-omarchy/build-spec.json
+  export_mount=/run/try-omarchy-boot-export
+  export_tag=try-omarchy-boot-export
+  if [ ! -d "$old_root" ] || [ -L "$old_root" ] \
+    || [ ! -d "$boot_directory" ] || [ -L "$boot_directory" ] \
+    || [ ! -f "$kernel_source" ] || [ -L "$kernel_source" ] || [ ! -s "$kernel_source" ] \
+    || [ ! -f "$initramfs_source" ] || [ -L "$initramfs_source" ] || [ ! -s "$initramfs_source" ] \
+    || [ ! -f "$build_spec_source" ] || [ -L "$build_spec_source" ] || [ ! -s "$build_spec_source" ]; then
+    try_omarchy_boot_export_poweroff "Try Omarchy boot export source is invalid"
+    return 1
+  fi
+  # Enforce host staging limits before exposing the 9p destination. The old
+  # root filesystem is mounted read-only, so these checked sizes cannot change
+  # underneath the copies.
+  if ! try_omarchy_boot_export_size_is_safe "$kernel_source" 60 536870912 \
+    || ! try_omarchy_boot_export_size_is_safe "$initramfs_source" 6 1073741824 \
+    || ! try_omarchy_boot_export_size_is_safe "$build_spec_source" 1 1048576; then
+    try_omarchy_boot_export_poweroff "Try Omarchy boot export source size is invalid"
+    return 1
+  fi
+
+  if { [ -e "$export_mount" ] || [ -L "$export_mount" ]; } \
+    && { [ ! -d "$export_mount" ] || [ -L "$export_mount" ]; }; then
+    try_omarchy_boot_export_poweroff "Try Omarchy boot export mount point is unsafe"
+    return 1
+  fi
+  mkdir -p "$export_mount" || {
+    try_omarchy_boot_export_poweroff "Could not create the Try Omarchy boot export mount point"
+    return 1
+  }
+  mount -t 9p \
+    -o trans=virtio,version=9p2000.L,msize=1048576,cache=none,nosuid,nodev,noexec \
+    "$export_tag" "$export_mount" || {
+      try_omarchy_boot_export_poweroff "Could not mount the Try Omarchy boot export share"
+      return 1
+    }
+  kernel_temporary=$export_mount/.kernel.tmp
+  initramfs_temporary=$export_mount/.initramfs.tmp
+  build_spec_temporary=$export_mount/.build-spec.json.tmp
+  complete_temporary=$export_mount/.complete.tmp
+  export_failed=0
+  rm -f \
+    "$export_mount/complete" \
+    "$kernel_temporary" \
+    "$initramfs_temporary" \
+    "$build_spec_temporary" \
+    "$complete_temporary" || export_failed=1
+  cp "$kernel_source" "$kernel_temporary" || export_failed=1
+  cp "$initramfs_source" "$initramfs_temporary" || export_failed=1
+  cp "$build_spec_source" "$build_spec_temporary" || export_failed=1
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    sync || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    mv -f "$kernel_temporary" "$export_mount/kernel" || export_failed=1
+    mv -f "$initramfs_temporary" "$export_mount/initramfs" || export_failed=1
+    mv -f "$build_spec_temporary" "$export_mount/build-spec.json" || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    sync || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    printf '%s\n' try-omarchy-boot-export-v1 >"$complete_temporary" || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    sync || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    mv -f "$complete_temporary" "$export_mount/complete" || export_failed=1
+  fi
+  if [ "${export_failed:-0}" -eq 0 ]; then
+    sync || export_failed=1
+  fi
+
+  if [ "${export_failed:-0}" -ne 0 ]; then
+    rm -f "$export_mount/complete" "$complete_temporary" 2>/dev/null || true
+    sync 2>/dev/null || true
+    umount "$export_mount" 2>/dev/null || true
+    try_omarchy_boot_export_poweroff "Try Omarchy boot export failed"
+    return 1
+  fi
+
+  if ! umount "$export_mount"; then
+    # The marker is the launcher's only success signal. Withdraw it while the
+    # share is still mounted if teardown fails, then stop this recovery boot.
+    rm -f "$export_mount/complete" 2>/dev/null || true
+    sync 2>/dev/null || true
+    try_omarchy_boot_export_poweroff "Could not unmount the Try Omarchy boot export share"
+    return 1
+  fi
+  poweroff -f
+  # As above, continuing the recovery boot is never safe if poweroff returns.
+  return 1
+}

--- a/guest/native-overlay/usr/lib/initcpio/install/try-omarchy-boot-export
+++ b/guest/native-overlay/usr/lib/initcpio/install/try-omarchy-boot-export
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+build() {
+  add_module 9p
+  add_module 9pnet
+  add_module 9pnet_virtio
+  add_runscript
+
+  for binary in cp mkdir mv rm stat sync; do
+    add_binary "/usr/bin/$binary"
+  done
+}
+
+help() {
+  cat <<'EOF'
+Export the installed kernel, initramfs, and recorded boot configuration to the
+launcher-owned 9p share when tryomarchy.export_boot=1 is present on the kernel
+command line.
+EOF
+}

--- a/guest/pacman.aarch64.conf
+++ b/guest/pacman.aarch64.conf
@@ -7,12 +7,11 @@ Color
 ILoveCandy
 VerbosePkgLists
 HoldPkg = pacman glibc
-# QEMU direct-boots the factory-bound kernel and initramfs beside the guest
-# disk. Keep the installed modules on that exact ABI; a different guest build
-# requires a fresh factory VM instead of an in-place kernel update. Hyprland is
-# likewise held until upstream includes our rounded-border coverage backport;
-# otherwise a routine full-system update can silently restore the defect.
-IgnorePkg = linux-aarch64 hyprland
+# QEMU direct-boots the kernel and initramfs paired with this VM disk. Keep its
+# installed modules and DKMS headers on that exact ABI. Hyprland is likewise
+# held until upstream includes our rounded-border coverage backport; otherwise
+# a routine full-system update can silently restore the defect.
+IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland
 Architecture = auto
 CheckSpace
 ParallelDownloads = 5

--- a/guest/tests/test_boot_export.py
+++ b/guest/tests/test_boot_export.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Isolated contracts for the one-time initramfs boot export."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+GUEST = Path(__file__).resolve().parents[1]
+INSTALL_HOOK = (
+    GUEST
+    / "native-overlay/usr/lib/initcpio/install/try-omarchy-boot-export"
+)
+RUNTIME_HOOK = (
+    GUEST
+    / "native-overlay/usr/lib/initcpio/hooks/try-omarchy-boot-export"
+)
+MKINITCPIO_CONFIG = (
+    GUEST / "factory-overlay/etc/mkinitcpio.conf.d/90-try-omarchy.conf"
+)
+
+
+class BootExportStaticTests(unittest.TestCase):
+    def test_install_hook_adds_only_the_needed_runtime(self) -> None:
+        source = INSTALL_HOOK.read_text(encoding="utf-8")
+        self.assertTrue(INSTALL_HOOK.stat().st_mode & stat.S_IXUSR)
+        self.assertIn("add_runscript", source)
+        for module in ("9p", "9pnet", "9pnet_virtio"):
+            self.assertIn(f"add_module {module}\n", source)
+        for binary in ("cp", "mkdir", "mv", "rm", "stat", "sync"):
+            self.assertIn(binary, source)
+
+    def test_runtime_hook_is_enabled_in_the_factory_initramfs(self) -> None:
+        config = MKINITCPIO_CONFIG.read_text(encoding="utf-8")
+        self.assertEqual(config.count("try-omarchy-boot-export"), 1)
+        self.assertIn("fsck try-omarchy-boot-export)", config)
+        self.assertTrue(RUNTIME_HOOK.stat().st_mode & stat.S_IXUSR)
+
+    def test_runtime_hook_reads_the_root_mounted_by_mkinitcpio(self) -> None:
+        source = RUNTIME_HOOK.read_text(encoding="utf-8")
+        self.assertIn("old_root=/new_root\n", source)
+        self.assertNotIn("old_root=/sysroot\n", source)
+
+
+class BootExportRuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.old_root = self.root / "new_root"
+        self.boot = self.old_root / "boot"
+        self.boot.mkdir(parents=True)
+        self.export = self.root / "export"
+        self.cmdline = self.root / "cmdline"
+        self.log = self.root / "commands.log"
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        self._write_fake_commands()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _write_fake(self, name: str, body: str) -> None:
+        path = self.fake_bin / name
+        path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _write_fake_commands(self) -> None:
+        record = 'printf \'%s:%s\\n\' "$0" "$*" >>"$BOOT_EXPORT_TEST_LOG"\n'
+        self._write_fake(
+            "mount",
+            record + 'exit "${BOOT_EXPORT_TEST_MOUNT_STATUS:-0}"\n',
+        )
+        self._write_fake(
+            "umount",
+            record + 'exit "${BOOT_EXPORT_TEST_UMOUNT_STATUS:-0}"\n',
+        )
+        self._write_fake("poweroff", record + "exit 0\n")
+        self._write_fake(
+            "sync",
+            record + '[ "${BOOT_EXPORT_TEST_SYNC_FAIL:-0}" -ne 0 ] && exit 1\nexit 0\n',
+        )
+        self._write_fake(
+            "stat",
+            'if [ "$1" != -c ] || [ "$2" != %s ] || [ "$3" != -- ]; then exit 64; fi\n'
+            'exec /usr/bin/stat -f %z "$4"\n',
+        )
+
+    def _run_hook(
+        self,
+        command_line: str,
+        *,
+        mount_status: int = 0,
+        sync_fails: bool = False,
+        umount_status: int = 0,
+    ) -> subprocess.CompletedProcess[str]:
+        self.cmdline.write_text(command_line + "\n", encoding="ascii")
+        test_hook = self.root / "try-omarchy-boot-export"
+        source = RUNTIME_HOOK.read_text(encoding="utf-8")
+        source = source.replace("/proc/cmdline", str(self.cmdline))
+        source = source.replace("/usr/bin/stat", str(self.fake_bin / "stat"))
+        source = source.replace("/new_root", str(self.old_root))
+        source = source.replace("/run/try-omarchy-boot-export", str(self.export))
+        test_hook.write_text(source, encoding="utf-8")
+
+        environment = os.environ.copy()
+        environment["PATH"] = f"{self.fake_bin}:{environment['PATH']}"
+        environment["BOOT_EXPORT_TEST_LOG"] = str(self.log)
+        environment["BOOT_EXPORT_TEST_MOUNT_STATUS"] = str(mount_status)
+        environment["BOOT_EXPORT_TEST_SYNC_FAIL"] = "1" if sync_fails else "0"
+        environment["BOOT_EXPORT_TEST_UMOUNT_STATUS"] = str(umount_status)
+        harness = """
+err() {
+  printf 'err:%s\\n' "$*" >>"$BOOT_EXPORT_TEST_LOG"
+}
+. "$1"
+run_latehook
+"""
+        return subprocess.run(
+            ["/bin/sh", "-c", harness, "boot-export-test", str(test_hook)],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+        )
+
+    def _write_boot_files(self) -> None:
+        (self.boot / "Image").write_bytes(b"installed kernel\n".ljust(64, b"\0"))
+        (self.boot / "initramfs-linux.img").write_bytes(b"installed initramfs\n")
+        build_spec = self.old_root / "usr/share/try-omarchy/build-spec.json"
+        build_spec.parent.mkdir(parents=True)
+        build_spec.write_text(
+            '{"runtime":{"kernelCommandLine":"root=/dev/vda rw rootwait '
+            'console=tty0 console=hvc0"}}\n',
+            encoding="ascii",
+        )
+
+    def _log_text(self) -> str:
+        return self.log.read_text(encoding="utf-8") if self.log.exists() else ""
+
+    def test_absent_and_lookalike_tokens_leave_boot_untouched(self) -> None:
+        for command_line in (
+            "root=/dev/vda rw",
+            "root=/dev/vda tryomarchy.export_boot=0",
+            "root=/dev/vda xtryomarchy.export_boot=1",
+            "root=/dev/vda tryomarchy.export_boot=1x",
+        ):
+            with self.subTest(command_line=command_line):
+                result = self._run_hook(command_line)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse(self.export.exists())
+                self.assertEqual(self._log_text(), "")
+
+    def test_exact_token_exports_files_then_publishes_marker_and_powers_off(self) -> None:
+        self._write_boot_files()
+
+        result = self._run_hook(
+            "root=/dev/vda rw tryomarchy.export_boot=1 console=hvc0"
+        )
+
+        # The mocked poweroff returns, so the hook deliberately reports failure
+        # instead of allowing this recovery boot to continue.
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(
+            (self.export / "kernel").read_bytes(),
+            b"installed kernel\n".ljust(64, b"\0"),
+        )
+        self.assertEqual(
+            (self.export / "initramfs").read_bytes(), b"installed initramfs\n"
+        )
+        self.assertIn(
+            '"kernelCommandLine"',
+            (self.export / "build-spec.json").read_text(encoding="ascii"),
+        )
+        self.assertEqual(
+            (self.export / "complete").read_text(encoding="ascii"),
+            "try-omarchy-boot-export-v1\n",
+        )
+        log = self._log_text()
+        self.assertIn(
+            "mount:-t 9p -o "
+            "trans=virtio,version=9p2000.L,msize=1048576,cache=none,nosuid,nodev,noexec "
+            f"try-omarchy-boot-export {self.export}",
+            log,
+        )
+        self.assertEqual(log.count("sync:"), 4)
+        self.assertLess(log.rfind("sync:"), log.find("umount:"))
+        self.assertLess(log.find("umount:"), log.find("poweroff:-f"))
+
+    def test_mount_failure_powers_off_without_writing_an_export(self) -> None:
+        self._write_boot_files()
+
+        result = self._run_hook(
+            "tryomarchy.export_boot=1 root=/dev/vda", mount_status=1
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.export / "complete").exists())
+        log = self._log_text()
+        self.assertIn("mount:", log)
+        self.assertIn("poweroff:-f", log)
+        self.assertNotIn("sync:", log)
+
+    def test_oversized_source_is_rejected_before_mount_or_copy(self) -> None:
+        self._write_boot_files()
+        build_spec = self.old_root / "usr/share/try-omarchy/build-spec.json"
+        build_spec.write_bytes(b"{" + b"x" * 1_048_576)
+
+        result = self._run_hook("root=/dev/vda tryomarchy.export_boot=1")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.export.exists())
+        log = self._log_text()
+        self.assertNotIn("mount:", log)
+        self.assertIn("poweroff:-f", log)
+
+    def test_symlinked_source_is_rejected_before_mounting(self) -> None:
+        (self.boot / "Image").write_bytes(b"installed kernel\n")
+        outside = self.root / "outside-initramfs"
+        outside.write_bytes(b"not a direct boot file\n")
+        (self.boot / "initramfs-linux.img").symlink_to(outside)
+
+        result = self._run_hook("root=/dev/vda tryomarchy.export_boot=1")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.export.exists())
+        log = self._log_text()
+        self.assertNotIn("mount:", log)
+        self.assertIn("poweroff:-f", log)
+
+    def test_sync_failure_never_publishes_complete_marker(self) -> None:
+        self._write_boot_files()
+
+        result = self._run_hook(
+            "root=/dev/vda tryomarchy.export_boot=1", sync_fails=True
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.export / "complete").exists())
+        self.assertIn("poweroff:-f", self._log_text())
+
+    def test_unmount_failure_withdraws_complete_marker(self) -> None:
+        self._write_boot_files()
+
+        result = self._run_hook(
+            "root=/dev/vda tryomarchy.export_boot=1", umount_status=1
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.export / "complete").exists())
+        log = self._log_text()
+        self.assertIn("umount:", log)
+        self.assertIn("poweroff:-f", log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -159,8 +159,8 @@ def main() -> None:
         "factory pacman retains the ARM Omarchy keyring repository",
     )
     check(
-        "IgnorePkg = linux-aarch64 hyprland" in pacman_conf,
-        "factory pacman holds the QEMU-booted kernel and patched compositor",
+        "IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland" in pacman_conf,
+        "factory pacman holds the QEMU-booted kernel, matching headers, and patched compositor",
     )
     arm_mirrorlist = read(GUEST / "mirrorlist.aarch64")
     check(

--- a/macos/README.md
+++ b/macos/README.md
@@ -54,9 +54,25 @@ Normal app launches maintain one stable user VM disk under
 `~/Library/Application Support/Try Omarchy/VM/v1`. Storage integration tests
 and specialized development runs can opt into identity-keyed parallel disks by
 setting `OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=1`; release behavior leaves it
-unset. The disk's guest-build identity is immutable so an older root filesystem
-can never boot with incompatible bundled kernel modules. A changed guest build
-requires the user-facing, confirmed Reset Omarchy flow.
+unset. Each persistent disk keeps the identity of the factory that created it
+and is paired with a private, validated boot kit containing that factory's
+kernel, initramfs, and base command line. App updates reuse the disk and its
+boot kit; the current bundled factory is selected only for a new, reset, or
+ephemeral VM. This keeps an older root filesystem on its matching kernel-module
+ABI and lets an existing VM launch without first materializing the new factory
+disk.
+
+Schema-2 disks created before boot kits use a one-time preserving migration.
+The first launcher pass reports that consent is required and exits before QEMU
+starts. The start menu then explains that the disk and data stay intact, the
+new factory is ignored for this VM, and the operation neither resets nor
+upgrades Omarchy. **Cancel** returns to the menu; **Continue** authorizes only
+that retry. The recovery-capable initramfs then attaches the old disk read-only,
+exports its installed `/boot/Image`, `/boot/initramfs-linux.img`, and recorded
+base command line over a private 9p share, and powers off without entering the
+old userspace. The launcher validates and atomically stages that boot kit before
+the normal launch. Unsupported storage or boot ABIs, and ambiguous multiple
+legacy disks, still use the user-facing, confirmed Reset Omarchy flow.
 
 The start menu can move that workspace to any APFS folder the user picks; the
 folder is used exactly as chosen, never with a folder created inside it — a

--- a/macos/Sources/OmarchyVMHelper/BootRecoveryLaunch.swift
+++ b/macos/Sources/OmarchyVMHelper/BootRecoveryLaunch.swift
@@ -1,0 +1,52 @@
+/// Whether the current persistent VM needs the one-time boot-file pairing
+/// before it can launch with its own saved kernel and initramfs.
+enum BootRecoveryLaunchPreflight: Equatable {
+    case notRequired
+    case requiresConfirmation
+}
+
+enum BootRecoveryLaunchGateDecision: Equatable {
+    case cancel
+    case launch(allowBootRecovery: Bool)
+}
+
+enum BootRecoveryChildExitDecision: Equatable {
+    case unrelated
+    case requestConfirmation
+    case reportFailure
+}
+
+/// Keeps the consent decision pure and testable. The confirmation closure is
+/// deliberately not evaluated for ordinary launches, so a paired VM never
+/// sees the one-time prompt again.
+enum BootRecoveryLaunchGate {
+    static func decide(
+        preflight: BootRecoveryLaunchPreflight,
+        confirm: () -> Bool
+    ) -> BootRecoveryLaunchGateDecision {
+        switch preflight {
+        case .notRequired:
+            .launch(allowBootRecovery: false)
+        case .requiresConfirmation:
+            confirm() ? .launch(allowBootRecovery: true) : .cancel
+        }
+    }
+}
+
+/// Resolves the second half of the fail-closed shell handshake. A second
+/// consent request after an authorized retry is always a failure, never a new
+/// prompt, which bounds recovery to one attempt per user decision.
+enum BootRecoveryChildExitGate {
+    static func decide(
+        presentation: VMExitPresentationDecision,
+        launchWasAuthorized: Bool
+    ) -> BootRecoveryChildExitDecision {
+        if presentation.reportsBootRecoveryFailure {
+            return .reportFailure
+        }
+        if presentation.requiresBootRecoveryConsent {
+            return launchWasAuthorized ? .reportFailure : .requestConfirmation
+        }
+        return .unrelated
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
+++ b/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
@@ -13,11 +13,19 @@ enum QEMUGPUStorageOption: String, Equatable {
 enum QEMUGPURuntimeEnvironment {
     static let inspectOnlyKey = "OMARCHY_QEMU_GPU_INSPECT_ONLY"
     static let dryRunKey = "OMARCHY_QEMU_GPU_DRY_RUN"
+    static let bootRecoveryConsentKey = "OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY"
 
     static func sanitizedForLaunch(_ base: [String: String]) -> [String: String] {
         var environment = base
         environment.removeValue(forKey: inspectOnlyKey)
         environment.removeValue(forKey: dryRunKey)
+        environment.removeValue(forKey: bootRecoveryConsentKey)
+        return environment
+    }
+
+    static func withBootRecoveryConsent(_ base: [String: String]) -> [String: String] {
+        var environment = sanitizedForLaunch(base)
+        environment[bootRecoveryConsentKey] = "1"
         return environment
     }
 
@@ -38,6 +46,12 @@ enum QEMUGPURuntimeEnvironment {
 
 enum QEMUGPUStorageSpaceEstimate {
     private static let stateRootEnvironmentKey = "OMARCHY_QEMU_GPU_STATE_ROOT"
+
+    private struct RecordedPersistentDisk {
+        let disk: URL
+        let identity: String
+        let schemaVersion: Int
+    }
 
     /// Resolution order is the environment override, then the stored
     /// preference, then Application Support. The override stays first because
@@ -147,11 +161,11 @@ enum QEMUGPUStorageSpaceEstimate {
 
         var total: Int64 = 0
         for directory in directories {
-            guard let diskURL = recordedDiskURL(
+            guard let recordedDisk = recordedPersistentDisk(
                 in: directory,
                 fileManager: fileManager
             ),
-                  let values = try? diskURL.resourceValues(forKeys: [
+                  let values = try? recordedDisk.disk.resourceValues(forKeys: [
                     .totalFileAllocatedSizeKey,
                     .fileAllocatedSizeKey,
                   ]),
@@ -162,6 +176,90 @@ enum QEMUGPUStorageSpaceEstimate {
             total = sum
         }
         return total > 0 ? total : nil
+    }
+
+    /// Whether this state root already contains a schema-2 persistent disk the
+    /// shell can launch. A launchable existing VM is selected before the
+    /// bundled factory image is materialized, including when its recorded
+    /// bundle identity belongs to an older app release. Unsupported schema-1
+    /// disks still require Reset and do not bypass new-VM space validation.
+    static func hasRecordedPersistentDisk(
+        stateRoot: String,
+        bundleIdentity: String? = nil,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let disks = URL(fileURLWithPath: stateRoot, isDirectory: true)
+            .appendingPathComponent("disks", isDirectory: true)
+        guard hasAttributes(
+            disks,
+            type: .typeDirectory,
+            permissions: 0o700,
+            fileManager: fileManager
+        ),
+              let contents = try? fileManager.contentsOfDirectory(
+                at: disks,
+                includingPropertiesForKeys: nil,
+                options: []
+              )
+        else { return false }
+
+        return selectedSinglePersistentDisk(
+            from: contents,
+            bundleIdentity: bundleIdentity,
+            fileManager: fileManager
+        )?.schemaVersion == 2
+    }
+
+    /// Read-only best-effort preflight for the one-time legacy boot-file
+    /// pairing. The shell repeats every check under its workspace lock and
+    /// requires an explicit one-shot consent variable, so a filesystem race or
+    /// a conservative false negative cannot perform recovery without consent.
+    static func bootRecoveryPreflight(
+        environment: [String: String],
+        bundleIdentity: String?,
+        preference: StorageLocationPreference = .default,
+        fileManager: FileManager = .default
+    ) -> BootRecoveryLaunchPreflight {
+        guard environment["OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK"] ?? "0" == "0",
+              let bundleIdentity,
+              isIdentity(bundleIdentity),
+              let root = storageRootURL(
+                environment: environment,
+                preference: preference,
+                fileManager: fileManager
+              ),
+              StorageLocationPolicy.hasValidRootMarker(in: root)
+        else { return .notRequired }
+
+        let disks = root.appendingPathComponent("disks", isDirectory: true)
+        guard hasAttributes(
+            disks,
+            type: .typeDirectory,
+            permissions: 0o700,
+            fileManager: fileManager
+        ),
+              let entries = try? fileManager.contentsOfDirectory(
+                at: disks,
+                includingPropertiesForKeys: nil,
+                options: []
+              )
+        else { return .notRequired }
+
+        guard let selected = selectedSinglePersistentDisk(
+            from: entries,
+            bundleIdentity: bundleIdentity,
+            fileManager: fileManager
+        ) else { return .notRequired }
+
+        guard selected.schemaVersion == 2,
+              selected.identity != bundleIdentity,
+              bootKitEntryIsMissing(
+                stateRoot: root,
+                identity: selected.identity,
+                fileManager: fileManager
+              )
+        else { return .notRequired }
+        return .requiresConfirmation
     }
 
     static func format(bytes: Int64) -> String? {
@@ -248,10 +346,10 @@ enum QEMUGPUStorageSpaceEstimate {
         }
     }
 
-    private static func recordedDiskURL(
+    private static func recordedPersistentDisk(
         in directory: URL,
         fileManager: FileManager
-    ) -> URL? {
+    ) -> RecordedPersistentDisk? {
         guard hasAttributes(
             directory,
             type: .typeDirectory,
@@ -308,7 +406,67 @@ enum QEMUGPUStorageSpaceEstimate {
               let diskSize = try? diskURL.resourceValues(forKeys: [.fileSizeKey]).fileSize,
               Int64(diskSize) >= sourceBytesNumber.int64Value
         else { return nil }
-        return diskURL
+        return RecordedPersistentDisk(
+            disk: diskURL,
+            identity: identity,
+            schemaVersion: schemaNumber.intValue
+        )
+    }
+
+    /// Mirrors the launcher's normal single-disk selection closely enough for
+    /// read-only UI preflight: `current` wins only when no second recognized
+    /// legacy VM exists; otherwise exactly one recognized identity directory
+    /// can be migrated. The shell repeats this under its lock.
+    private static func selectedSinglePersistentDisk(
+        from entries: [URL],
+        bundleIdentity: String? = nil,
+        fileManager: FileManager
+    ) -> RecordedPersistentDisk? {
+        let currentEntry = entries.first { $0.lastPathComponent == "current" }
+        let validLegacyDisks = entries
+            .filter { isIdentity($0.lastPathComponent) }
+            .compactMap { recordedPersistentDisk(in: $0, fileManager: fileManager) }
+
+        if let currentEntry {
+            guard validLegacyDisks.isEmpty else { return nil }
+            return recordedPersistentDisk(in: currentEntry, fileManager: fileManager)
+        }
+        if let bundleIdentity,
+           let exactEntry = entries.first(where: { $0.lastPathComponent == bundleIdentity }),
+           recordedPersistentDisk(in: exactEntry, fileManager: fileManager) == nil {
+            // The shell refuses to select around an invalid legacy directory
+            // bearing the current bundle's exact identity.
+            return nil
+        }
+        guard validLegacyDisks.count == 1 else { return nil }
+        return validLegacyDisks.first
+    }
+
+    /// Missing is the only state in which recovery is meaningful. Any direct
+    /// entry, valid or not, suppresses the prompt: the shell owns full boot-kit
+    /// validation and must report an unsafe collision rather than overwrite it.
+    private static func bootKitEntryIsMissing(
+        stateRoot: URL,
+        identity: String,
+        fileManager: FileManager
+    ) -> Bool {
+        let bootRoot = stateRoot.appendingPathComponent("boot", isDirectory: true)
+        var information = stat()
+        if Darwin.lstat(bootRoot.path, &information) != 0 {
+            return errno == ENOENT
+        }
+        guard hasAttributes(
+            bootRoot,
+            type: .typeDirectory,
+            permissions: 0o700,
+            fileManager: fileManager
+        ) else { return false }
+
+        let bootKit = bootRoot.appendingPathComponent(identity, isDirectory: true)
+        if Darwin.lstat(bootKit.path, &information) == 0 {
+            return false
+        }
+        return errno == ENOENT
     }
 
     private static func hasAttributes(

--- a/macos/Sources/OmarchyVMHelper/StartMenuPresentation.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuPresentation.swift
@@ -30,6 +30,15 @@ struct StartMenuPortForwardingPresentation: Equatable {
 /// of AppKit makes the important behavior testable without relying on window
 /// positions, font metrics, run-loop timing, or the current display size.
 enum StartMenuPresentation {
+    static let incompatibleWorkspaceDetail = "The saved VM uses a storage or boot format this version can’t use, or its data folder contains multiple saved VMs. Reset Omarchy to create a compatible VM. Resetting permanently erases everything in the VM."
+
+    static let bootRecoveryConfirmationTitle = "Prepare this saved VM once?"
+    static let bootRecoveryConfirmationDetail = """
+        Try Omarchy found an existing VM from an earlier app version. Before it starts, Try Omarchy will run a one-time, read-only recovery to pair that VM with its own kernel and startup files. The saved disk and all of its data remain intact.
+
+        The factory image bundled with this app is ignored for this VM. Continuing does not reset the VM, upgrade Omarchy, or install system updates.
+        """
+
     static func microphone(
         state: MicrophoneAuthorizationState,
         requestInFlight: Bool

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -291,9 +291,23 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = "Reset Omarchy to continue"
-        alert.informativeText = "This VM was created by a different Try Omarchy build. Reset Omarchy to use this version. Resetting permanently erases everything in the VM."
+        alert.informativeText = StartMenuPresentation.incompatibleWorkspaceDetail
         alert.addButton(withTitle: "OK")
         alert.beginSheetModal(for: window)
+    }
+
+    /// Requests one-shot consent for legacy boot-file pairing. This remains a
+    /// synchronous application-modal decision so the launcher cannot start in
+    /// the gap between presenting the explanation and receiving the answer.
+    func confirmBootRecovery() -> Bool {
+        guard launchInProgress else { return false }
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = StartMenuPresentation.bootRecoveryConfirmationTitle
+        alert.informativeText = StartMenuPresentation.bootRecoveryConfirmationDetail
+        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: "Continue")
+        return alert.runModal() == .alertSecondButtonReturn
     }
 
     func launchDidFail(errorMessage: String) {

--- a/macos/Sources/OmarchyVMHelper/StorageLocation.swift
+++ b/macos/Sources/OmarchyVMHelper/StorageLocation.swift
@@ -155,8 +155,9 @@ struct StorageLocationResolution: Equatable {
 
 /// Mirrors the launcher's own state-root checks so the start menu can explain a
 /// rejected folder before QEMU ever sees it, and adds the two guards the shell
-/// library cannot express cheaply: the filesystem must be APFS, and there must
-/// be room for the factory image.
+/// library cannot express cheaply: the filesystem must be APFS, and a new VM
+/// must have room for the factory image. An existing VM is launched from its
+/// recorded disk without materializing the current app's factory image.
 enum StorageLocationPolicy {
     static let environmentKey = "OMARCHY_QEMU_GPU_STATE_ROOT"
     static let workspaceDirectoryName = "Try Omarchy"
@@ -310,7 +311,13 @@ enum StorageLocationPolicy {
         }
 
         var warning: String?
-        if let metrics {
+        let hasRecordedPersistentDisk = isExistingWorkspace
+            && QEMUGPUStorageSpaceEstimate.hasRecordedPersistentDisk(
+                stateRoot: root,
+                bundleIdentity: metrics?.identity,
+                fileManager: fileManager
+            )
+        if let metrics, !hasRecordedPersistentDisk {
             let requirement = StorageSpaceRequirement(
                 sourceBytes: metrics.sourceDiskBytes,
                 workingBytes: metrics.workingDiskBytes,

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -29,6 +29,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private var childRunning = false
     private var applicationTerminationPending = false
     private var virtualMachineReachedStart = false
+    private var activeLaunchAllowedBootRecovery = false
 
     /// True while a modal alert this controller opened itself (rather than
     /// AppKit) is on screen awaiting a click. `finish()`'s watchdog checks
@@ -169,7 +170,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func startVirtualMachine() {
+    private func startVirtualMachine(allowBootRecovery: Bool = false) {
         virtualMachineReachedStart = false
         do {
             let accessibilityDecision = AccessibilityLaunchDecision.make(
@@ -194,6 +195,31 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
                 startMenuWindow?.launchDidAbort()
                 return
             }
+            var approvedBootRecovery = allowBootRecovery
+            if !approvedBootRecovery {
+                let preflight: BootRecoveryLaunchPreflight
+                if initialArguments.first == QEMUGPUStorageOption.ephemeral.rawValue {
+                    preflight = .notRequired
+                } else {
+                    preflight = QEMUGPUStorageSpaceEstimate.bootRecoveryPreflight(
+                        environment: baseEnvironment,
+                        bundleIdentity: bundledMetrics?.identity,
+                        preference: storageLocationStore.load()
+                    )
+                }
+                switch BootRecoveryLaunchGate.decide(
+                    preflight: preflight,
+                    confirm: { [weak self] in
+                        self?.startMenuWindow?.confirmBootRecovery() ?? false
+                    }
+                ) {
+                case .cancel:
+                    startMenuWindow?.launchDidAbort()
+                    return
+                case .launch(let allowBootRecovery):
+                    approvedBootRecovery = allowBootRecovery
+                }
+            }
             let cameraDecision = CameraPreflight.decision()
             if let warning = cameraDecision.warning {
                 fputs("[camera] \(warning)\n", stderr)
@@ -201,7 +227,10 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             guard cameraDecision.allowsLaunch else {
                 throw HelperError.io("camera policy unexpectedly prevented launch")
             }
-            try launch(arguments: launchArguments())
+            try launch(
+                arguments: launchArguments(),
+                allowBootRecovery: approvedBootRecovery
+            )
         } catch {
             failLaunch(error)
         }
@@ -348,7 +377,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         )
     }
 
-    private func launch(arguments: [String]) throws {
+    private func launch(arguments: [String], allowBootRecovery: Bool = false) throws {
         let context = childLaunchContext()
         // The UI gate above normally resolves this first; failing closed here
         // too keeps a silent fallback impossible for any future caller.
@@ -357,18 +386,28 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         }
         try PortForwardAvailability.validate(context.portForwardMappings)
         activeStateRoot = context.stateRoot
+        var environment = context.environment
+        if allowBootRecovery {
+            environment = QEMUGPURuntimeEnvironment.withBootRecoveryConsent(environment)
+        }
 
-        try supervisor.start(
-            executableURL: launcherURL,
-            arguments: arguments,
-            environment: context.environment,
-            launchEvent: { [weak self] event in
-                if event == .virtualMachineReady {
-                    self?.virtualMachineDidStart()
+        activeLaunchAllowedBootRecovery = allowBootRecovery
+        do {
+            try supervisor.start(
+                executableURL: launcherURL,
+                arguments: arguments,
+                environment: environment,
+                launchEvent: { [weak self] event in
+                    if event == .virtualMachineReady {
+                        self?.virtualMachineDidStart()
+                    }
                 }
+            ) { [weak self] status in
+                self?.childDidExit(status: status)
             }
-        ) { [weak self] status in
-            self?.childDidExit(status: status)
+        } catch {
+            activeLaunchAllowedBootRecovery = false
+            throw error
         }
         childRunning = true
     }
@@ -599,6 +638,8 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private func childDidExit(status: Int32) {
         guard childRunning else { return }
         childRunning = false
+        let launchAllowedBootRecovery = activeLaunchAllowedBootRecovery
+        activeLaunchAllowedBootRecovery = false
         let recentStandardError = supervisor.recentStandardError
 
         let wasStopping = lifecycle.isStopping
@@ -623,6 +664,42 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             if presentation.requiresWorkspaceReset {
                 startMenuWindow?.launchRequiresReset()
                 return
+            }
+            switch BootRecoveryChildExitGate.decide(
+                presentation: presentation,
+                launchWasAuthorized: launchAllowedBootRecovery
+            ) {
+            case .reportFailure:
+                startMenuWindow?.launchDidFail(
+                    errorMessage: "Try Omarchy could not complete the one-time boot-file pairing. The saved VM was not reset or upgraded. You can safely try again."
+                )
+                return
+            case .requestConfirmation:
+                switch BootRecoveryLaunchGate.decide(
+                    preflight: .requiresConfirmation,
+                    confirm: { [weak self] in
+                        self?.startMenuWindow?.confirmBootRecovery() ?? false
+                    }
+                ) {
+                case .cancel:
+                    startMenuWindow?.launchDidAbort()
+                case .launch:
+                    // Retry the same configured workspace directly. Re-running
+                    // availability resolution here could offer to switch from
+                    // a just-disconnected external VM to the default one, then
+                    // accidentally spend consent on a different saved disk.
+                    do {
+                        try launch(
+                            arguments: launchArguments(),
+                            allowBootRecovery: true
+                        )
+                    } catch {
+                        failLaunch(error)
+                    }
+                }
+                return
+            case .unrelated:
+                break
             }
             if presentation.showsStartupFailure {
                 startMenuWindow?.dismiss()

--- a/macos/Sources/OmarchyVMHelper/VMRunLifecycle.swift
+++ b/macos/Sources/OmarchyVMHelper/VMRunLifecycle.swift
@@ -30,19 +30,33 @@ struct VMRunLifecycle: Equatable {
 struct VMExitPresentationDecision: Equatable {
     let showsStartupFailure: Bool
     let requiresWorkspaceReset: Bool
+    let requiresBootRecoveryConsent: Bool
+    let reportsBootRecoveryFailure: Bool
 
     static let incompatibleWorkspaceStatus: Int32 = 78
+    static let bootRecoveryConsentRequiredStatus: Int32 = 80
+    static let bootRecoveryFailedStatus: Int32 = 81
 
     static func make(status: Int32, reachedVirtualMachineStart: Bool, wasStopping: Bool) -> Self {
         let requiresWorkspaceReset = status == incompatibleWorkspaceStatus
+            && !reachedVirtualMachineStart
+            && !wasStopping
+        let requiresBootRecoveryConsent = status == bootRecoveryConsentRequiredStatus
+            && !reachedVirtualMachineStart
+            && !wasStopping
+        let reportsBootRecoveryFailure = status == bootRecoveryFailedStatus
             && !reachedVirtualMachineStart
             && !wasStopping
         return Self(
             showsStartupFailure: status != 0
                 && !reachedVirtualMachineStart
                 && !wasStopping
-                && !requiresWorkspaceReset,
-            requiresWorkspaceReset: requiresWorkspaceReset
+                && !requiresWorkspaceReset
+                && !requiresBootRecoveryConsent
+                && !reportsBootRecoveryFailure,
+            requiresWorkspaceReset: requiresWorkspaceReset,
+            requiresBootRecoveryConsent: requiresBootRecoveryConsent,
+            reportsBootRecoveryFailure: reportsBootRecoveryFailure
         )
     }
 }

--- a/macos/Tests/OmarchyVMHelperTests/AudioDevicesTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/AudioDevicesTests.swift
@@ -255,6 +255,8 @@ struct VMRunLifecycleTests {
         )
         #expect(decision.showsStartupFailure)
         #expect(!decision.requiresWorkspaceReset)
+        #expect(!decision.requiresBootRecoveryConsent)
+        #expect(!decision.reportsBootRecoveryFailure)
     }
 
     @Test("an incompatible saved VM stays on the start menu for reset")
@@ -266,5 +268,53 @@ struct VMRunLifecycleTests {
         )
         #expect(!decision.showsStartupFailure)
         #expect(decision.requiresWorkspaceReset)
+        #expect(!decision.requiresBootRecoveryConsent)
+        #expect(!decision.reportsBootRecoveryFailure)
+    }
+
+    @Test("boot recovery consent is requested only before the VM starts")
+    func bootRecoveryConsentIsAStartupDecision() {
+        let required = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryConsentRequiredStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: false
+        )
+        #expect(!required.showsStartupFailure)
+        #expect(!required.requiresWorkspaceReset)
+        #expect(required.requiresBootRecoveryConsent)
+
+        let afterStart = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryConsentRequiredStatus,
+            reachedVirtualMachineStart: true,
+            wasStopping: false
+        )
+        #expect(!afterStart.requiresBootRecoveryConsent)
+
+        let whileStopping = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryConsentRequiredStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: true
+        )
+        #expect(!whileStopping.requiresBootRecoveryConsent)
+    }
+
+    @Test("a failed boot recovery stays on the start menu with a specific error")
+    func bootRecoveryFailureIsSpecific() {
+        let failed = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryFailedStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: false
+        )
+        #expect(!failed.showsStartupFailure)
+        #expect(!failed.requiresWorkspaceReset)
+        #expect(!failed.requiresBootRecoveryConsent)
+        #expect(failed.reportsBootRecoveryFailure)
+
+        let whileStopping = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryFailedStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: true
+        )
+        #expect(!whileStopping.reportsBootRecoveryFailure)
     }
 }

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -81,9 +81,23 @@ struct QEMUGPURuntimeEnvironmentTests {
             "KEEP_ME": "yes",
             QEMUGPURuntimeEnvironment.inspectOnlyKey: "1",
             QEMUGPURuntimeEnvironment.dryRunKey: "1",
+            QEMUGPURuntimeEnvironment.bootRecoveryConsentKey: "1",
         ])
 
         #expect(environment == ["KEEP_ME": "yes"])
+    }
+
+    @Test("boot recovery consent is an explicit one-launch environment addition")
+    func addsBootRecoveryConsent() {
+        let ordinary = QEMUGPURuntimeEnvironment.sanitizedForLaunch(["KEEP_ME": "yes"])
+        let approved = QEMUGPURuntimeEnvironment.withBootRecoveryConsent(ordinary)
+
+        #expect(ordinary == ["KEEP_ME": "yes"])
+        #expect(approved == [
+            "KEEP_ME": "yes",
+            QEMUGPURuntimeEnvironment.bootRecoveryConsentKey: "1",
+        ])
+        #expect(QEMUGPURuntimeEnvironment.sanitizedForLaunch(approved) == ordinary)
     }
 
     @Test("storage reset ignores inherited integration settings")
@@ -96,6 +110,7 @@ struct QEMUGPURuntimeEnvironmentTests {
             PortForwardPolicy.environmentKey,
             QEMUGPURuntimeEnvironment.inspectOnlyKey,
             QEMUGPURuntimeEnvironment.dryRunKey,
+            QEMUGPURuntimeEnvironment.bootRecoveryConsentKey,
         ]
         var inherited = ["KEEP_ME": "yes"]
         for key in controlledKeys {

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuPresentationTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuPresentationTests.swift
@@ -3,6 +3,105 @@ import Testing
 
 @Suite("Start menu presentation")
 struct StartMenuPresentationTests {
+    @Test("the reset notice describes actual compatibility failures, not app updates")
+    func incompatibleWorkspaceNotice() {
+        let detail = StartMenuPresentation.incompatibleWorkspaceDetail
+        #expect(detail.contains("storage or boot format"))
+        #expect(detail.contains("multiple saved VMs"))
+        #expect(detail.contains("permanently erases"))
+        #expect(!detail.contains("different Try Omarchy build"))
+    }
+
+    @Test("boot recovery notice promises preservation and no automatic upgrade")
+    func bootRecoveryNotice() {
+        let detail = StartMenuPresentation.bootRecoveryConfirmationDetail
+        #expect(detail.contains("one-time, read-only"))
+        #expect(detail.contains("saved disk"))
+        #expect(detail.contains("data remain intact"))
+        #expect(detail.contains("factory image"))
+        #expect(detail.contains("does not reset"))
+        #expect(detail.contains("upgrade Omarchy"))
+    }
+
+    @Test("continuing the one-time prompt grants consent for only that launch")
+    func bootRecoveryContinue() {
+        var promptCount = 0
+        let decision = BootRecoveryLaunchGate.decide(
+            preflight: .requiresConfirmation,
+            confirm: {
+                promptCount += 1
+                return true
+            }
+        )
+        #expect(promptCount == 1)
+        #expect(decision == .launch(allowBootRecovery: true))
+    }
+
+    @Test("cancelling the one-time prompt aborts launch")
+    func bootRecoveryCancel() {
+        var promptCount = 0
+        let decision = BootRecoveryLaunchGate.decide(
+            preflight: .requiresConfirmation,
+            confirm: {
+                promptCount += 1
+                return false
+            }
+        )
+        #expect(promptCount == 1)
+        #expect(decision == .cancel)
+    }
+
+    @Test("a paired VM suppresses the prompt and launches without consent")
+    func pairedVMSuppressesRecoveryPrompt() {
+        var promptCount = 0
+        let decision = BootRecoveryLaunchGate.decide(
+            preflight: .notRequired,
+            confirm: {
+                promptCount += 1
+                return true
+            }
+        )
+        #expect(promptCount == 0)
+        #expect(decision == .launch(allowBootRecovery: false))
+    }
+
+    @Test("the recovery handshake retries at most once per confirmation")
+    func bootRecoveryHandshakeIsBounded() {
+        let consentRequired = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryConsentRequiredStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: false
+        )
+        #expect(BootRecoveryChildExitGate.decide(
+            presentation: consentRequired,
+            launchWasAuthorized: false
+        ) == .requestConfirmation)
+
+        let accepted = BootRecoveryLaunchGate.decide(
+            preflight: .requiresConfirmation,
+            confirm: { true }
+        )
+        #expect(accepted == .launch(allowBootRecovery: true))
+        #expect(BootRecoveryChildExitGate.decide(
+            presentation: consentRequired,
+            launchWasAuthorized: true
+        ) == .reportFailure)
+
+        let recoveryFailed = VMExitPresentationDecision.make(
+            status: VMExitPresentationDecision.bootRecoveryFailedStatus,
+            reachedVirtualMachineStart: false,
+            wasStopping: false
+        )
+        #expect(BootRecoveryChildExitGate.decide(
+            presentation: recoveryFailed,
+            launchWasAuthorized: true
+        ) == .reportFailure)
+        #expect(BootRecoveryLaunchGate.decide(
+            preflight: .requiresConfirmation,
+            confirm: { false }
+        ) == .cancel)
+    }
+
     @Test("microphone permission states offer only valid actions")
     func microphoneStates() {
         let authorized = StartMenuPresentation.microphone(

--- a/macos/Tests/OmarchyVMHelperTests/StorageLocationContractTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StorageLocationContractTests.swift
@@ -48,6 +48,23 @@ struct StorageLocationContractTests {
         #expect(library.contains("if [[ -n ${\(StorageLocationPolicy.environmentKey):-} ]]; then"))
     }
 
+    @Test("Swift and the launcher agree on the boot-recovery consent handshake")
+    func bootRecoveryConsentHandshake() throws {
+        let launcher = try source(named: "run-qemu-gpu.sh")
+        #expect(launcher.contains(
+            "boot_recovery_consent_required_status=\(VMExitPresentationDecision.bootRecoveryConsentRequiredStatus)"
+        ))
+        #expect(launcher.contains(
+            "boot_recovery_failed_status=\(VMExitPresentationDecision.bootRecoveryFailedStatus)"
+        ))
+        #expect(launcher.contains(
+            "case ${\(QEMUGPURuntimeEnvironment.bootRecoveryConsentKey):-0} in"
+        ))
+        #expect(launcher.contains(
+            "[[ ${\(QEMUGPURuntimeEnvironment.bootRecoveryConsentKey):-0} != 1 ]]"
+        ))
+    }
+
     private func source(named relativePath: String) throws -> String {
         let testFile = URL(fileURLWithPath: #filePath)
         let macosDirectory = testFile

--- a/macos/Tests/OmarchyVMHelperTests/StorageLocationTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StorageLocationTests.swift
@@ -69,6 +69,47 @@ private func writeValidRootMarker(in container: URL) throws -> URL {
     return marker
 }
 
+/// Writes a persistent-disk directory in the canonical form accepted by both
+/// `recordedPersistentDisk` and `_qps_validate_recorded_workspace`.
+@discardableResult
+private func writeRecordedPersistentDisk(
+    in container: URL,
+    directoryName: String,
+    identity: String,
+    schemaVersion: Int = 2
+) throws -> URL {
+    let disks = container.appendingPathComponent("disks", isDirectory: true)
+    try FileManager.default.createDirectory(at: disks, withIntermediateDirectories: true)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: disks.path
+    )
+    let directory = disks.appendingPathComponent(directoryName, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o700],
+        ofItemAtPath: directory.path
+    )
+
+    let sourceSHA = String(repeating: "d", count: 64)
+    let metadata = directory.appendingPathComponent("metadata.json", isDirectory: false)
+    try Data(
+        "{\"bundleIdentity\":\"\(identity)\",\"kind\":\"omarchy-qemu-persistent-disk\",\"schemaVersion\":\(schemaVersion),\"sourceRootfs\":{\"bytes\":1,\"sha256\":\"\(sourceSHA)\"}}\n".utf8
+    ).write(to: metadata)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: metadata.path
+    )
+
+    let disk = directory.appendingPathComponent("rootfs.ext4", isDirectory: false)
+    try Data([0x5a]).write(to: disk)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: disk.path
+    )
+    return disk
+}
+
 @Suite("Storage location policy")
 struct StorageLocationPolicyTests {
     @Test("accepts an owned, empty APFS folder and uses it directly")
@@ -351,6 +392,114 @@ struct StorageLocationPolicyTests {
         }
     }
 
+    @Test("an existing VM from a previous app build is not charged for the new factory image")
+    func previousBundleDiskSkipsFactorySpaceRequirement() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        let previousIdentity = String(repeating: "b", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: previousIdentity
+        )
+
+        #expect(!StorageLocationPolicy.hasMaterializedSource(
+            stateRoot: container.path,
+            identity: metrics.identity
+        ))
+        let resolution = try StorageLocationPolicy.validate(
+            container.path,
+            metrics: metrics,
+            probe: FakeVolumeProbe(result: volume(available: 1))
+        )
+        #expect(resolution.stateRoot == container.path)
+        #expect(resolution.spaceWarning == nil)
+    }
+
+    @Test("a legacy identity-scoped VM is recognized before launcher migration")
+    func legacyDiskSkipsFactorySpaceRequirement() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        let previousIdentity = String(repeating: "b", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: previousIdentity,
+            identity: previousIdentity
+        )
+
+        let resolution = try StorageLocationPolicy.validate(
+            container.path,
+            metrics: metrics,
+            probe: FakeVolumeProbe(result: volume(available: 1))
+        )
+        #expect(resolution.stateRoot == container.path)
+        #expect(resolution.spaceWarning == nil)
+    }
+
+    @Test("a workspace marker without a recorded disk still needs factory-image space")
+    func markerAloneDoesNotSkipFactorySpaceRequirement() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+
+        #expect(throws: StorageLocationPolicyError.self) {
+            try StorageLocationPolicy.validate(
+                container.path,
+                metrics: metrics,
+                probe: FakeVolumeProbe(result: volume(available: 1))
+            )
+        }
+    }
+
+    @Test("an unsupported schema-1 disk does not bypass new-VM space validation")
+    func schemaOneDiskDoesNotSkipFactorySpaceRequirement() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: String(repeating: "b", count: 64),
+            schemaVersion: 1
+        )
+
+        #expect(throws: StorageLocationPolicyError.self) {
+            try StorageLocationPolicy.validate(
+                container.path,
+                metrics: metrics,
+                probe: FakeVolumeProbe(result: volume(available: 1))
+            )
+        }
+    }
+
+    @Test("ambiguous multiple saved VMs do not bypass new-VM space validation")
+    func multipleDisksDoNotSkipFactorySpaceRequirement() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: String(repeating: "b", count: 64)
+        )
+        let legacyIdentity = String(repeating: "c", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: legacyIdentity,
+            identity: legacyIdentity
+        )
+
+        #expect(throws: StorageLocationPolicyError.self) {
+            try StorageLocationPolicy.validate(
+                container.path,
+                metrics: metrics,
+                probe: FakeVolumeProbe(result: volume(available: 1))
+            )
+        }
+    }
+
     @Test("accepts with a warning between the floor and the comfort target")
     func warnsWhenRoomIsTight() throws {
         let container = try temporaryDirectory()
@@ -429,6 +578,85 @@ struct StorageLocationPolicyTests {
                 )
             )
         }
+    }
+}
+
+@Suite("Boot recovery preflight")
+struct BootRecoveryPreflightTests {
+    @Test("an older canonical VM without a boot kit requests one-time confirmation")
+    func olderDiskNeedsConfirmation() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        let previousIdentity = String(repeating: "b", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: previousIdentity
+        )
+
+        #expect(QEMUGPUStorageSpaceEstimate.bootRecoveryPreflight(
+            environment: [StorageLocationPolicy.environmentKey: container.path],
+            bundleIdentity: metrics.identity
+        ) == .requiresConfirmation)
+    }
+
+    @Test("a legacy identity-scoped VM requests confirmation before migration")
+    func legacyDiskNeedsConfirmation() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        let previousIdentity = String(repeating: "b", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: previousIdentity,
+            identity: previousIdentity
+        )
+
+        #expect(QEMUGPUStorageSpaceEstimate.bootRecoveryPreflight(
+            environment: [StorageLocationPolicy.environmentKey: container.path],
+            bundleIdentity: metrics.identity
+        ) == .requiresConfirmation)
+    }
+
+    @Test("an existing boot-kit entry suppresses the one-time prompt on later launches")
+    func pairedDiskDoesNotPromptAgain() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        let previousIdentity = String(repeating: "b", count: 64)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: previousIdentity
+        )
+        let boot = container.appendingPathComponent("boot", isDirectory: true)
+        try FileManager.default.createDirectory(at: boot, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: boot.path)
+        let kit = boot.appendingPathComponent(previousIdentity, isDirectory: true)
+        try FileManager.default.createDirectory(at: kit, withIntermediateDirectories: false)
+
+        #expect(QEMUGPUStorageSpaceEstimate.bootRecoveryPreflight(
+            environment: [StorageLocationPolicy.environmentKey: container.path],
+            bundleIdentity: metrics.identity
+        ) == .notRequired)
+    }
+
+    @Test("a VM created from the current bundle stages its boot kit without recovery")
+    func currentDiskDoesNotNeedRecovery() throws {
+        let container = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: container) }
+        try writeValidRootMarker(in: container)
+        try writeRecordedPersistentDisk(
+            in: container,
+            directoryName: "current",
+            identity: metrics.identity
+        )
+
+        #expect(QEMUGPUStorageSpaceEstimate.bootRecoveryPreflight(
+            environment: [StorageLocationPolicy.environmentKey: container.path],
+            bundleIdentity: metrics.identity
+        ) == .notRequired)
     }
 }
 

--- a/macos/Tests/qemu-persistent-storage.test.sh
+++ b/macos/Tests/qemu-persistent-storage.test.sh
@@ -7,6 +7,12 @@ native_dir=$(cd "$test_dir/.." && pwd -P)
 # shellcheck source=../qemu-persistent-storage.sh
 source "$native_dir/qemu-persistent-storage.sh"
 
+grep -Fq '/bin/rm -rf -x "$qps_discarded"' \
+  "$native_dir/qemu-persistent-storage.sh" || {
+    printf 'qemu-persistent-storage.test: structural boot reset may cross a nested mount\n' >&2
+    exit 1
+  }
+
 fail() {
   printf 'qemu-persistent-storage.test: %s\n' "$*" >&2
   exit 1
@@ -162,6 +168,60 @@ identity_bad=$(printf 'bundle-bad' | shasum -a 256 | awk '{print $1}')
 identity_expanded=$(printf 'bundle-expanded' | shasum -a 256 | awk '{print $1}')
 identity_compressed=$(printf 'bundle-compressed' | shasum -a 256 | awk '{print $1}')
 
+# Direct-kernel boots must stay paired with the userspace on each saved disk.
+# These tiny fixtures carry the two file signatures enforced by the storage
+# library while remaining visibly different across bundle generations.
+kernel_a="$test_root/kernel-a"
+kernel_b="$test_root/kernel-b"
+initramfs_a="$test_root/initramfs-a"
+initramfs_b="$test_root/initramfs-b"
+initramfs_zstd="$test_root/initramfs-zstd"
+initramfs_zstd_truncated="$test_root/initramfs-zstd-truncated"
+dd if=/dev/zero of="$kernel_a" bs=1 count=64 >/dev/null 2>&1
+dd if=/dev/zero of="$kernel_b" bs=1 count=64 >/dev/null 2>&1
+printf 'A' | dd of="$kernel_a" bs=1 seek=0 conv=notrunc >/dev/null 2>&1
+printf 'B' | dd of="$kernel_b" bs=1 seek=0 conv=notrunc >/dev/null 2>&1
+printf '\x41\x52\x4d\x64' | dd of="$kernel_a" bs=1 seek=56 conv=notrunc >/dev/null 2>&1
+printf '\x41\x52\x4d\x64' | dd of="$kernel_b" bs=1 seek=56 conv=notrunc >/dev/null 2>&1
+printf '070701initramfs-a\n' >"$initramfs_a"
+printf '070701initramfs-b\n' >"$initramfs_b"
+printf '\x28\xb5\x2f\xfdzstd-initramfs\n' >"$initramfs_zstd"
+printf '\x28\xb5\x2f\xfd' >"$initramfs_zstd_truncated"
+kernel_command_line_a='root=/dev/vda rw rootwait console=tty0 console=hvc0 loglevel=4'
+kernel_command_line_b='root=/dev/vda rw rootwait console=tty0 console=hvc0 loglevel=5'
+
+# Inspecting a new location reports "missing" without asking for, copying, or
+# materializing a factory disk. A full selection then creates the VM and pairs
+# it with the current bundle's boot files.
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/missing-state"
+export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=0
+assert_status "$QEMU_PERSISTENT_STORAGE_MISSING_STATUS" \
+  qemu_persistent_storage_select_existing \
+    "$identity_a" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/disks/current"
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_a"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_a"
+assert_eq "$QEMU_SELECTED_KERNEL_COMMAND_LINE" "$kernel_command_line_a"
+assert_eq "$QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY" 0
+qemu_persistent_storage_release_lock
+
+# The published v0.1.0 and v0.2.0 images used mkinitcpio's zstd compression.
+# Their saved VMs must be able to retain the exact compressed initramfs too.
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/zstd-boot-state"
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_zstd" "$kernel_command_line_a"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_zstd"
+qemu_persistent_storage_release_lock
+assert_fails _qps_assert_boot_source_file \
+  "$initramfs_zstd_truncated" 'truncated zstd initramfs' 1073741824
+
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/state"
+export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=1
+
 # A compressed app payload is expanded once into the private immutable-image
 # cache, verified against the raw manifest digest, and reused thereafter.
 compressed_disk="$test_root/source.ext4.zst"
@@ -230,37 +290,138 @@ assert test "$persistent_b" != "$persistent_a"
 assert cmp -s "$persistent_b" "$source_disk"
 qemu_persistent_storage_release_lock
 
-# A user-facing launch must never relabel an older factory disk as a newer app
-# build. The mismatch is reported with a dedicated status, leaves every byte
-# untouched, and only the explicit reset replaces it with the new factory.
+# A release update reuses the one saved VM across bundle identities. The disk
+# keeps its recorded identity and original boot kit; the newer factory image
+# and boot files are relevant only after an explicit reset.
 export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/single-state"
 export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=1
 qemu_persistent_storage_select \
-  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" ''
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
 legacy_single_disk=$QEMU_SELECTED_DISK
 printf 'single-user-data' | dd of="$legacy_single_disk" bs=1 seek=512 conv=notrunc >/dev/null 2>&1
 legacy_single_metadata_sha=$(shasum -a 256 "${legacy_single_disk%/*}/metadata.json" | awk '{print $1}')
 qemu_persistent_storage_release_lock
 
 export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=0
-assert_status "$QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS" \
-  qemu_persistent_storage_select \
-    persistent "$identity_b" "$source_disk_b" "$source_sha_b" "$source_bytes_b" ''
-assert test -f "$legacy_single_disk"
-assert_eq "$(dd if="$legacy_single_disk" bs=1 skip=512 count=16 2>/dev/null)" single-user-data
+qemu_persistent_storage_select_existing \
+  "$identity_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
+single_disk=$QEMU_SELECTED_DISK
+assert_eq "$single_disk" "$OMARCHY_QEMU_GPU_STATE_ROOT/disks/current/rootfs.ext4"
+assert test ! -e "$legacy_single_disk"
+assert_eq "$(dd if="$single_disk" bs=1 skip=512 count=16 2>/dev/null)" single-user-data
 assert_eq \
-  "$(shasum -a 256 "${legacy_single_disk%/*}/metadata.json" | awk '{print $1}')" \
+  "$(shasum -a 256 "${single_disk%/*}/metadata.json" | awk '{print $1}')" \
   "$legacy_single_metadata_sha"
-assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/disks/current"
+assert_eq "$QEMU_PERSISTENT_STORAGE_IDENTITY" "$identity_a"
+assert_eq "$QEMU_SELECTED_KERNEL" "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel"
+assert_eq "$QEMU_SELECTED_INITRAMFS" "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/initramfs"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_a"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_a"
+assert_eq "$QEMU_SELECTED_KERNEL_COMMAND_LINE" "$kernel_command_line_a"
+assert_eq "$QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY" 0
+assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_b"
+qemu_persistent_storage_release_lock
 
 qemu_persistent_storage_select \
-  reset "$identity_b" "$source_disk_b" "$source_sha_b" "$source_bytes_b" ''
+  reset "$identity_b" "$source_disk_b" "$source_sha_b" "$source_bytes_b" '' \
+  "$source_bytes_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
 single_disk=$QEMU_SELECTED_DISK
 assert_eq "$single_disk" "$OMARCHY_QEMU_GPU_STATE_ROOT/disks/current/rootfs.ext4"
 assert cmp -s "$single_disk" "$source_disk_b"
-assert test ! -e "$legacy_single_disk"
 assert grep -Fq '"schemaVersion":2' "${single_disk%/*}/metadata.json"
 assert grep -Fq "\"bundleIdentity\":\"$identity_b\"" "${single_disk%/*}/metadata.json"
+assert_eq "$QEMU_PERSISTENT_STORAGE_IDENTITY" "$identity_b"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_b"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_b"
+assert_eq "$QEMU_SELECTED_KERNEL_COMMAND_LINE" "$kernel_command_line_b"
+assert_eq "$QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY" 0
+assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a"
+qemu_persistent_storage_release_lock
+
+# Schema-2 disks created before boot kits existed remain reusable. Selection
+# reports that one-time recovery is needed without substituting the new app's
+# kernel; the launcher can then stage the files exported from the old disk.
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/boot-recovery-state"
+export OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK=0
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" ''
+recovery_disk=$QEMU_SELECTED_DISK
+printf 'recovery-user-data' | dd of="$recovery_disk" bs=1 seek=544 conv=notrunc >/dev/null 2>&1
+qemu_persistent_storage_release_lock
+
+qemu_persistent_storage_select_existing \
+  "$identity_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
+assert_eq "$QEMU_PERSISTENT_STORAGE_IDENTITY" "$identity_a"
+assert_eq "$QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY" 1
+assert_eq "$QEMU_SELECTED_KERNEL" ''
+assert_eq "$QEMU_SELECTED_INITRAMFS" ''
+assert_eq "$QEMU_SELECTED_KERNEL_COMMAND_LINE" ''
+assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_b"
+qemu_persistent_storage_stage_selected_boot_kit \
+  "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+assert_eq "$QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY" 0
+assert_eq "$QEMU_SELECTED_KERNEL" "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_a"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_a"
+assert_eq "$QEMU_SELECTED_KERNEL_COMMAND_LINE" "$kernel_command_line_a"
+assert_eq "$(dd if="$QEMU_SELECTED_DISK" bs=1 skip=544 count=18 2>/dev/null)" recovery-user-data
+qemu_persistent_storage_release_lock
+
+# A boot kit is security-sensitive executable input. Hash corruption and
+# symlink substitution both fail closed while leaving the VM disk untouched.
+printf 'X' | dd \
+  of="$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel" \
+  bs=1 seek=0 conv=notrunc >/dev/null 2>&1
+assert_status 1 qemu_persistent_storage_select_existing \
+  "$identity_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
+assert_eq "$(dd if="$recovery_disk" bs=1 skip=544 count=18 2>/dev/null)" recovery-user-data
+
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/symlink-boot-state"
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+symlink_boot_disk=$QEMU_SELECTED_DISK
+printf 'symlink-user-data' | dd of="$symlink_boot_disk" bs=1 seek=576 conv=notrunc >/dev/null 2>&1
+qemu_persistent_storage_release_lock
+/bin/rm -f "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel"
+ln -s "$kernel_a" "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel"
+assert_status 1 qemu_persistent_storage_select_existing \
+  "$identity_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
+assert test -L "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel"
+assert_eq "$(dd if="$symlink_boot_disk" bs=1 skip=576 count=17 2>/dev/null)" symlink-user-data
+
+# Reset is the escape hatch for an unusable boot kit. It removes the exact
+# app-owned entry without following corrupt contents such as this symlink.
+qemu_persistent_storage_select \
+  reset "$identity_b" "$source_disk_b" "$source_sha_b" "$source_bytes_b" '' \
+  "$source_bytes_b" "$kernel_b" "$initramfs_b" "$kernel_command_line_b"
+assert cmp -s "$QEMU_SELECTED_DISK" "$source_disk_b"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_b"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_b"
+assert test -f "$kernel_a"
+assert test ! -e "$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a"
+qemu_persistent_storage_release_lock
+
+# An interrupted earlier reset may have removed the disk before its corrupt
+# current-identity boot kit. A new confirmed reset must still clear that orphan
+# and publish a complete fresh disk/boot pair.
+export OMARCHY_QEMU_GPU_STATE_ROOT="$test_root/orphan-boot-state"
+qemu_persistent_storage_select \
+  persistent "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+orphan_boot_disk_directory=${QEMU_SELECTED_DISK%/*}
+qemu_persistent_storage_release_lock
+/bin/rm -rf "$orphan_boot_disk_directory"
+printf 'X' | dd \
+  of="$OMARCHY_QEMU_GPU_STATE_ROOT/boot/$identity_a/kernel" \
+  bs=1 seek=0 conv=notrunc >/dev/null 2>&1
+qemu_persistent_storage_select \
+  reset "$identity_a" "$source_disk" "$source_sha" "$source_bytes" '' \
+  "$source_bytes" "$kernel_a" "$initramfs_a" "$kernel_command_line_a"
+assert cmp -s "$QEMU_SELECTED_DISK" "$source_disk"
+assert cmp -s "$QEMU_SELECTED_KERNEL" "$kernel_a"
+assert cmp -s "$QEMU_SELECTED_INITRAMFS" "$initramfs_a"
 qemu_persistent_storage_release_lock
 
 # Schema 1 is never trusted for launch, even if it claims the current bundle:

--- a/macos/Tests/run-qemu-ssh-contract.test.sh
+++ b/macos/Tests/run-qemu-ssh-contract.test.sh
@@ -105,7 +105,26 @@ import sys
 import time
 
 arguments = sys.argv[1:]
-Path(os.environ["FAKE_QEMU_LOG"]).write_text("\n".join(arguments) + "\n")
+is_recovery = "Try Omarchy Boot Recovery" in arguments
+log_variable = "FAKE_QEMU_RECOVERY_LOG" if is_recovery else "FAKE_QEMU_LOG"
+Path(os.environ[log_variable]).write_text("\n".join(arguments) + "\n")
+
+if is_recovery:
+    export_path = None
+    for argument in arguments:
+        if argument.startswith("local,id=omarchy-boot-export,"):
+            for field in argument.split(","):
+                if field.startswith("path="):
+                    export_path = Path(field[5:])
+    if export_path is None:
+        raise SystemExit("recovery invocation has no boot-export path")
+    export_path.joinpath("kernel").write_text("recovered-kernel\n")
+    export_path.joinpath("initramfs").write_text("recovered-initramfs\n")
+    export_path.joinpath("build-spec.json").write_text(
+        '{"runtime":{"kernelCommandLine":"root=/dev/vda rw rootwait '
+        'console=tty0 console=hvc0 loglevel=3"}}\n'
+    )
+    export_path.joinpath("complete").write_text("try-omarchy-boot-export-v1\n")
 socket_paths = []
 for argument in arguments:
     if argument.startswith("unix:"):
@@ -140,27 +159,97 @@ chmod 755 "$resources/runtime/bin/Try Omarchy"
 cat >"$resources/scripts/qemu-persistent-storage.sh" <<'SH'
 #!/bin/bash
 QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS=78
+QEMU_PERSISTENT_STORAGE_MISSING_STATUS=79
 QEMU_PERSISTENT_STORAGE_QEMU_ADD_FD='fd=9,set=77,opaque=omarchy-persistent-lock'
 QEMU_SELECTED_DISK=''
 QEMU_SELECTED_STORAGE_MODE=''
 QEMU_PERSISTENT_STORAGE_DIRECTORY=''
+QEMU_PERSISTENT_STORAGE_IDENTITY=''
+QEMU_SELECTED_KERNEL=''
+QEMU_SELECTED_INITRAMFS=''
+QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
 _qps_owner() { /usr/bin/stat -f '%u' "$1"; }
 _qps_permissions() { /usr/bin/stat -f '%Lp' "$1"; }
+_qps_lstat_kind() { /usr/bin/stat -f '%HT' "$1"; }
+_qps_size() { /usr/bin/stat -f '%z' "$1"; }
 qemu_persistent_storage_release_lock() { :; }
-qemu_persistent_storage_materialize_source() { return 1; }
+qemu_persistent_storage_materialize_source() {
+  printf 'materialize\n' >>"$FAKE_STORAGE_LOG"
+  return 1
+}
+qemu_persistent_storage_select_existing() {
+  printf 'select-existing\n' >>"$FAKE_STORAGE_LOG"
+  QEMU_SELECTED_DISK="$FAKE_PERSISTENT_ROOT/rootfs.ext4"
+  if [[ ! -f $QEMU_SELECTED_DISK ]]; then
+    QEMU_SELECTED_DISK=''
+    return "$QEMU_PERSISTENT_STORAGE_MISSING_STATUS"
+  fi
+  printf 'reuse\n' >>"$FAKE_STORAGE_LOG"
+  QEMU_SELECTED_STORAGE_MODE=persistent
+  QEMU_PERSISTENT_STORAGE_DIRECTORY=$FAKE_PERSISTENT_ROOT
+  QEMU_PERSISTENT_STORAGE_IDENTITY=${FAKE_SAVED_IDENTITY:-saved-vm}
+  if [[ -f $FAKE_PERSISTENT_ROOT/boot/kernel && \
+        -f $FAKE_PERSISTENT_ROOT/boot/initramfs && \
+        -f $FAKE_PERSISTENT_ROOT/boot/command-line ]]; then
+    QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+    QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=$(<"$FAKE_PERSISTENT_ROOT/boot/command-line")
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+  else
+    QEMU_SELECTED_KERNEL=''
+    QEMU_SELECTED_INITRAMFS=''
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=1
+  fi
+}
+qemu_persistent_storage_stage_selected_boot_kit() {
+  printf 'stage-recovered-boot\n' >>"$FAKE_STORAGE_LOG"
+  mkdir -p "$FAKE_PERSISTENT_ROOT/boot"
+  /bin/cp "$1" "$FAKE_PERSISTENT_ROOT/boot/kernel"
+  /bin/cp "$2" "$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  printf '%s\n' "$3" >"$FAKE_PERSISTENT_ROOT/boot/command-line"
+  QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+  QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=$3
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+}
 qemu_persistent_storage_select() {
   printf 'select %s\n' "$1" >>"$FAKE_STORAGE_LOG"
+  if [[ $1 == ephemeral ]]; then
+    mkdir -p "$6"
+    QEMU_SELECTED_DISK="$6/rootfs.ext4"
+    /bin/cp "$3" "$QEMU_SELECTED_DISK"
+    chmod 600 "$QEMU_SELECTED_DISK"
+    QEMU_SELECTED_STORAGE_MODE=ephemeral
+    QEMU_PERSISTENT_STORAGE_DIRECTORY=''
+    QEMU_PERSISTENT_STORAGE_IDENTITY=''
+    QEMU_SELECTED_KERNEL=$8
+    QEMU_SELECTED_INITRAMFS=$9
+    QEMU_SELECTED_KERNEL_COMMAND_LINE=${10}
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+    return 0
+  fi
   mkdir -p "$FAKE_PERSISTENT_ROOT"
   QEMU_SELECTED_DISK="$FAKE_PERSISTENT_ROOT/rootfs.ext4"
-  if [[ -f $QEMU_SELECTED_DISK ]]; then
+  if [[ $1 != reset && -f $QEMU_SELECTED_DISK ]]; then
     printf 'reuse\n' >>"$FAKE_STORAGE_LOG"
   else
     printf 'factory\n' >"$QEMU_SELECTED_DISK"
     printf 'create\n' >>"$FAKE_STORAGE_LOG"
   fi
   chmod 600 "$QEMU_SELECTED_DISK"
-  QEMU_SELECTED_STORAGE_MODE=$([[ $1 == ephemeral ]] && printf ephemeral || printf persistent)
+  mkdir -p "$FAKE_PERSISTENT_ROOT/boot"
+  /bin/cp "$8" "$FAKE_PERSISTENT_ROOT/boot/kernel"
+  /bin/cp "$9" "$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  printf '%s\n' "${10}" >"$FAKE_PERSISTENT_ROOT/boot/command-line"
+  QEMU_SELECTED_STORAGE_MODE=persistent
   QEMU_PERSISTENT_STORAGE_DIRECTORY=$FAKE_PERSISTENT_ROOT
+  QEMU_PERSISTENT_STORAGE_IDENTITY=${FAKE_SAVED_IDENTITY:-saved-vm}
+  QEMU_SELECTED_KERNEL="$FAKE_PERSISTENT_ROOT/boot/kernel"
+  QEMU_SELECTED_INITRAMFS="$FAKE_PERSISTENT_ROOT/boot/initramfs"
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=${10}
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
 }
 SH
 chmod 644 "$resources/scripts/qemu-persistent-storage.sh"
@@ -234,11 +323,17 @@ run_scenario() {
 
 run_scenario disabled 0 ''
 disabled_qemu=$(<"$test_root/disabled/qemu.log")
+assert_line_pair "$test_root/disabled/qemu.log" -machine \
+  'virt,accel=hvf,gic-version=3'
+assert_not_contains "$disabled_qemu" gic-version=2
 assert_line_pair "$test_root/disabled/qemu.log" -netdev 'user,id=omarchy-net'
+assert_line_pair "$test_root/disabled/qemu.log" -kernel "$persistent_root/boot/kernel"
+assert_line_pair "$test_root/disabled/qemu.log" -initrd "$persistent_root/boot/initramfs"
 assert_not_contains "$disabled_qemu" hostfwd
 assert_not_contains "$disabled_qemu" tryomarchy.ssh_access
 assert_contains "$disabled_qemu" \
   'cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=on,full-grab=on,immersive=on,swap-opt-cmd=off'
+assert_contains "$(<"$test_root/disabled/storage.log")" select-existing
 assert_contains "$(<"$test_root/disabled/storage.log")" create
 
 run_scenario non-immersive 0 '' OMARCHY_QEMU_GPU_IMMERSIVE=0
@@ -246,13 +341,121 @@ non_immersive_qemu=$(<"$test_root/non-immersive/qemu.log")
 assert_contains "$non_immersive_qemu" \
   'cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=on,full-grab=on,immersive=off,swap-opt-cmd=off'
 
+# Simulate installing a newer app build after the first VM was created. The
+# saved VM must be selected before the launcher even considers the absent new
+# factory image, and it must boot with the kernel, initramfs, and base command
+# line that were paired with its disk.
+/bin/rm -f "$guest/rootfs.ext4"
+printf 'new-kernel\n' >"$guest/vmlinuz-linux"
+printf 'new-initramfs\n' >"$guest/initramfs-linux.img"
+/usr/bin/plutil -replace kernelCommandLine -string \
+  'root=/dev/vda rw rootwait console=tty0 console=hvc0 loglevel=5 systemd.show_status=false rd.systemd.show_status=false mitigations=off nowatchdog' \
+  "$guest/launch.plist"
 run_scenario enabled 0 '' OMARCHY_QEMU_GPU_PORT_FORWARDS=tcp:2223:22
 enabled_qemu=$(<"$test_root/enabled/qemu.log")
 assert_line_pair "$test_root/enabled/qemu.log" -netdev \
   'user,id=omarchy-net,hostfwd=tcp:127.0.0.1:2223-:22'
+assert_line_pair "$test_root/enabled/qemu.log" -kernel "$persistent_root/boot/kernel"
+assert_line_pair "$test_root/enabled/qemu.log" -initrd "$persistent_root/boot/initramfs"
 assert_contains "$enabled_qemu" tryomarchy.ssh_access=1
+assert_contains "$enabled_qemu" loglevel=4
+assert_not_contains "$enabled_qemu" loglevel=5
 assert_not_contains "$enabled_qemu" 0.0.0.0
 assert_contains "$(<"$test_root/enabled/storage.log")" reuse
+assert_not_contains "$(<"$test_root/enabled/storage.log")" materialize
+assert_not_contains "$(<"$test_root/enabled/storage.log")" 'select persistent'
+assert_contains "$(<"$persistent_root/boot/kernel")" kernel
+assert_not_contains "$(<"$persistent_root/boot/kernel")" new-kernel
+printf 'factory\n' >"$guest/rootfs.ext4"
+
+# Older schema-2 disks have no host-side boot kit. Merely selecting one asks
+# the app for explicit consent (status 80) and does not start either recovery
+# or the normal VM.
+recovery_root="$test_root/recovery-persistent"
+mkdir -p "$recovery_root"
+printf 'legacy-user-disk\n' >"$recovery_root/rootfs.ext4"
+chmod 600 "$recovery_root/rootfs.ext4"
+run_scenario recovery-consent-required 80 '' \
+  "FAKE_PERSISTENT_ROOT=$recovery_root" \
+  "FAKE_QEMU_RECOVERY_LOG=$test_root/recovery-consent-required/recovery.log"
+assert_contains "$(<"$test_root/recovery-consent-required/storage.log")" reuse
+assert_not_contains "$(<"$test_root/recovery-consent-required/storage.log")" stage-recovered-boot
+assert_contains "$(<"$test_root/recovery-consent-required/stderr")" \
+  'needs consent for one-time read-only boot pairing'
+[[ ! -e $test_root/recovery-consent-required/qemu.log ]] || \
+  fail 'recovery consent request started the normal VM'
+[[ ! -e $test_root/recovery-consent-required/recovery.log ]] || \
+  fail 'recovery consent request started recovery QEMU'
+[[ ! -e $recovery_root/boot ]] || fail 'recovery consent request staged boot files'
+
+# A recovery-specific failure keeps its own status so the app can explain that
+# the saved VM remains intact and offer another attempt instead of blaming the
+# installed app generally.
+recovery_failure_root="$test_root/recovery-failure-persistent"
+mkdir -p "$recovery_failure_root"
+printf 'legacy-user-disk\n' >"$recovery_failure_root/rootfs.ext4"
+chmod 600 "$recovery_failure_root/rootfs.ext4"
+run_scenario recovery-failed 81 '' \
+  "FAKE_PERSISTENT_ROOT=$recovery_failure_root" \
+  "FAKE_QEMU_RECOVERY_LOG=$test_root/recovery-failed/recovery.log" \
+  OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY=1 \
+  FAKE_QEMU_STATUS=17
+assert_contains "$(<"$test_root/recovery-failed/stderr")" \
+  'the one-time boot recovery exited with status 17'
+[[ ! -e $test_root/recovery-failed/qemu.log ]] || \
+  fail 'failed recovery started the normal VM'
+[[ ! -e $recovery_failure_root/boot ]] || \
+  fail 'failed recovery staged a boot kit'
+assert_contains "$(<"$recovery_failure_root/rootfs.ext4")" legacy-user-disk
+
+# With consent, the recovery boot exposes the disk read-only and exports only
+# its matching boot pair. The subsequent normal boot consumes the newly staged
+# files and the recovered base command line.
+run_scenario recovery-allowed 0 '' \
+  "FAKE_PERSISTENT_ROOT=$recovery_root" \
+  "FAKE_QEMU_RECOVERY_LOG=$test_root/recovery-allowed/recovery.log" \
+  OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY=1
+recovery_qemu=$(<"$test_root/recovery-allowed/recovery.log")
+assert_line_pair "$test_root/recovery-allowed/recovery.log" -machine \
+  'virt,accel=hvf,gic-version=3'
+assert_not_contains "$recovery_qemu" gic-version=2
+assert_line_pair "$test_root/recovery-allowed/recovery.log" -drive \
+  "if=none,id=omarchy-recovery-root,file=$recovery_root/rootfs.ext4,format=raw,media=disk,cache=none,readonly=on"
+assert_line_pair "$test_root/recovery-allowed/recovery.log" -device \
+  'virtio-9p-pci,fsdev=omarchy-boot-export,mount_tag=try-omarchy-boot-export,romfile='
+assert_contains "$recovery_qemu" 'root=/dev/vda ro rootwait'
+assert_contains "$recovery_qemu" 'rootflags=noload fsck.mode=skip tryomarchy.export_boot=1'
+assert_not_contains "$recovery_qemu" 'root=/dev/vda rw rootwait'
+[[ $(grep -o 'rootflags=noload' \
+  "$test_root/recovery-allowed/recovery.log" | wc -l | tr -d ' ') == 1 ]] || \
+  fail 'recovery must force exactly one read-only no-journal mount option'
+[[ $(grep -o 'tryomarchy.export_boot=1' \
+  "$test_root/recovery-allowed/recovery.log" | wc -l | tr -d ' ') == 1 ]] || \
+  fail 'recovery must append exactly one boot-export activation token'
+assert_contains "$(<"$test_root/recovery-allowed/storage.log")" stage-recovered-boot
+assert_line_pair "$test_root/recovery-allowed/qemu.log" -kernel "$recovery_root/boot/kernel"
+assert_line_pair "$test_root/recovery-allowed/qemu.log" -initrd "$recovery_root/boot/initramfs"
+assert_contains "$(<"$test_root/recovery-allowed/qemu.log")" loglevel=3
+assert_not_contains "$(<"$test_root/recovery-allowed/qemu.log")" loglevel=5
+assert_contains "$(<"$recovery_root/boot/kernel")" recovered-kernel
+assert_contains "$(<"$recovery_root/boot/initramfs")" recovered-initramfs
+assert_contains "$(<"$recovery_root/boot/command-line")" loglevel=3
+assert_contains "$(<"$recovery_root/rootfs.ext4")" legacy-user-disk
+
+# Once paired, the same VM launches without consent and without another
+# recovery invocation.
+run_scenario recovery-relaunch 0 '' \
+  "FAKE_PERSISTENT_ROOT=$recovery_root" \
+  "FAKE_QEMU_RECOVERY_LOG=$test_root/recovery-relaunch/recovery.log"
+assert_contains "$(<"$test_root/recovery-relaunch/storage.log")" reuse
+assert_not_contains "$(<"$test_root/recovery-relaunch/storage.log")" stage-recovered-boot
+assert_not_contains "$(<"$test_root/recovery-relaunch/stderr")" 'needs consent'
+[[ ! -e $test_root/recovery-relaunch/recovery.log ]] || \
+  fail 'a paired VM unnecessarily ran boot recovery again'
+assert_line_pair "$test_root/recovery-relaunch/qemu.log" -kernel "$recovery_root/boot/kernel"
+assert_line_pair "$test_root/recovery-relaunch/qemu.log" -initrd "$recovery_root/boot/initramfs"
+assert_contains "$(<"$test_root/recovery-relaunch/qemu.log")" loglevel=3
+assert_contains "$(<"$recovery_root/rootfs.ext4")" legacy-user-disk
 
 run_scenario preset 0 '' OMARCHY_QEMU_GPU_PORT_FORWARDS=tcp:2222:22
 assert_line_pair "$test_root/preset/qemu.log" -netdev \
@@ -283,6 +486,9 @@ assert_contains "$(<"$test_root/ephemeral/qemu.log")" \
   'user,id=omarchy-net,hostfwd=tcp:127.0.0.1:2224-:22'
 assert_contains "$(<"$test_root/ephemeral/qemu.log")" tryomarchy.ssh_access=1
 assert_contains "$(<"$test_root/ephemeral/storage.log")" 'select ephemeral'
+assert_line_pair "$test_root/ephemeral/qemu.log" -kernel "$guest/vmlinuz-linux"
+assert_line_pair "$test_root/ephemeral/qemu.log" -initrd "$guest/initramfs-linux.img"
+assert_contains "$(<"$test_root/ephemeral/qemu.log")" loglevel=5
 
 run_scenario malformed 1 '' OMARCHY_QEMU_GPU_PORT_FORWARDS=tcp:02222:22
 [[ ! -s $test_root/malformed/storage.log ]] || fail 'malformed mapping touched storage'
@@ -293,6 +499,9 @@ run_scenario reset-only 0 --reset-storage-only \
 assert_contains "$(<"$test_root/reset-only/storage.log")" 'select reset'
 [[ ! -e $test_root/reset-only/qemu.log ]] || fail 'reset-only launch started QEMU'
 assert_not_contains "$(<"$test_root/reset-only/stderr")" tryomarchy.ssh_access
+assert_contains "$(<"$persistent_root/boot/kernel")" new-kernel
+assert_contains "$(<"$persistent_root/boot/initramfs")" new-initramfs
+assert_contains "$(<"$persistent_root/boot/command-line")" loglevel=5
 
 /usr/bin/plutil -replace kernelCommandLine -string \
   'root=/dev/vda rw rootwait console=tty0 console=hvc0 tryomarchy.ssh_access=0' \

--- a/macos/qemu-persistent-storage.sh
+++ b/macos/qemu-persistent-storage.sh
@@ -11,10 +11,13 @@
 
 QEMU_PERSISTENT_STORAGE_SCHEMA=2
 QEMU_PERSISTENT_STORAGE_KIND='omarchy-qemu-persistent-disk'
+QEMU_PERSISTENT_STORAGE_BOOT_KIT_KIND='omarchy-qemu-boot-kit'
+QEMU_PERSISTENT_STORAGE_BOOT_ABI='qemu-arm64-direct-v1'
 QEMU_PERSISTENT_STORAGE_ROOT_MARKER='omarchy-qemu-storage-root-v1'
 QEMU_PERSISTENT_STORAGE_LOCK_FD=9
 QEMU_PERSISTENT_STORAGE_QEMU_ADD_FD='fd=9,set=77,opaque=omarchy-persistent-lock'
 QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS=78
+QEMU_PERSISTENT_STORAGE_MISSING_STATUS=79
 # Room the guest needs beyond whatever the workspace itself costs to create.
 QEMU_PERSISTENT_STORAGE_HEADROOM_BYTES=1073741824
 
@@ -25,12 +28,24 @@ QEMU_PERSISTENT_STORAGE_IDENTITY=''
 QEMU_PERSISTENT_STORAGE_LOCK_PATH=''
 QEMU_PERSISTENT_STORAGE_WORKING_BYTES=''
 QEMU_IMMUTABLE_SOURCE_DISK=''
+QEMU_SELECTED_KERNEL=''
+QEMU_SELECTED_INITRAMFS=''
+QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
 QPS_LEGACY_LOCK_PATH=''
 QPS_METADATA_SCHEMA=''
 QPS_METADATA_IDENTITY=''
 QPS_METADATA_SOURCE_SHA=''
 QPS_METADATA_SOURCE_BYTES=''
 QPS_RECORDED_EXISTING_BYTES=''
+QPS_BOOT_IDENTITY=''
+QPS_BOOT_ABI=''
+QPS_BOOT_COMMAND_LINE_BYTES=''
+QPS_BOOT_COMMAND_LINE_SHA=''
+QPS_BOOT_INITRAMFS_BYTES=''
+QPS_BOOT_INITRAMFS_SHA=''
+QPS_BOOT_KERNEL_BYTES=''
+QPS_BOOT_KERNEL_SHA=''
 
 _qps_error() {
   printf 'qemu-persistent-storage: %s\n' "$*" >&2
@@ -68,6 +83,18 @@ _qps_permissions() {
 
 _qps_size() {
   /usr/bin/stat -f '%z' "$1" 2>/dev/null
+}
+
+_qps_sha256() {
+  /usr/bin/shasum -a 256 "$1" 2>/dev/null | awk '{ print $1 }'
+}
+
+_qps_sha256_line() {
+  printf '%s\n' "$1" | /usr/bin/shasum -a 256 2>/dev/null | awk '{ print $1 }'
+}
+
+_qps_line_bytes() {
+  printf '%s\n' "$1" | /usr/bin/wc -c | tr -d '[:space:]'
 }
 
 _qps_file_identity() {
@@ -305,7 +332,7 @@ _qps_prepare_state_root() {
   fi
   _qps_validate_root_marker "$qps_marker" || return 1
 
-  for qps_child in disks images locks; do
+  for qps_child in boot disks images locks; do
     if [[ ! -e $qps_root/$qps_child && ! -L $qps_root/$qps_child ]]; then
       if mkdir "$qps_root/$qps_child" 2>/dev/null; then
         chmod 700 "$qps_root/$qps_child" || return 1
@@ -318,6 +345,7 @@ _qps_prepare_state_root() {
   done
 
   QEMU_PERSISTENT_STORAGE_ROOT=$qps_root
+  QEMU_PERSISTENT_STORAGE_BOOT_ROOT="$qps_root/boot"
   QEMU_PERSISTENT_STORAGE_DISKS_ROOT="$qps_root/disks"
   QEMU_PERSISTENT_STORAGE_IMAGES_ROOT="$qps_root/images"
   QEMU_PERSISTENT_STORAGE_LOCKS_ROOT="$qps_root/locks"
@@ -588,6 +616,429 @@ _qps_clone_disk() {
     _qps_fail "cannot flush the initialized root disk"
     return 1
   }
+}
+
+_qps_validate_kernel_command_line() {
+  local qps_line=$1
+  local qps_argument=''
+  local qps_root_count=0
+  local qps_rw_count=0
+  local qps_rootwait_count=0
+  local qps_console_zero_count=0
+  local qps_console_hvc_count=0
+
+  [[ -n $qps_line && ${#qps_line} -le 16384 ]] || return 1
+  [[ $qps_line != *$'\n'* && $qps_line != *$'\r'* && \
+     $qps_line != *$'\t'* && $qps_line != *'"'* && \
+     $qps_line != *'\\'* ]] || return 1
+  for qps_argument in $qps_line; do
+    case "$qps_argument" in
+      root=/dev/vda) ((qps_root_count += 1)) ;;
+      rw) ((qps_rw_count += 1)) ;;
+      rootwait) ((qps_rootwait_count += 1)) ;;
+      console=tty0) ((qps_console_zero_count += 1)) ;;
+      console=hvc0) ((qps_console_hvc_count += 1)) ;;
+      omarchy.qemu_virgl=*|omarchy.shared_folder_name=*|tryomarchy.ssh_access=*|\
+      tryomarchy.export_boot=*) return 1 ;;
+    esac
+  done
+  (( qps_root_count == 1 && qps_rw_count == 1 && qps_rootwait_count == 1 && \
+     qps_console_zero_count == 1 && qps_console_hvc_count == 1 ))
+}
+
+_qps_assert_boot_source_file() {
+  local qps_path=$1
+  local qps_label=$2
+  local qps_maximum_bytes=$3
+  local qps_bytes=''
+  local qps_magic=''
+
+  [[ -f $qps_path && ! -L $qps_path ]] || {
+    _qps_fail "$qps_label is missing or unsafe: $qps_path"
+    return 1
+  }
+  [[ $(_qps_lstat_kind "$qps_path") == 'Regular File' ]] || {
+    _qps_fail "$qps_label is not a regular file: $qps_path"
+    return 1
+  }
+  qps_bytes=$(_qps_size "$qps_path")
+  _qps_is_positive_integer "$qps_bytes" && (( qps_bytes <= qps_maximum_bytes )) || {
+    _qps_fail "$qps_label has an invalid size: $qps_path"
+    return 1
+  }
+  case "$qps_label" in
+    *kernel)
+      qps_magic=$(/usr/bin/od -An -tc -j 56 -N 4 "$qps_path" | tr -d '[:space:]') || return 1
+      [[ $qps_magic == ARMd ]] || {
+        _qps_fail "$qps_label is not an uncompressed ARM64 Image"
+        return 1
+      }
+      ;;
+    *initramfs)
+      qps_magic=$(/usr/bin/od -An -tx1 -N 6 "$qps_path" | tr -d '[:space:]') || return 1
+      case "$qps_magic" in
+        303730373031|303730373032|28b52ffd????) ;;
+        *)
+        _qps_fail "$qps_label is not a raw newc or zstd initramfs"
+        return 1
+        ;;
+      esac
+      ;;
+  esac
+}
+
+_qps_copy_private_file() {
+  local qps_source=$1
+  local qps_destination=$2
+  local qps_label=$3
+  local qps_expected_bytes=$4
+  local qps_expected_sha=$5
+
+  [[ ! -e $qps_destination && ! -L $qps_destination ]] || return 1
+  if /bin/cp -c "$qps_source" "$qps_destination" 2>/dev/null; then
+    :
+  else
+    [[ ! -e $qps_destination && ! -L $qps_destination ]] || /bin/rm -f "$qps_destination"
+    /bin/cp "$qps_source" "$qps_destination" || {
+      _qps_fail "cannot copy $qps_label"
+      return 1
+    }
+  fi
+  chmod 600 "$qps_destination" || return 1
+  _qps_assert_private_regular_file "$qps_destination" "$qps_label" || return 1
+  [[ $(_qps_size "$qps_destination") == "$qps_expected_bytes" && \
+     $(_qps_sha256 "$qps_destination") == "$qps_expected_sha" ]] || {
+    _qps_fail "$qps_label copy does not match its source"
+    return 1
+  }
+  [[ $(_qps_file_identity "$qps_destination") != $(_qps_file_identity "$qps_source") ]] || {
+    _qps_fail "$qps_label copy aliases its source inode"
+    return 1
+  }
+}
+
+_qps_write_boot_metadata() {
+  local qps_path=$1
+  local qps_identity=$2
+  local qps_command_line_bytes=$3
+  local qps_command_line_sha=$4
+  local qps_kernel_bytes=$5
+  local qps_kernel_sha=$6
+  local qps_initramfs_bytes=$7
+  local qps_initramfs_sha=$8
+
+  (umask 077; set -o noclobber; printf \
+    '{"bootABI":"%s","bundleIdentity":"%s","commandLine":{"bytes":%s,"sha256":"%s"},"initramfs":{"bytes":%s,"sha256":"%s"},"kernel":{"bytes":%s,"sha256":"%s"},"kind":"%s","schemaVersion":1}\n' \
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ABI" \
+    "$qps_identity" \
+    "$qps_command_line_bytes" \
+    "$qps_command_line_sha" \
+    "$qps_initramfs_bytes" \
+    "$qps_initramfs_sha" \
+    "$qps_kernel_bytes" \
+    "$qps_kernel_sha" \
+    "$QEMU_PERSISTENT_STORAGE_BOOT_KIT_KIND" >"$qps_path") 2>/dev/null
+}
+
+_qps_read_boot_metadata() {
+  local qps_path=$1
+  local qps_content=''
+  local qps_pattern='^\{"bootABI":"([A-Za-z0-9._-]+)","bundleIdentity":"([0-9a-f]{64})","commandLine":\{"bytes":([1-9][0-9]*),"sha256":"([0-9a-f]{64})"\},"initramfs":\{"bytes":([1-9][0-9]*),"sha256":"([0-9a-f]{64})"\},"kernel":\{"bytes":([1-9][0-9]*),"sha256":"([0-9a-f]{64})"\},"kind":"omarchy-qemu-boot-kit","schemaVersion":1\}$'
+
+  _qps_assert_private_regular_file "$qps_path" 'boot-kit metadata' || return 1
+  [[ $(_qps_size "$qps_path") -le 16384 ]] || return 1
+  qps_content=$(<"$qps_path")
+  [[ $qps_content =~ $qps_pattern ]] || {
+    _qps_fail 'boot-kit metadata has an unknown format'
+    return 1
+  }
+  QPS_BOOT_ABI=${BASH_REMATCH[1]}
+  QPS_BOOT_IDENTITY=${BASH_REMATCH[2]}
+  QPS_BOOT_COMMAND_LINE_BYTES=${BASH_REMATCH[3]}
+  QPS_BOOT_COMMAND_LINE_SHA=${BASH_REMATCH[4]}
+  QPS_BOOT_INITRAMFS_BYTES=${BASH_REMATCH[5]}
+  QPS_BOOT_INITRAMFS_SHA=${BASH_REMATCH[6]}
+  QPS_BOOT_KERNEL_BYTES=${BASH_REMATCH[7]}
+  QPS_BOOT_KERNEL_SHA=${BASH_REMATCH[8]}
+}
+
+_qps_has_only_boot_contents() (
+  local qps_directory=$1
+  local qps_entry=''
+  local qps_names=''
+
+  shopt -s nullglob dotglob
+  for qps_entry in "$qps_directory"/*; do
+    qps_names+="${qps_entry##*/}"$'\n'
+  done
+  shopt -u nullglob dotglob
+  [[ $qps_names == $'command-line\ninitramfs\nkernel\nmetadata.json\n' ]]
+)
+
+_qps_validate_boot_kit_directory() {
+  local qps_directory=$1
+  local qps_expected_identity=$2
+  local qps_command_line=''
+
+  _qps_assert_private_directory "$qps_directory" 'boot-kit directory' || return 1
+  _qps_has_only_boot_contents "$qps_directory" || {
+    _qps_fail "boot-kit directory contains unexpected files: $qps_directory"
+    return 1
+  }
+  _qps_read_boot_metadata "$qps_directory/metadata.json" || return 1
+  [[ $QPS_BOOT_ABI == "$QEMU_PERSISTENT_STORAGE_BOOT_ABI" ]] || {
+    _qps_incompatible "the saved VM uses unsupported boot ABI $QPS_BOOT_ABI"
+    return $?
+  }
+  [[ $QPS_BOOT_IDENTITY == "$qps_expected_identity" ]] || {
+    _qps_fail 'boot-kit identity does not match its VM disk'
+    return 1
+  }
+  case ${qps_directory##*/} in
+    "$qps_expected_identity"|."$qps_expected_identity".initializing.??????) ;;
+    *)
+      _qps_fail 'boot-kit directory name does not match its VM disk'
+      return 1
+      ;;
+  esac
+  _qps_assert_private_regular_file "$qps_directory/command-line" 'boot-kit command line' || return 1
+  _qps_assert_private_regular_file "$qps_directory/kernel" 'boot-kit kernel' || return 1
+  _qps_assert_private_regular_file "$qps_directory/initramfs" 'boot-kit initramfs' || return 1
+  [[ $(_qps_size "$qps_directory/command-line") == "$QPS_BOOT_COMMAND_LINE_BYTES" && \
+     $(_qps_sha256 "$qps_directory/command-line") == "$QPS_BOOT_COMMAND_LINE_SHA" && \
+     $(_qps_size "$qps_directory/kernel") == "$QPS_BOOT_KERNEL_BYTES" && \
+     $(_qps_sha256 "$qps_directory/kernel") == "$QPS_BOOT_KERNEL_SHA" && \
+     $(_qps_size "$qps_directory/initramfs") == "$QPS_BOOT_INITRAMFS_BYTES" && \
+     $(_qps_sha256 "$qps_directory/initramfs") == "$QPS_BOOT_INITRAMFS_SHA" ]] || {
+    _qps_fail 'boot-kit contents do not match their metadata'
+    return 1
+  }
+  _qps_assert_boot_source_file "$qps_directory/kernel" 'boot-kit kernel' 536870912 || return 1
+  _qps_assert_boot_source_file "$qps_directory/initramfs" 'boot-kit initramfs' 1073741824 || return 1
+  qps_command_line=$(<"$qps_directory/command-line")
+  _qps_validate_kernel_command_line "$qps_command_line" || {
+    _qps_fail 'boot-kit command line is invalid'
+    return 1
+  }
+}
+
+_qps_validate_interrupted_boot_staging() (
+  local qps_staging=$1
+  local qps_identity=$2
+  local qps_kernel_bytes=$3
+  local qps_kernel_sha=$4
+  local qps_initramfs_bytes=$5
+  local qps_initramfs_sha=$6
+  local qps_command_line_bytes=$7
+  local qps_command_line_sha=$8
+  local qps_entry=''
+  local qps_has_kernel=0
+  local qps_has_initramfs=0
+  local qps_has_command_line=0
+  local qps_has_metadata=0
+  local qps_count=0
+
+  case "$qps_staging" in
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/.${qps_identity}.initializing."??????) ;;
+    *) return 1 ;;
+  esac
+  _qps_assert_private_directory \
+    "$qps_staging" 'interrupted boot-kit staging directory' || return 1
+  shopt -s nullglob dotglob
+  for qps_entry in "$qps_staging"/*; do
+    ((qps_count += 1))
+    case ${qps_entry##*/} in
+      kernel) qps_has_kernel=1 ;;
+      initramfs) qps_has_initramfs=1 ;;
+      command-line) qps_has_command_line=1 ;;
+      metadata.json) qps_has_metadata=1 ;;
+      *) return 1 ;;
+    esac
+  done
+  shopt -u nullglob dotglob
+
+  # The staging sequence is kernel, initramfs, command line, then metadata.
+  # Only prefixes whose bytes exactly match this launch are attributable to us.
+  (( qps_has_kernel == 1 && qps_count >= 1 && qps_count <= 4 )) || return 1
+  (( qps_has_initramfs == 1 || qps_count == 1 )) || return 1
+  (( qps_has_command_line == 1 || qps_count <= 2 )) || return 1
+  (( qps_has_metadata == 1 || qps_count <= 3 )) || return 1
+  _qps_assert_private_regular_file \
+    "$qps_staging/kernel" 'interrupted boot-kit kernel' || return 1
+  [[ $(_qps_size "$qps_staging/kernel") == "$qps_kernel_bytes" && \
+     $(_qps_sha256 "$qps_staging/kernel") == "$qps_kernel_sha" ]] || return 1
+  if (( qps_has_initramfs )); then
+    _qps_assert_private_regular_file \
+      "$qps_staging/initramfs" 'interrupted boot-kit initramfs' || return 1
+    [[ $(_qps_size "$qps_staging/initramfs") == "$qps_initramfs_bytes" && \
+       $(_qps_sha256 "$qps_staging/initramfs") == "$qps_initramfs_sha" ]] || return 1
+  fi
+  if (( qps_has_command_line )); then
+    _qps_assert_private_regular_file \
+      "$qps_staging/command-line" 'interrupted boot-kit command line' || return 1
+    [[ $(_qps_size "$qps_staging/command-line") == "$qps_command_line_bytes" && \
+       $(_qps_sha256 "$qps_staging/command-line") == "$qps_command_line_sha" ]] || return 1
+  fi
+  if (( qps_has_metadata )); then
+    _qps_validate_boot_kit_directory "$qps_staging" "$qps_identity" || return 1
+    [[ $QPS_BOOT_KERNEL_BYTES == "$qps_kernel_bytes" && \
+       $QPS_BOOT_KERNEL_SHA == "$qps_kernel_sha" && \
+       $QPS_BOOT_INITRAMFS_BYTES == "$qps_initramfs_bytes" && \
+       $QPS_BOOT_INITRAMFS_SHA == "$qps_initramfs_sha" && \
+       $QPS_BOOT_COMMAND_LINE_BYTES == "$qps_command_line_bytes" && \
+       $QPS_BOOT_COMMAND_LINE_SHA == "$qps_command_line_sha" ]] || return 1
+  fi
+)
+
+_qps_reap_interrupted_boot_staging() {
+  local qps_identity=$1
+  local qps_kernel_bytes=$2
+  local qps_kernel_sha=$3
+  local qps_initramfs_bytes=$4
+  local qps_initramfs_sha=$5
+  local qps_command_line_bytes=$6
+  local qps_command_line_sha=$7
+  local qps_staging=''
+
+  for qps_staging in \
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT"/."$qps_identity".initializing.??????; do
+    [[ -e $qps_staging || -L $qps_staging ]] || continue
+    if _qps_validate_interrupted_boot_staging \
+      "$qps_staging" "$qps_identity" \
+      "$qps_kernel_bytes" "$qps_kernel_sha" \
+      "$qps_initramfs_bytes" "$qps_initramfs_sha" \
+      "$qps_command_line_bytes" "$qps_command_line_sha"; then
+      if /bin/rm -rf "$qps_staging"; then
+        _qps_fsync "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" || true
+        _qps_error "removed recognized interrupted boot-kit staging ${qps_staging##*/}"
+      else
+        _qps_error "could not remove recognized interrupted boot-kit staging: $qps_staging"
+      fi
+    else
+      _qps_error "left unrecognized interrupted boot-kit staging untouched: $qps_staging"
+    fi
+  done
+  return 0
+}
+
+_qps_stage_boot_kit_locked() {
+  local qps_identity=$1
+  local qps_kernel=$2
+  local qps_initramfs=$3
+  local qps_command_line=$4
+  local qps_final="$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$qps_identity"
+  local qps_staging=''
+  local qps_kernel_bytes=''
+  local qps_kernel_sha=''
+  local qps_initramfs_bytes=''
+  local qps_initramfs_sha=''
+  local qps_command_line_bytes=''
+  local qps_command_line_sha=''
+
+  _qps_is_identity "$qps_identity" || return 1
+  _qps_assert_boot_source_file "$qps_kernel" 'source boot-kit kernel' 536870912 || return 1
+  _qps_assert_boot_source_file "$qps_initramfs" 'source boot-kit initramfs' 1073741824 || return 1
+  _qps_validate_kernel_command_line "$qps_command_line" || {
+    _qps_fail 'source boot-kit command line is invalid'
+    return 1
+  }
+  qps_kernel_bytes=$(_qps_size "$qps_kernel")
+  qps_kernel_sha=$(_qps_sha256 "$qps_kernel")
+  qps_initramfs_bytes=$(_qps_size "$qps_initramfs")
+  qps_initramfs_sha=$(_qps_sha256 "$qps_initramfs")
+  qps_command_line_bytes=$(_qps_line_bytes "$qps_command_line")
+  qps_command_line_sha=$(_qps_sha256_line "$qps_command_line")
+  _qps_is_identity "$qps_kernel_sha" && _qps_is_identity "$qps_initramfs_sha" || return 1
+  _qps_is_positive_integer "$qps_command_line_bytes" && \
+    _qps_is_identity "$qps_command_line_sha" || return 1
+  _qps_reap_interrupted_boot_staging \
+    "$qps_identity" "$qps_kernel_bytes" "$qps_kernel_sha" \
+    "$qps_initramfs_bytes" "$qps_initramfs_sha" \
+    "$qps_command_line_bytes" "$qps_command_line_sha" || true
+
+  if [[ -e $qps_final || -L $qps_final ]]; then
+    _qps_validate_boot_kit_directory "$qps_final" "$qps_identity" || return $?
+    [[ $QPS_BOOT_KERNEL_BYTES == "$qps_kernel_bytes" && \
+       $QPS_BOOT_KERNEL_SHA == "$qps_kernel_sha" && \
+       $QPS_BOOT_INITRAMFS_BYTES == "$qps_initramfs_bytes" && \
+       $QPS_BOOT_INITRAMFS_SHA == "$qps_initramfs_sha" && \
+       $QPS_BOOT_COMMAND_LINE_BYTES == "$qps_command_line_bytes" && \
+       $QPS_BOOT_COMMAND_LINE_SHA == "$qps_command_line_sha" ]] || {
+      _qps_fail 'a different boot kit is already paired with this VM generation'
+      return 1
+    }
+    return 0
+  fi
+  qps_staging=$(mktemp -d \
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/.${qps_identity}.initializing.XXXXXX") || return 1
+  chmod 700 "$qps_staging" || return 1
+  if ! _qps_copy_private_file \
+    "$qps_kernel" "$qps_staging/kernel" 'staged boot-kit kernel' \
+    "$qps_kernel_bytes" "$qps_kernel_sha" || \
+    ! _qps_copy_private_file \
+    "$qps_initramfs" "$qps_staging/initramfs" 'staged boot-kit initramfs' \
+    "$qps_initramfs_bytes" "$qps_initramfs_sha"; then
+    /bin/rm -rf "$qps_staging"
+    return 1
+  fi
+  (umask 077; set -o noclobber; printf '%s\n' "$qps_command_line" \
+    >"$qps_staging/command-line") 2>/dev/null || {
+    /bin/rm -rf "$qps_staging"
+    return 1
+  }
+  [[ $(_qps_size "$qps_staging/command-line") == "$qps_command_line_bytes" && \
+     $(_qps_sha256 "$qps_staging/command-line") == "$qps_command_line_sha" ]] || {
+    /bin/rm -rf "$qps_staging"
+    return 1
+  }
+  if ! _qps_write_boot_metadata \
+    "$qps_staging/metadata.json" "$qps_identity" \
+    "$qps_command_line_bytes" "$qps_command_line_sha" \
+    "$qps_kernel_bytes" "$qps_kernel_sha" \
+    "$qps_initramfs_bytes" "$qps_initramfs_sha" || \
+    ! _qps_validate_boot_kit_directory "$qps_staging" "$qps_identity"; then
+    /bin/rm -rf "$qps_staging"
+    return 1
+  fi
+  _qps_fsync "$qps_staging" || return 1
+  [[ ! -e $qps_final && ! -L $qps_final ]] || return 1
+  /bin/mv "$qps_staging" "$qps_final" || return 1
+  _qps_fsync "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" || return 1
+  _qps_error "paired VM disk ${qps_identity:0:12} with its boot kit"
+}
+
+_qps_set_selected_boot_kit() {
+  local qps_identity=$1
+  local qps_directory="$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$qps_identity"
+
+  QEMU_SELECTED_KERNEL=''
+  QEMU_SELECTED_INITRAMFS=''
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+  if [[ ! -e $qps_directory && ! -L $qps_directory ]]; then
+    QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=1
+    return 0
+  fi
+  _qps_validate_boot_kit_directory "$qps_directory" "$qps_identity" || return $?
+  QEMU_SELECTED_KERNEL="$qps_directory/kernel"
+  QEMU_SELECTED_INITRAMFS="$qps_directory/initramfs"
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=$(<"$qps_directory/command-line")
+}
+
+qemu_persistent_storage_stage_selected_boot_kit() {
+  local qps_kernel=${1:-}
+  local qps_initramfs=${2:-}
+  local qps_command_line=${3:-}
+
+  if [[ $QEMU_SELECTED_STORAGE_MODE != persistent || \
+        -z $QEMU_PERSISTENT_STORAGE_IDENTITY ]] || ! _qps_lock_fd_is_open; then
+    _qps_fail 'a locked persistent VM must be selected before pairing its boot kit'
+    return 1
+  fi
+  _qps_stage_boot_kit_locked \
+    "$QEMU_PERSISTENT_STORAGE_IDENTITY" "$qps_kernel" "$qps_initramfs" \
+    "$qps_command_line" || return $?
+  _qps_set_selected_boot_kit "$QEMU_PERSISTENT_STORAGE_IDENTITY"
 }
 
 _qps_expand_disk() {
@@ -905,6 +1356,68 @@ _qps_initialize_persistent_disk() {
   _qps_error "initialized persistent workspace ${qps_identity:0:12}"
 }
 
+_qps_validate_boot_kit_reset_target() {
+  local qps_identity=$1
+  local qps_final="$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$qps_identity"
+  local qps_final_kind=''
+
+  _qps_is_identity "$qps_identity" || return 1
+  _qps_assert_private_directory \
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" 'state boot directory' || return 1
+  [[ -e $qps_final || -L $qps_final ]] || return 0
+  case "$qps_final" in
+    "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$qps_identity") ;;
+    *)
+      _qps_fail 'refusing to reset a boot-kit path outside its identity scope'
+      return 1
+      ;;
+  esac
+  qps_final_kind=$(_qps_lstat_kind "$qps_final") || return 1
+  [[ $(_qps_owner "$qps_final") == $(id -u) ]] || {
+    _qps_fail 'refusing to reset a boot-kit entry not owned by the current user'
+    return 1
+  }
+  if [[ $qps_final_kind == Directory ]]; then
+    [[ ! -L $qps_final ]] || return 1
+    [[ $(/usr/bin/stat -f '%d' "$qps_final" 2>/dev/null) == \
+       $(/usr/bin/stat -f '%d' "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" 2>/dev/null) ]] || {
+      _qps_fail 'refusing to recursively reset a boot kit on another filesystem'
+      return 1
+    }
+  fi
+}
+
+_qps_reset_boot_kit() {
+  local qps_identity=$1
+  local qps_final="$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$qps_identity"
+  local qps_discarded=''
+
+  _qps_validate_boot_kit_reset_target "$qps_identity" || return 1
+  [[ -e $qps_final || -L $qps_final ]] || return 0
+  qps_discarded="$QEMU_PERSISTENT_STORAGE_BOOT_ROOT/.${qps_identity}.discarded.$$.$RANDOM$RANDOM"
+  [[ ! -e $qps_discarded && ! -L $qps_discarded ]] || {
+    _qps_fail 'cannot allocate boot-kit reset transaction name'
+    return 1
+  }
+  /bin/mv "$qps_final" "$qps_discarded" || {
+    _qps_fail 'cannot detach the saved VM boot kit for reset'
+    return 1
+  }
+  _qps_fsync "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" || return 1
+  if [[ -d $qps_discarded && ! -L $qps_discarded ]]; then
+    # Corrupt contents are deliberately allowed here so Reset remains an escape
+    # hatch, but never cross a nested mount into data outside this boot kit.
+    /bin/rm -rf -x "$qps_discarded"
+  else
+    /bin/rm -f "$qps_discarded"
+  fi || {
+    _qps_fail 'cannot remove the reset VM boot kit'
+    return 1
+  }
+  _qps_fsync "$QEMU_PERSISTENT_STORAGE_BOOT_ROOT" || return 1
+  _qps_error "reset saved boot kit ${qps_identity:0:12}"
+}
+
 _qps_reset_persistent_disk() {
   local qps_storage_key=$1
   local qps_final="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/$qps_storage_key"
@@ -922,7 +1435,7 @@ _qps_reset_persistent_disk() {
   qps_existing_schema=$QPS_METADATA_SCHEMA
   qps_existing_source_sha=$QPS_METADATA_SOURCE_SHA
   qps_existing_source_bytes=$QPS_METADATA_SOURCE_BYTES
-
+  _qps_validate_boot_kit_reset_target "$qps_existing_identity" || return 1
   qps_discarded="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/.${qps_storage_key}.discarded.$$.$RANDOM$RANDOM"
   [[ ! -e $qps_discarded && ! -L $qps_discarded ]] || {
     _qps_fail 'cannot allocate reset transaction name'
@@ -937,6 +1450,7 @@ _qps_reset_persistent_disk() {
     "$qps_discarded" "$qps_existing_identity" "$qps_existing_source_sha" \
     "$qps_existing_source_bytes" "$qps_existing_bytes" 0 \
     "$qps_existing_schema" || return 1
+  _qps_reset_boot_kit "$qps_existing_identity" || return $?
   _qps_error "reset persistent workspace ${qps_existing_identity:0:12}"
 }
 
@@ -969,32 +1483,18 @@ _qps_validate_recorded_workspace() {
 _qps_require_compatible_workspace() {
   local qps_directory=$1
   local qps_identity=$2
-  local qps_source_sha=$3
-  local qps_source_bytes=$4
-  local qps_working_bytes=$5
-  local qps_existing_bytes=''
 
   _qps_validate_recorded_workspace "$qps_directory" || return 1
-  qps_existing_bytes=$QPS_RECORDED_EXISTING_BYTES
 
-  if [[ $QPS_METADATA_SCHEMA != "$QEMU_PERSISTENT_STORAGE_SCHEMA" || \
-        $QPS_METADATA_IDENTITY != "$qps_identity" || \
-        $QPS_METADATA_SOURCE_SHA != "$qps_source_sha" || \
-        $QPS_METADATA_SOURCE_BYTES != "$qps_source_bytes" ]]; then
+  if [[ $QPS_METADATA_SCHEMA != "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]]; then
     _qps_incompatible \
-      'the saved VM was created by a different Try Omarchy build; use Reset Omarchy to continue'
+      'the saved VM uses an unsupported storage format; use Reset Omarchy to continue'
     return $?
   fi
-
-  (( qps_existing_bytes <= qps_working_bytes )) || {
-    _qps_fail 'the existing Omarchy disk is larger than this app supports; refusing to shrink it'
-    return 1
-  }
-  if (( qps_existing_bytes < qps_working_bytes )); then
-    _qps_expand_disk "$qps_directory/rootfs.ext4" "$qps_existing_bytes" "$qps_working_bytes" || return 1
-    _qps_fsync "$qps_directory/rootfs.ext4" || return 1
+  if [[ $QPS_METADATA_IDENTITY != "$qps_identity" ]]; then
+    _qps_error \
+      "reusing saved VM ${QPS_METADATA_IDENTITY:0:12}; the bundled factory image applies only to new VMs"
   fi
-
   return 0
 }
 
@@ -1021,7 +1521,10 @@ _qps_reset_remaining_legacy_workspaces() {
       _qps_fail 'a legacy workspace changed before it could be reset'
       return 1
     fi
-
+    if ! _qps_validate_boot_kit_reset_target "$qps_candidate_name"; then
+      _qps_release_legacy_lock
+      return 1
+    fi
     qps_discarded="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/.current.discarded.legacy.${qps_candidate_name}.$$.$RANDOM$RANDOM"
     [[ ! -e $qps_discarded && ! -L $qps_discarded ]] || {
       _qps_release_legacy_lock
@@ -1033,6 +1536,10 @@ _qps_reset_remaining_legacy_workspaces() {
       ! _qps_remove_recorded_directory "$qps_discarded"; then
       _qps_release_legacy_lock
       _qps_fail "cannot reset legacy workspace $qps_candidate_name"
+      return 1
+    fi
+    if ! _qps_reset_boot_kit "$qps_candidate_name"; then
+      _qps_release_legacy_lock
       return 1
     fi
     _qps_release_legacy_lock
@@ -1063,9 +1570,6 @@ _qps_has_recognized_legacy_workspace() {
 _qps_migrate_legacy_single_workspace() {
   local qps_mode=$1
   local qps_identity=$2
-  local qps_source_sha=$3
-  local qps_source_bytes=$4
-  local qps_working_bytes=$5
   local qps_final="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/current"
   local qps_candidate=''
   local qps_candidate_mtime=''
@@ -1104,11 +1608,6 @@ _qps_migrate_legacy_single_workspace() {
       continue
     fi
     ((qps_valid_count += 1))
-    if (( QPS_RECORDED_EXISTING_BYTES > qps_working_bytes )); then
-      [[ $qps_candidate_name != "$qps_identity" ]] || qps_exact_invalid=1
-      _qps_error "leaving oversized legacy workspace untouched: $qps_candidate_name"
-      continue
-    fi
     qps_candidate_mtime=$(/usr/bin/stat -f '%m' "$qps_candidate/rootfs.ext4" 2>/dev/null)
     [[ $qps_candidate_mtime =~ ^[0-9]+$ ]] || {
       [[ $qps_candidate_name != "$qps_identity" ]] || qps_exact_invalid=1
@@ -1116,13 +1615,9 @@ _qps_migrate_legacy_single_workspace() {
       continue
     }
     if [[ $qps_mode == persistent ]]; then
-      if [[ $qps_candidate_name == "$qps_identity" && \
-            $QPS_METADATA_SCHEMA == "$QEMU_PERSISTENT_STORAGE_SCHEMA" && \
-            $QPS_METADATA_SOURCE_SHA == "$qps_source_sha" && \
-            $QPS_METADATA_SOURCE_BYTES == "$qps_source_bytes" ]]; then
+      if [[ $QPS_METADATA_SCHEMA == "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]]; then
         qps_selected=$qps_candidate
         qps_selected_mtime=$qps_candidate_mtime
-        qps_selected_is_exact=1
       fi
     elif [[ $qps_candidate_name == "$qps_identity" ]]; then
       qps_selected=$qps_candidate
@@ -1149,7 +1644,7 @@ _qps_migrate_legacy_single_workspace() {
   [[ -n $qps_selected ]] || {
     if [[ $qps_mode == persistent && $qps_valid_count -gt 0 ]]; then
       _qps_incompatible \
-        'the saved VM was created by a different Try Omarchy build; use Reset Omarchy to continue'
+        'the saved VM uses an unsupported storage format; use Reset Omarchy to continue'
       return $?
     fi
     _qps_fail 'legacy Omarchy disks were found, but none are safe to migrate or reset'
@@ -1160,12 +1655,8 @@ _qps_migrate_legacy_single_workspace() {
   _qps_acquire_legacy_lock "$qps_selected_name" || return 1
   if ! _qps_validate_recorded_workspace "$qps_selected" || \
     [[ $QPS_METADATA_IDENTITY != "$qps_selected_name" ]] || \
-    (( QPS_RECORDED_EXISTING_BYTES > qps_working_bytes )) || \
     { [[ $qps_mode == persistent ]] && \
-      { [[ $QPS_METADATA_SCHEMA != "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]] || \
-        [[ $QPS_METADATA_IDENTITY != "$qps_identity" ]] || \
-        [[ $QPS_METADATA_SOURCE_SHA != "$qps_source_sha" ]] || \
-        [[ $QPS_METADATA_SOURCE_BYTES != "$qps_source_bytes" ]]; }; }; then
+      [[ $QPS_METADATA_SCHEMA != "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]]; }; then
     _qps_release_legacy_lock
     _qps_fail 'the selected legacy workspace changed before it could be migrated'
     return 1
@@ -1187,6 +1678,42 @@ _qps_migrate_legacy_single_workspace() {
   fi
 }
 
+_qps_publish_recorded_selection() {
+  local qps_final=$1
+  local qps_current_identity=$2
+  local qps_kernel=${3:-}
+  local qps_initramfs=${4:-}
+  local qps_command_line=${5:-}
+  local qps_source=${6:-}
+
+  _qps_validate_recorded_workspace "$qps_final" || return 1
+  if [[ $QPS_METADATA_SCHEMA != "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]]; then
+    _qps_incompatible \
+      'the saved VM uses an unsupported storage format; use Reset Omarchy to continue'
+    return $?
+  fi
+  if [[ -n $qps_source ]] && \
+    [[ $(_qps_file_identity "$qps_final/rootfs.ext4") == $(_qps_file_identity "$qps_source") ]]; then
+    _qps_fail 'persistent root disk aliases the immutable source disk'
+    return 1
+  fi
+
+  QEMU_SELECTED_DISK="$qps_final/rootfs.ext4"
+  QEMU_SELECTED_STORAGE_MODE=persistent
+  QEMU_PERSISTENT_STORAGE_DIRECTORY=$qps_final
+  QEMU_PERSISTENT_STORAGE_IDENTITY=$QPS_METADATA_IDENTITY
+  QEMU_PERSISTENT_STORAGE_WORKING_BYTES=$QPS_RECORDED_EXISTING_BYTES
+
+  if [[ ! -e $QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$QPS_METADATA_IDENTITY && \
+        ! -L $QEMU_PERSISTENT_STORAGE_BOOT_ROOT/$QPS_METADATA_IDENTITY && \
+        $QPS_METADATA_IDENTITY == "$qps_current_identity" && -n $qps_kernel ]]; then
+    _qps_stage_boot_kit_locked \
+      "$QPS_METADATA_IDENTITY" "$qps_kernel" "$qps_initramfs" \
+      "$qps_command_line" || return $?
+  fi
+  _qps_set_selected_boot_kit "$QPS_METADATA_IDENTITY"
+}
+
 _qps_select_persistent_disk() {
   local qps_mode=$1
   local qps_identity=$2
@@ -1194,6 +1721,9 @@ _qps_select_persistent_disk() {
   local qps_source_sha=$4
   local qps_source_bytes=$5
   local qps_working_bytes=$6
+  local qps_kernel=${7:-}
+  local qps_initramfs=${8:-}
+  local qps_command_line=${9:-}
   local qps_final=''
   local qps_status=0
   local qps_storage_key='current'
@@ -1208,7 +1738,6 @@ _qps_select_persistent_disk() {
       ;;
   esac
   _qps_acquire_lock "$qps_storage_key" || return 1
-  QEMU_PERSISTENT_STORAGE_IDENTITY=$qps_identity
   qps_final="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/$qps_storage_key"
 
   if [[ $qps_storage_key == current ]]; then
@@ -1225,12 +1754,25 @@ _qps_select_persistent_disk() {
 
   _qps_reap_interrupted_work "$qps_storage_key"
   if [[ $qps_mode == reset ]]; then
+    # Validate an orphan current-identity boot entry before deleting any disk,
+    # then re-check it immediately before removal below.
+    if ! _qps_validate_boot_kit_reset_target "$qps_identity"; then
+      qemu_persistent_storage_release_lock
+      return 1
+    fi
     if ! _qps_reset_persistent_disk "$qps_storage_key"; then
       qemu_persistent_storage_release_lock
       return 1
     fi
     if [[ $qps_storage_key == current ]] && \
       ! _qps_reset_remaining_legacy_workspaces; then
+      qemu_persistent_storage_release_lock
+      return 1
+    fi
+    # A prior interrupted reset can leave the current app identity's boot kit
+    # after its disk has already gone. Reset is explicitly destructive, so
+    # discard that exact app-owned entry before creating the fresh VM too.
+    if ! _qps_reset_boot_kit "$qps_identity"; then
       qemu_persistent_storage_release_lock
       return 1
     fi
@@ -1260,21 +1802,15 @@ _qps_select_persistent_disk() {
       return 1
     fi
   fi
-  if ! _qps_validate_store_directory \
-    "$qps_final" "$qps_identity" "$qps_source_sha" "$qps_source_bytes" \
-    "$qps_working_bytes"; then
+  if _qps_publish_recorded_selection \
+    "$qps_final" "$qps_identity" "$qps_kernel" "$qps_initramfs" \
+    "$qps_command_line" "$qps_source"; then
+    return 0
+  else
+    qps_status=$?
     qemu_persistent_storage_release_lock
-    return 1
+    return "$qps_status"
   fi
-  [[ $(_qps_file_identity "$qps_final/rootfs.ext4") != $(_qps_file_identity "$qps_source") ]] || {
-    qemu_persistent_storage_release_lock
-    _qps_fail 'persistent root disk aliases the immutable source disk'
-    return 1
-  }
-
-  QEMU_SELECTED_DISK="$qps_final/rootfs.ext4"
-  QEMU_SELECTED_STORAGE_MODE=persistent
-  QEMU_PERSISTENT_STORAGE_DIRECTORY=$qps_final
 }
 
 _qps_select_ephemeral_disk() {
@@ -1308,6 +1844,84 @@ _qps_select_ephemeral_disk() {
   QEMU_SELECTED_STORAGE_MODE=ephemeral
   QEMU_PERSISTENT_STORAGE_DIRECTORY=''
   QEMU_PERSISTENT_STORAGE_IDENTITY=''
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+}
+
+# Select an already-existing persistent VM without touching the bundled factory
+# image. Returns QEMU_PERSISTENT_STORAGE_MISSING_STATUS when no VM exists, so
+# the launcher can materialize the factory only for a genuinely new machine.
+qemu_persistent_storage_select_existing() {
+  local qps_identity=${1:-}
+  local qps_kernel=${2:-}
+  local qps_initramfs=${3:-}
+  local qps_command_line=${4:-}
+  local qps_storage_key=current
+  local qps_final=''
+  local qps_status=0
+
+  QEMU_SELECTED_DISK=''
+  QEMU_SELECTED_STORAGE_MODE=''
+  QEMU_PERSISTENT_STORAGE_DIRECTORY=''
+  QEMU_PERSISTENT_STORAGE_IDENTITY=''
+  QEMU_PERSISTENT_STORAGE_LOCK_PATH=''
+  QEMU_PERSISTENT_STORAGE_WORKING_BYTES=''
+  QEMU_SELECTED_KERNEL=''
+  QEMU_SELECTED_INITRAMFS=''
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
+
+  _qps_is_identity "$qps_identity" || {
+    _qps_fail 'bundle identity must be exactly 64 lowercase hexadecimal characters'
+    return 1
+  }
+  if [[ -n $qps_kernel || -n $qps_initramfs || -n $qps_command_line ]]; then
+    [[ -n $qps_kernel && -n $qps_initramfs && -n $qps_command_line ]] || return 1
+    _qps_assert_boot_source_file "$qps_kernel" 'bundled kernel' 536870912 || return 1
+    _qps_assert_boot_source_file "$qps_initramfs" 'bundled initramfs' 1073741824 || return 1
+    _qps_validate_kernel_command_line "$qps_command_line" || return 1
+  fi
+
+  _qps_prepare_state_root || return 1
+  case "${OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK:-0}" in
+    0) ;;
+    1) qps_storage_key=$qps_identity ;;
+    *)
+      _qps_fail 'OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK must be 0 or 1'
+      return 1
+      ;;
+  esac
+  _qps_acquire_lock "$qps_storage_key" || return 1
+  qps_final="$QEMU_PERSISTENT_STORAGE_DISKS_ROOT/$qps_storage_key"
+  if [[ $qps_storage_key == current ]]; then
+    if _qps_migrate_legacy_single_workspace persistent "$qps_identity"; then
+      :
+    else
+      qps_status=$?
+      qemu_persistent_storage_release_lock
+      return "$qps_status"
+    fi
+  fi
+  _qps_reap_interrupted_work "$qps_storage_key"
+  if [[ ! -e $qps_final && ! -L $qps_final ]]; then
+    qemu_persistent_storage_release_lock
+    return "$QEMU_PERSISTENT_STORAGE_MISSING_STATUS"
+  fi
+  if _qps_require_compatible_workspace "$qps_final" "$qps_identity"; then
+    :
+  else
+    qps_status=$?
+    qemu_persistent_storage_release_lock
+    return "$qps_status"
+  fi
+  if _qps_publish_recorded_selection \
+    "$qps_final" "$qps_identity" "$qps_kernel" "$qps_initramfs" \
+    "$qps_command_line"; then
+    return 0
+  else
+    qps_status=$?
+    qemu_persistent_storage_release_lock
+    return "$qps_status"
+  fi
 }
 
 # Select and prepare a QEMU root disk.
@@ -1320,6 +1934,9 @@ _qps_select_ephemeral_disk() {
 #   5. source-rootfs byte count from the manifest
 #   6. private run directory (required only for ephemeral mode)
 #   7. working rootfs byte count (optional; defaults to source size)
+#   8. validated bundled kernel (optional only for storage-library tests)
+#   9. validated bundled initramfs (required with argument 8)
+#  10. validated base kernel command line (required with argument 8)
 #
 # On success, QEMU_SELECTED_DISK and QEMU_SELECTED_STORAGE_MODE are populated.
 # Persistent/reset mode also holds FD 9 until the caller exits or explicitly
@@ -1332,6 +1949,9 @@ qemu_persistent_storage_select() {
   local qps_source_bytes=${5:-}
   local qps_work_directory=${6:-}
   local qps_working_bytes=${7:-$qps_source_bytes}
+  local qps_kernel=${8:-}
+  local qps_initramfs=${9:-}
+  local qps_command_line=${10:-}
 
   QEMU_SELECTED_DISK=''
   QEMU_SELECTED_STORAGE_MODE=''
@@ -1339,6 +1959,10 @@ qemu_persistent_storage_select() {
   QEMU_PERSISTENT_STORAGE_IDENTITY=''
   QEMU_PERSISTENT_STORAGE_LOCK_PATH=''
   QEMU_PERSISTENT_STORAGE_WORKING_BYTES=''
+  QEMU_SELECTED_KERNEL=''
+  QEMU_SELECTED_INITRAMFS=''
+  QEMU_SELECTED_KERNEL_COMMAND_LINE=''
+  QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY=0
 
   case "$qps_mode" in
     persistent|reset|ephemeral) ;;
@@ -1368,14 +1992,33 @@ qemu_persistent_storage_select() {
     return 1
   }
   _qps_assert_source_disk "$qps_source" "$qps_source_bytes" || return 1
+  if [[ -n $qps_kernel || -n $qps_initramfs || -n $qps_command_line ]]; then
+    [[ -n $qps_kernel && -n $qps_initramfs && -n $qps_command_line ]] || {
+      _qps_fail 'kernel, initramfs, and command line must be supplied together'
+      return 1
+    }
+    _qps_assert_boot_source_file "$qps_kernel" 'bundled kernel' 536870912 || return 1
+    _qps_assert_boot_source_file "$qps_initramfs" 'bundled initramfs' 1073741824 || return 1
+    _qps_validate_kernel_command_line "$qps_command_line" || {
+      _qps_fail 'bundled kernel command line is invalid'
+      return 1
+    }
+  fi
   QEMU_PERSISTENT_STORAGE_WORKING_BYTES=$qps_working_bytes
 
   if [[ $qps_mode == ephemeral ]]; then
-    _qps_select_ephemeral_disk \
-      "$qps_source" "$qps_source_bytes" "$qps_work_directory" "$qps_working_bytes"
+    if _qps_select_ephemeral_disk \
+      "$qps_source" "$qps_source_bytes" "$qps_work_directory" "$qps_working_bytes"; then
+      QEMU_SELECTED_KERNEL=$qps_kernel
+      QEMU_SELECTED_INITRAMFS=$qps_initramfs
+      QEMU_SELECTED_KERNEL_COMMAND_LINE=$qps_command_line
+    else
+      return $?
+    fi
   else
     _qps_select_persistent_disk \
       "$qps_mode" "$qps_identity" "$qps_source" "$qps_source_sha" \
-      "$qps_source_bytes" "$qps_working_bytes"
+      "$qps_source_bytes" "$qps_working_bytes" \
+      "$qps_kernel" "$qps_initramfs" "$qps_command_line"
   fi
 }

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -14,6 +14,17 @@ fail() {
 
 storage_mode=persistent
 reset_only=0
+boot_recovery_consent_required_status=80
+boot_recovery_failed_status=81
+# QEMU 11's HVF backend requires Apple's in-hypervisor GICv3. Keep recovery
+# and normal launches on one machine definition so they cannot drift apart.
+qemu_machine='virt,accel=hvf,gic-version=3'
+
+boot_recovery_fail() {
+  echo "run-qemu-gpu: $*" >&2
+  exit "$boot_recovery_failed_status"
+}
+
 case ${1:-} in
   --ephemeral)
     storage_mode=ephemeral
@@ -47,7 +58,7 @@ port_forwarding_library="$script_dir/qemu-port-forwarding.sh"
 [[ -d $guest_input && ! -L $guest_input ]] || fail "ARM guest directory is missing or unsafe: $guest_input"
 guest_dir=$(cd "$guest_input" && pwd -P)
 
-for command in codesign file getconf id mktemp ps sysctl; do
+for command in codesign file getconf id mktemp plutil ps sysctl; do
   command -v "$command" >/dev/null || fail "$command is required"
 done
 
@@ -977,6 +988,164 @@ reap_stale_work_dirs() {
 
 reap_stale_work_dirs
 
+boot_export_has_only_expected_contents() (
+  local candidate=''
+  local names=''
+
+  shopt -s nullglob dotglob
+  for candidate in "$1"/*; do
+    names+="${candidate##*/}"$'\n'
+  done
+  shopt -u nullglob dotglob
+  [[ $names == $'build-spec.json\ncomplete\ninitramfs\nkernel\n' ]]
+)
+
+assert_direct_owned_export_file() {
+  local path=$1
+  local label=$2
+
+  [[ -f $path && ! -L $path ]] || boot_recovery_fail "$label is missing or unsafe"
+  [[ $(_qps_lstat_kind "$path") == 'Regular File' ]] || {
+    boot_recovery_fail "$label is not a direct regular file"
+  }
+  [[ $(_qps_owner "$path") == $(id -u) ]] || {
+    boot_recovery_fail "$label is not owned by this user"
+  }
+}
+
+recover_persistent_boot_kit() {
+  local boot_export_dir="$work_dir/boot-export"
+  local recovery_argument=''
+  local recovery_command_line=''
+  local recovery_state=''
+  local recovery_status=0
+  local recovery_stopped=0
+  local attempt=0
+  local recovered_command_line=''
+
+  [[ $QEMU_SELECTED_STORAGE_MODE == persistent && \
+     -n $QEMU_PERSISTENT_STORAGE_IDENTITY ]] || {
+    boot_recovery_fail 'boot recovery requires a selected persistent VM'
+  }
+  [[ ${OMARCHY_QEMU_GPU_DRY_RUN:-0} == 0 ]] || {
+    boot_recovery_fail 'this saved VM needs a one-time boot recovery; launch it normally before using dry-run mode'
+  }
+  mkdir -m 700 "$boot_export_dir" || boot_recovery_fail 'could not create the private boot-export directory'
+  [[ -d $boot_export_dir && ! -L $boot_export_dir ]] || {
+    boot_recovery_fail 'the private boot-export directory is unsafe'
+  }
+  [[ $(_qps_owner "$boot_export_dir") == $(id -u) && \
+     $(_qps_permissions "$boot_export_dir") == 700 ]] || {
+    boot_recovery_fail 'the private boot-export directory is not protected'
+  }
+
+  # The recovery initramfs mounts the old disk only far enough to read /boot.
+  # QEMU also exposes the block device read-only, so neither fsck nor a malformed
+  # guest can change user data while the matching boot pair is being recovered.
+  for recovery_argument in $kernel_command_line; do
+    if [[ $recovery_argument == rootflags=* ]]; then
+      continue
+    fi
+    if [[ $recovery_argument == rw ]]; then
+      recovery_argument=ro
+    fi
+    recovery_command_line+=" $recovery_argument"
+  done
+  recovery_command_line=${recovery_command_line# }
+  recovery_command_line+=' rootflags=noload fsck.mode=skip tryomarchy.export_boot=1'
+
+  echo '[qemu-gpu] Pairing the saved VM with its original boot files (one time).' >&2
+  "$qemu_bin" \
+    -name 'Try Omarchy Boot Recovery' \
+    -machine "$qemu_machine" \
+    -cpu 'host,pmu=off' \
+    -smp '2,sockets=1,cores=2,threads=1' \
+    -m 2G \
+    -nodefaults \
+    -no-reboot \
+    -display none \
+    -serial none \
+    -monitor none \
+    -qmp "unix:$qmp_socket,server=on,wait=off" \
+    -kernel "$bundled_kernel" \
+    -initrd "$bundled_initramfs" \
+    -append "$recovery_command_line" \
+    -drive "if=none,id=omarchy-recovery-root,file=$working_disk,format=raw,media=disk,cache=none,readonly=on" \
+    -device 'virtio-blk-pci,drive=omarchy-recovery-root,serial=omarchy-root' \
+    -device 'virtio-serial-pci,id=omarchy-recovery-serial' \
+    -chardev 'stdio,id=omarchy-recovery-hvc0,signal=off' \
+    -device 'virtconsole,bus=omarchy-recovery-serial.0,nr=0,chardev=omarchy-recovery-hvc0' \
+    -fsdev "local,id=omarchy-boot-export,path=$boot_export_dir,security_model=none,multidevs=remap" \
+    -device 'virtio-9p-pci,fsdev=omarchy-boot-export,mount_tag=try-omarchy-boot-export,romfile=' \
+    -add-fd "$QEMU_PERSISTENT_STORAGE_QEMU_ADD_FD" &
+  qemu_pid=$!
+  printf '%s\n' "$qemu_pid" >"$work_dir/.qemu.pid" || \
+    boot_recovery_fail 'could not record the recovery process'
+  chmod 600 "$work_dir/.qemu.pid" || \
+    boot_recovery_fail 'could not protect the recovery process record'
+
+  for ((attempt = 0; attempt < 600; attempt++)); do
+    recovery_state=$(ps -p "$qemu_pid" -o state= 2>/dev/null || true)
+    if [[ -z $recovery_state || $recovery_state == *Z* ]]; then
+      recovery_stopped=1
+      break
+    fi
+    sleep 0.1
+  done
+  if (( recovery_stopped == 0 )); then
+    terminate_child "$qemu_pid" 40
+    qemu_pid=''
+    boot_recovery_fail 'the one-time boot recovery did not finish within 60 seconds'
+  fi
+  if wait "$qemu_pid"; then
+    recovery_status=0
+  else
+    recovery_status=$?
+  fi
+  qemu_pid=''
+  /bin/rm -f "$work_dir/.qemu.pid" || \
+    boot_recovery_fail 'could not clear the recovery process record'
+  [[ ! -e $qmp_socket && ! -L $qmp_socket ]] || \
+    /bin/rm -f "$qmp_socket" || boot_recovery_fail 'could not clear the recovery control socket'
+  (( recovery_status == 0 )) || {
+    boot_recovery_fail "the one-time boot recovery exited with status $recovery_status"
+  }
+
+  boot_export_has_only_expected_contents "$boot_export_dir" || {
+    boot_recovery_fail 'the one-time boot recovery did not publish an exact, complete export'
+  }
+  assert_direct_owned_export_file "$boot_export_dir/complete" 'boot-export marker'
+  assert_direct_owned_export_file "$boot_export_dir/kernel" 'recovered kernel'
+  assert_direct_owned_export_file "$boot_export_dir/initramfs" 'recovered initramfs'
+  assert_direct_owned_export_file "$boot_export_dir/build-spec.json" 'recovered build specification'
+  [[ $(_qps_size "$boot_export_dir/complete") == 27 && \
+     $(<"$boot_export_dir/complete") == try-omarchy-boot-export-v1 ]] || {
+    boot_recovery_fail 'the one-time boot recovery completion marker is invalid'
+  }
+  [[ $(_qps_size "$boot_export_dir/build-spec.json") =~ ^[1-9][0-9]*$ && \
+     $(_qps_size "$boot_export_dir/build-spec.json") -le 1048576 ]] || {
+    boot_recovery_fail 'the recovered build specification has an invalid size'
+  }
+  recovered_command_line=$(
+    /usr/bin/plutil -extract runtime.kernelCommandLine raw -expect string \
+      "$boot_export_dir/build-spec.json" 2>/dev/null
+  ) || boot_recovery_fail 'the recovered build specification has no kernel command line'
+  chmod 600 \
+    "$boot_export_dir/complete" \
+    "$boot_export_dir/kernel" \
+    "$boot_export_dir/initramfs" \
+    "$boot_export_dir/build-spec.json" || {
+      boot_recovery_fail 'could not protect the recovered boot files'
+    }
+  qemu_persistent_storage_stage_selected_boot_kit \
+    "$boot_export_dir/kernel" \
+    "$boot_export_dir/initramfs" \
+    "$recovered_command_line" || {
+      boot_recovery_fail 'could not pair the saved VM with its recovered boot files'
+    }
+  echo '[qemu-gpu] Saved VM boot files recovered; continuing normal launch.' >&2
+}
+
 umask 077
 work_dir=$(mktemp -d '/private/tmp/omarchy-qemu-gpu.XXXXXX') || {
   fail "could not create a private temporary directory"
@@ -1002,34 +1171,80 @@ clipboard_bridge_socket="/tmp/${work_dir##*/}/clipboard.sock"
 audio_route_dir="/tmp/${work_dir##*/}/audio-routes"
 mkdir -m 700 "$work_dir/audio-routes"
 
-source_disk="$guest_dir/rootfs.ext4"
-if [[ ! -e $source_disk && ! -L $source_disk ]]; then
-  qemu_persistent_storage_materialize_source \
+bundled_kernel="$guest_dir/vmlinuz-linux"
+bundled_initramfs="$guest_dir/initramfs-linux.img"
+selected_existing=0
+if [[ $storage_mode == persistent ]]; then
+  if qemu_persistent_storage_select_existing \
+    "$bundle_identity" "$bundled_kernel" "$bundled_initramfs" \
+    "$kernel_command_line"; then
+    selected_existing=1
+  else
+    storage_status=$?
+    if (( storage_status == QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS )); then
+      exit "$storage_status"
+    fi
+    if (( storage_status != QEMU_PERSISTENT_STORAGE_MISSING_STATUS )); then
+      fail "could not inspect the saved VM disk"
+    fi
+  fi
+fi
+
+if (( selected_existing == 0 )); then
+  source_disk="$guest_dir/rootfs.ext4"
+  if [[ ! -e $source_disk && ! -L $source_disk ]]; then
+    qemu_persistent_storage_materialize_source \
+      "$bundle_identity" \
+      "$guest_dir/rootfs.ext4.zst" \
+      "$compressed_disk_bytes" \
+      "$source_disk_sha" \
+      "$source_disk_bytes" \
+      "$resources_dir/runtime/bin/zstd" || fail "could not materialize the bundled root disk"
+    source_disk=$QEMU_IMMUTABLE_SOURCE_DISK
+  fi
+  if qemu_persistent_storage_select \
+    "$storage_mode" \
     "$bundle_identity" \
-    "$guest_dir/rootfs.ext4.zst" \
-    "$compressed_disk_bytes" \
+    "$source_disk" \
     "$source_disk_sha" \
     "$source_disk_bytes" \
-    "$resources_dir/runtime/bin/zstd" || fail "could not materialize the bundled root disk"
-  source_disk=$QEMU_IMMUTABLE_SOURCE_DISK
-fi
-if qemu_persistent_storage_select \
-  "$storage_mode" \
-  "$bundle_identity" \
-  "$source_disk" \
-  "$source_disk_sha" \
-  "$source_disk_bytes" \
-  "$work_dir" \
-  "$expanded_disk_bytes"; then
-  :
-else
-  storage_status=$?
-  if (( storage_status == QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS )); then
-    exit "$storage_status"
+    "$work_dir" \
+    "$expanded_disk_bytes" \
+    "$bundled_kernel" \
+    "$bundled_initramfs" \
+    "$kernel_command_line"; then
+    :
+  else
+    storage_status=$?
+    if (( storage_status == QEMU_PERSISTENT_STORAGE_INCOMPATIBLE_STATUS )); then
+      exit "$storage_status"
+    fi
+    fail "could not prepare the selected root disk"
   fi
-  fail "could not prepare the selected root disk"
 fi
 working_disk=$QEMU_SELECTED_DISK
+
+case ${OMARCHY_QEMU_GPU_DRY_RUN:-0} in
+  0|1) ;;
+  *) fail "OMARCHY_QEMU_GPU_DRY_RUN must be 0 or 1" ;;
+esac
+case ${OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY:-0} in
+  0|1) ;;
+  *) fail "OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY must be 0 or 1" ;;
+esac
+if (( QEMU_PERSISTENT_STORAGE_NEEDS_BOOT_RECOVERY )); then
+  if [[ ${OMARCHY_QEMU_GPU_ALLOW_BOOT_RECOVERY:-0} != 1 ]]; then
+    echo '[qemu-gpu] This older saved VM needs consent for one-time read-only boot pairing.' >&2
+    exit "$boot_recovery_consent_required_status"
+  fi
+  recover_persistent_boot_kit
+fi
+launch_kernel=$QEMU_SELECTED_KERNEL
+launch_initramfs=$QEMU_SELECTED_INITRAMFS
+launch_kernel_command_line=$QEMU_SELECTED_KERNEL_COMMAND_LINE
+[[ -n $launch_kernel && -n $launch_initramfs && -n $launch_kernel_command_line ]] || {
+  fail 'the selected VM has no complete boot kit'
+}
 
 if ((reset_only)); then
   qemu_persistent_storage_release_lock
@@ -1045,9 +1260,7 @@ esac
 
 qemu_args=(
   -name 'Try Omarchy'
-  # HVF exposes the ARM virtual GICv2 interface on current Apple Silicon.
-  # Eight vCPUs is the architectural GICv2 limit and matches our host cap.
-  -machine 'virt,accel=hvf,gic-version=3'
+  -machine "$qemu_machine"
   # HVF does not provide a usable guest PMU on Apple Silicon. Do not advertise
   # one: Linux otherwise probes the dead device and prints a misleading failure.
   -cpu 'host,pmu=off'
@@ -1064,9 +1277,9 @@ qemu_args=(
   -serial none
   -monitor none
   -qmp "unix:$qmp_socket,server=on,wait=off"
-  -kernel "$guest_dir/vmlinuz-linux"
-  -initrd "$guest_dir/initramfs-linux.img"
-  -append "$kernel_command_line omarchy.qemu_virgl=1$shared_folder_kernel_argument$ssh_kernel_argument"
+  -kernel "$launch_kernel"
+  -initrd "$launch_initramfs"
+  -append "$launch_kernel_command_line omarchy.qemu_virgl=1$shared_folder_kernel_argument$ssh_kernel_argument"
   -drive "if=none,id=omarchy-root,file=$working_disk,format=raw,media=disk,cache=writeback"
   -device 'virtio-blk-pci,drive=omarchy-root,serial=omarchy-root'
   -device "$gpu_device"


### PR DESCRIPTION
## Summary

- Reuse an existing schema-2 VM disk across app/guest build changes instead of forcing Reset Omarchy.
- Show a Continue / Cancel warning before a one-time, read-only recovery boot for disks that predate host-side boot kits.
- Recover and atomically retain each VM matching kernel, initramfs, and base command line, then boot it with the current QEMU harness.
- Use the current bundled factory only for new, reset, and ephemeral VMs.
- Update storage-space preflight, failure presentation, documentation, and release guidance.

## Review fixes

- Read the root filesystem from mkinitcpio actual /new_root late-hook mount.
- Share one QEMU 11 GICv3 machine definition between recovery and normal launch; GICv2 is rejected by QEMU 11 HVF.
- Add regressions for both paths.

## Compatibility

The v0.1.0 and v0.2.0 tags both created schema-2 disks with the expected installed boot paths and build specification. Their zstd-compressed initramfs format is explicitly accepted and covered by the storage tests. Unsupported schema-1 or unsafe/ambiguous workspaces still require a confirmed reset.

## Testing

- make test
  - 7 build-cache tests
  - 64 guest tests plus native guest verification
  - 180 Swift tests
  - all macOS launcher/storage/network/power shell contracts
- Real QEMU 11.1.1 integration against an APFS clone of an existing older VM:
  - consent status returned without reset or factory materialization
  - recovery mounted the clone read-only and exported byte-identical old boot files
  - recovered old kernel/initramfs booted the preserved VM through multi-user.target to the login prompt under GICv3
  - original VM disk was never attached or modified