### PR TITLE
Use official Omarchy mark in app branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Try Omarchy packages a project-built ARM64 Arch Linux image configured with Omar
 
 <img width="800" src="https://github.com/user-attachments/assets/1368a8f5-5099-43e4-8d3b-3d7d7fba0326" />
 
+The Omarchy mark in the app icon is sourced from the
+[official Omarchy brand kit](https://omarchy.org/brand/) and remains subject to
+Omarchy's trademark rights.
+
 ## Highlights
 
 - Hardware-accelerated ARM64 virtualization and VirGL graphics

--- a/macos/OmarchyIcon.svg
+++ b/macos/OmarchyIcon.svg
@@ -2,21 +2,14 @@
   width="1024" height="1024" viewBox="0 0 1024 1024"
   role="img" aria-labelledby="title desc">
   <title id="title">Try Omarchy app icon</title>
-  <desc id="desc">A centered green play symbol framed by Omarchy-inspired square geometry on a dark rounded tile.</desc>
+  <desc id="desc">The official Omarchy logo, centered on a dark rounded tile.</desc>
   <rect x="100" y="100" width="824" height="824" rx="191"
     fill="#151912" stroke="#9ECE6A" stroke-opacity="0.28" stroke-width="4"/>
-  <g transform="translate(212 212) scale(2)">
-    <g fill="none" stroke="#9ECE6A" stroke-width="20"
-      stroke-linecap="butt" stroke-linejoin="miter">
-      <path d="M 0 10 H 260"/>
-      <path d="M 290 0 V 260"/>
-      <path d="M 40 290 H 300"/>
-      <path d="M 10 40 V 300"/>
-      <path d="M 120 60 H 60 V 120"/>
-      <path d="M 180 60 H 240 V 120"/>
-      <path d="M 240 180 V 240 H 180"/>
-      <path d="M 120 240 H 60 V 180"/>
-    </g>
-    <path d="M 128 112 L 194 150 L 128 188 Z" fill="#9ECE6A"/>
+  <!-- Official mark from omacom/omarchy-site@70d4015 (SHA-256 4d00403e...),
+       preserved without recoloring. See https://omarchy.org/brand/. -->
+  <g transform="translate(212 212) scale(0.5)">
+    <path clip-rule="evenodd"
+      d="m1200 1200h-480v-80h400v-1040h-479.996v160h-400v720h720v-720h-80v-80h159.996v880h-400v160h-640v-1200h1200zm-1120-80h480v-80h-400l.004-400h-80.004zm0-560h80.004v-400h400v-80h-480.004z"
+      fill="#9ece6a" fill-rule="evenodd"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- replace the app icon's custom play-mark artwork with the official Omarchy mark
- preserve the existing 1024 px canvas, dark rounded tile, color, proportional scaling, and safe margin
- document the official source and keep the project's independent status explicit

This deliberately retains the icon pipeline and outer treatment introduced in #87; only the central symbol changes.

## Brand provenance

The mark is copied without redrawing or recoloring from [`omacom/omarchy-site@70d4015`](https://github.com/omacom/omarchy-site/blob/70d401595ac7ef45620ba25f2a64d9c519b241e0/brand/omarchy-logo.svg), published through the [official Omarchy brand page](https://omarchy.org/brand/). The source SVG SHA-256 is `4d00403ea7796c1fcd9a1574f807203f8d17f94d7c7fe90045963cf150346f70`.

The README continues to state that Try Omarchy is not official or affiliated with Omarchy and notes that the mark remains subject to Omarchy's trademark rights.

## Verification

- `git diff --check`
- parsed the source and adapted SVGs and confirmed the official path data and `#9ece6a` fill are exact
- rendered the 1024 px source successfully
- visually inspected full-size output and light, dark, and checkerboard previews at 16, 32, 64, 128, and 256 px
- confirmed 98 px outer tile clearance on every edge

`make test` could not be run in the local Linux workspace because this project's required Swift/AppKit environment is macOS. Hosted CI should provide the authoritative macOS test result for this exact branch.