### PR TITLE
Give the start menu a standard Mac app lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ port. The `dtc` mirror should be reverted once kernel.org returns.
 2. Open the DMG and drag **Try Omarchy** to **Applications**.
 3. Launch **Try Omarchy** from Applications.
 
-Every launch begins at the start menu. **Immersive** is on by default, so Omarchy opens Full Screen with the Mac menu bar and Dock hidden. Turn it off to open a resizable window; if you later enter Full Screen, the Mac menu bar and Dock remain available at the screen edges. Whenever the Omarchy window is focused, Command belongs to the guest as Super in either mode; Accessibility permission lets system shortcuts such as Command-Space reach it before macOS. Microphone and camera access are optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
+Every launch begins at the start menu. While that menu is open, Try Omarchy behaves like a regular Mac app with standard Quit, Close Window, and Minimize commands; after the VM starts, that native app chrome steps aside for Omarchy. **Immersive** is on by default, so Omarchy opens Full Screen with the Mac menu bar and Dock hidden. Turn it off to open a resizable window; if you later enter Full Screen, the Mac menu bar and Dock remain available at the screen edges. Whenever the Omarchy window is focused, Command belongs to the guest as Super in either mode; Accessibility permission lets system shortcuts such as Command-Space reach it before macOS. Microphone and camera access are optional. The first launch takes longer while the app prepares Linux and starts Omarchy's account provisioning.
 
 Restarting from inside Omarchy reboots the guest in the same Try Omarchy app.
 Shutting down Omarchy closes the app and leaves it closed.

--- a/macos/Sources/OmarchyVMHelper/ApplicationPresentation.swift
+++ b/macos/Sources/OmarchyVMHelper/ApplicationPresentation.swift
@@ -1,0 +1,53 @@
+import AppKit
+
+@MainActor
+enum ApplicationPresentation {
+    static let prelaunchActivationPolicy = NSApplication.ActivationPolicy.regular
+    static let runningActivationPolicy = NSApplication.ActivationPolicy.accessory
+
+    static func installMainMenu(
+        in application: NSApplication,
+        applicationName: String
+    ) {
+        let mainMenu = NSMenu(title: "Main Menu")
+
+        let applicationItem = NSMenuItem()
+        mainMenu.addItem(applicationItem)
+        let applicationMenu = NSMenu(title: applicationName)
+        applicationItem.submenu = applicationMenu
+        applicationMenu.addItem(
+            withTitle: "About \(applicationName)",
+            action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+            keyEquivalent: ""
+        )
+        applicationMenu.addItem(.separator())
+        applicationMenu.addItem(
+            withTitle: "Hide \(applicationName)",
+            action: #selector(NSApplication.hide(_:)),
+            keyEquivalent: "h"
+        )
+        applicationMenu.addItem(
+            withTitle: "Quit \(applicationName)",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
+
+        let windowItem = NSMenuItem()
+        mainMenu.addItem(windowItem)
+        let windowMenu = NSMenu(title: "Window")
+        windowItem.submenu = windowMenu
+        windowMenu.addItem(
+            withTitle: "Close Window",
+            action: #selector(NSWindow.performClose(_:)),
+            keyEquivalent: "w"
+        )
+        windowMenu.addItem(
+            withTitle: "Minimize",
+            action: #selector(NSWindow.performMiniaturize(_:)),
+            keyEquivalent: "m"
+        )
+
+        application.mainMenu = mainMenu
+        application.windowsMenu = windowMenu
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -414,6 +414,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
 
     private func virtualMachineDidStart() {
         virtualMachineReachedStart = true
+        NSApp.setActivationPolicy(ApplicationPresentation.runningActivationPolicy)
         startMenuWindow?.dismiss()
         startMenuWindow = nil
     }

--- a/macos/Sources/OmarchyVMHelper/main.swift
+++ b/macos/Sources/OmarchyVMHelper/main.swift
@@ -128,7 +128,11 @@ do {
         // isolated while `NSApplication.run()` services its event loop.
         let status = MainActor.assumeIsolated { () -> Int32 in
             let application = NSApplication.shared
-            application.setActivationPolicy(.accessory)
+            application.setActivationPolicy(ApplicationPresentation.prelaunchActivationPolicy)
+            ApplicationPresentation.installMainMenu(
+                in: application,
+                applicationName: "Try Omarchy"
+            )
             let controller = VMApplicationController(
                 launcherURL: launcher,
                 initialArguments: launcherArguments

--- a/macos/Tests/OmarchyVMHelperTests/ApplicationPresentationTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/ApplicationPresentationTests.swift
@@ -1,0 +1,43 @@
+import AppKit
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Application presentation", .serialized)
+@MainActor
+struct ApplicationPresentationTests {
+    @Test("the start menu behaves like a regular app before yielding to QEMU")
+    func activationPolicies() {
+        #expect(ApplicationPresentation.prelaunchActivationPolicy == .regular)
+        #expect(ApplicationPresentation.runningActivationPolicy == .accessory)
+    }
+
+    @Test("the application menu exposes standard quit and window shortcuts")
+    func standardApplicationMenu() throws {
+        let application = NSApplication.shared
+        let previousMainMenu = application.mainMenu
+        let previousWindowMenu = application.windowsMenu
+        defer {
+            application.mainMenu = previousMainMenu
+            application.windowsMenu = previousWindowMenu
+        }
+
+        ApplicationPresentation.installMainMenu(
+            in: application,
+            applicationName: "Try Omarchy"
+        )
+
+        let appMenu = try #require(application.mainMenu?.items.first?.submenu)
+        let quit = try #require(appMenu.items.first(where: {
+            $0.title == "Quit Try Omarchy"
+        }))
+        #expect(quit.keyEquivalent == "q")
+        #expect(quit.action == #selector(NSApplication.terminate(_:)))
+
+        let windowMenu = try #require(application.windowsMenu)
+        let close = try #require(windowMenu.items.first(where: {
+            $0.title == "Close Window"
+        }))
+        #expect(close.keyEquivalent == "w")
+        #expect(close.action == #selector(NSWindow.performClose(_:)))
+    }
+}


### PR DESCRIPTION
## Summary

- present the start menu with the regular macOS application activation policy
- add native About, Hide, Quit, Close Window, and Minimize menu commands
- return to accessory mode after QEMU reports that Omarchy is ready
- document the prelaunch behavior and cover its activation/menu contracts

## Why

The start menu is an interactive Mac window, but the helper currently runs as an accessory application from process launch. The red close control works, while standard application commands such as Command-Q, Command-W, and Command-M are not discoverable through a normal app menu.

This keeps the native lifecycle only for setup. Once the VM is ready, Try Omarchy returns to accessory mode so the Mac app chrome does not compete with the guest experience.

## Tests

- `make test`
- 183 Swift tests passed, including the new serialized application-presentation suite