### PR TITLE
Pause the VM across macOS host sleep

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,16 @@ is updated. Graphics travel from Linux through virtio-gpu and VirGL to the
 native Cocoa window. Storage, networking, audio, and input use their matching
 QEMU virtual devices and host backends.
 
+The macOS helper opens an authenticated connection to QEMU's private,
+single-client machine protocol socket before host sleep and retains that control
+session through wake. Before macOS sleeps it synchronously pauses the guest
+vCPUs, and after wake it resumes them only when that sleep handler observed the
+pause transition. The bundled Cocoa runtime removes its in-process Pause and
+Resume menu actions because they cannot participate in QMP connection
+ownership. Abnormal QEMU states such as an I/O error are never overridden. This
+preserves in-memory guest state across lid close while leaving safety stops
+untouched.
+
 One small host-integration channel sits beside those devices. A virtio-serial
 port (`dev.tryomarchy.clipboard`) carries newline-delimited JSON between a
 Swift bridge on the Mac, which watches the `NSPasteboard` change count, and a

--- a/macos/Sources/OmarchyVMHelper/FocusedCommandSuperBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/FocusedCommandSuperBridge.swift
@@ -214,223 +214,39 @@ private extension CGEventFlags {
 }
 
 final class QMPMetaKeyClient: @unchecked Sendable {
-    private let descriptor: Int32
-    private let queue = DispatchQueue(label: "org.omarchy.qmp-meta-keys", qos: .userInteractive)
-    private var nextIdentifier: UInt64 = 1
-    private var closed = false
+    private let connection: QMPConnection
 
     init(socketPath: String) throws {
-        descriptor = try Self.connectSecureSocket(path: socketPath)
-        do {
-            guard let greeting = try Self.readJSONObject(from: descriptor, timeoutMilliseconds: 2_000),
-                  greeting["QMP"] != nil else {
-                throw HelperError.io("QMP socket did not send a valid greeting")
-            }
-            try Self.writeJSON([
-                "execute": "qmp_capabilities",
-                "id": "omarchy-capabilities",
-            ], to: descriptor)
-            guard let response = try Self.readResponse(
-                id: "omarchy-capabilities",
-                from: descriptor,
-                timeoutMilliseconds: 2_000
-            ), response["return"] != nil, response["error"] == nil else {
-                throw HelperError.io("QMP capability negotiation failed")
-            }
-        } catch {
-            Darwin.close(descriptor)
-            throw error
-        }
+        connection = try QMPConnection(
+            socketPath: socketPath,
+            identifierPrefix: "omarchy-meta"
+        )
     }
 
     func send(_ transition: GuestMetaTransition) throws {
         // Complete the local socket write before the following chord key is
         // reposted. Otherwise a very fast Command-key chord could reach QEMU
         // before its guest Meta-down command.
-        try queue.sync { [self] in
-            guard !closed else {
-                throw HelperError.io("QMP key injection is unavailable")
-            }
-            do {
-                let identifier = "omarchy-meta-\(nextIdentifier)"
-                nextIdentifier += 1
-                try Self.writeJSON([
-                    "execute": "input-send-event",
-                    "arguments": [
-                        "events": [[
-                            "type": "key",
-                            "data": [
-                                "down": transition.down,
-                                "key": ["type": "qcode", "data": transition.key.rawValue],
-                            ],
-                        ]],
+        try connection.send(
+            "input-send-event",
+            arguments: [
+                "events": [[
+                    "type": "key",
+                    "data": [
+                        "down": transition.down,
+                        "key": ["type": "qcode", "data": transition.key.rawValue],
                     ],
-                    "id": identifier,
-                ], to: descriptor)
-                Self.drainAvailableInput(from: descriptor)
-            } catch {
-                closed = true
-                Darwin.close(descriptor)
-                throw error
-            }
-        }
+                ]],
+            ]
+        )
     }
 
     func close() {
-        queue.sync {
-            guard !closed else { return }
-            closed = true
-            Darwin.close(descriptor)
-        }
-    }
-
-    private static func connectSecureSocket(path: String) throws -> Int32 {
-        guard path.hasPrefix("/"), !path.utf8.contains(0) else {
-            throw HelperError.io("QMP socket path must be an absolute pathname")
-        }
-        let url = URL(fileURLWithPath: path).standardizedFileURL
-        guard url.path == path else {
-            throw HelperError.io("QMP socket path must already be standardized")
-        }
-        let parent = url.deletingLastPathComponent()
-        var parentInfo = stat()
-        guard lstat(parent.path, &parentInfo) == 0,
-              (parentInfo.st_mode & S_IFMT) == S_IFDIR,
-              parentInfo.st_uid == getuid(),
-              (parentInfo.st_mode & 0o077) == 0 else {
-            throw HelperError.io("QMP socket parent must be a private directory owned by this user")
-        }
-        var socketInfo = stat()
-        guard lstat(path, &socketInfo) == 0,
-              (socketInfo.st_mode & S_IFMT) == S_IFSOCK,
-              socketInfo.st_uid == getuid() else {
-            throw HelperError.io("QMP endpoint must be a Unix socket owned by this user")
-        }
-
-        let pathBytes = Array(path.utf8)
-        var address = sockaddr_un()
-        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
-            throw HelperError.io("QMP socket path is too long")
-        }
-        address.sun_family = sa_family_t(AF_UNIX)
-        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
-            buffer.initializeMemory(as: UInt8.self, repeating: 0)
-            buffer.copyBytes(from: pathBytes)
-        }
-
-        let fileDescriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fileDescriptor >= 0 else { throw HelperError.io("cannot create QMP socket") }
-        var noSignal: Int32 = 1
-        guard withUnsafePointer(to: &noSignal, {
-            setsockopt(
-                fileDescriptor,
-                SOL_SOCKET,
-                SO_NOSIGPIPE,
-                $0,
-                socklen_t(MemoryLayout<Int32>.size)
-            )
-        }) == 0 else {
-            Darwin.close(fileDescriptor)
-            throw HelperError.io("cannot make QMP socket resilient to guest exit")
-        }
-        let offset = MemoryLayout.offset(of: \sockaddr_un.sun_path) ?? 0
-        let length = socklen_t(offset + pathBytes.count + 1)
-        let result = withUnsafePointer(to: &address) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                Darwin.connect(fileDescriptor, $0, length)
-            }
-        }
-        guard result == 0 else {
-            let detail = String(cString: strerror(errno))
-            Darwin.close(fileDescriptor)
-            throw HelperError.io("cannot connect to QMP socket: \(detail)")
-        }
-        return fileDescriptor
+        connection.close()
     }
 
     static func writeJSON(_ object: [String: Any], to descriptor: Int32) throws {
-        var data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
-        data.append(contentsOf: [0x0D, 0x0A])
-        try data.withUnsafeBytes { rawBuffer in
-            guard let base = rawBuffer.baseAddress else { return }
-            var written = 0
-            while written < rawBuffer.count {
-                let result = Darwin.write(descriptor, base.advanced(by: written), rawBuffer.count - written)
-                if result > 0 {
-                    written += result
-                } else if result < 0 && errno == EINTR {
-                    continue
-                } else {
-                    throw HelperError.io("cannot write QMP command")
-                }
-            }
-        }
-    }
-
-    private static func readResponse(
-        id: String,
-        from descriptor: Int32,
-        timeoutMilliseconds: Int32
-    ) throws -> [String: Any]? {
-        let deadline = DispatchTime.now().uptimeNanoseconds
-            + UInt64(timeoutMilliseconds) * 1_000_000
-        while DispatchTime.now().uptimeNanoseconds < deadline {
-            let remaining = Int32(min(
-                UInt64(Int32.max),
-                (deadline - DispatchTime.now().uptimeNanoseconds) / 1_000_000 + 1
-            ))
-            guard let object = try readJSONObject(from: descriptor, timeoutMilliseconds: remaining) else {
-                return nil
-            }
-            if object["id"] as? String == id { return object }
-        }
-        return nil
-    }
-
-    private static func readJSONObject(
-        from descriptor: Int32,
-        timeoutMilliseconds: Int32
-    ) throws -> [String: Any]? {
-        var bytes = Data()
-        while bytes.count <= 1_048_576 {
-            var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
-            let ready = Darwin.poll(&descriptorPoll, 1, timeoutMilliseconds)
-            if ready == 0 { return nil }
-            if ready < 0 {
-                if errno == EINTR { continue }
-                throw HelperError.io("cannot poll QMP socket")
-            }
-            guard descriptorPoll.revents & Int16(POLLIN) != 0 else {
-                throw HelperError.io("QMP socket closed during handshake")
-            }
-            var byte: UInt8 = 0
-            let count = Darwin.read(descriptor, &byte, 1)
-            if count == 1 {
-                if byte == 0x0A {
-                    guard let object = try JSONSerialization.jsonObject(with: bytes) as? [String: Any] else {
-                        throw HelperError.io("QMP response is not a JSON object")
-                    }
-                    return object
-                }
-                if byte != 0x0D { bytes.append(byte) }
-            } else if count == 0 {
-                throw HelperError.io("QMP socket closed during handshake")
-            } else if errno != EINTR {
-                throw HelperError.io("cannot read QMP socket")
-            }
-        }
-        throw HelperError.io("QMP response exceeds one MiB")
-    }
-
-    private static func drainAvailableInput(from descriptor: Int32) {
-        var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
-        var buffer = [UInt8](repeating: 0, count: 4096)
-        while Darwin.poll(&descriptorPoll, 1, 0) > 0,
-              descriptorPoll.revents & Int16(POLLIN) != 0 {
-            let count = Darwin.read(descriptor, &buffer, buffer.count)
-            if count <= 0 { return }
-            descriptorPoll.revents = 0
-        }
+        try QMPConnection.writeJSON(object, to: descriptor)
     }
 }
 

--- a/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
+++ b/macos/Sources/OmarchyVMHelper/QEMUGPULauncher.swift
@@ -721,7 +721,7 @@ enum CameraPreflight {
 
 final class QEMUGPUProcessSupervisor: @unchecked Sendable {
     enum LaunchEvent: Equatable {
-        case virtualMachineReady
+        case virtualMachineReady(qmpSocketPath: String?)
     }
 
     struct StandardErrorDrain {
@@ -731,7 +731,7 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
 
     private struct StandardErrorConsumption {
         let reachedEnd: Bool
-        let reportsVirtualMachineStart: Bool
+        let launchEvents: [LaunchEvent]
     }
 
     private static let standardErrorReadBudget = 64 * 1_024
@@ -767,9 +767,11 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
             if consumption.reachedEnd {
                 handle.readabilityHandler = nil
             }
-            if consumption.reportsVirtualMachineStart {
+            if !consumption.launchEvents.isEmpty {
                 DispatchQueue.main.async {
-                    launchEvent(.virtualMachineReady)
+                    for event in consumption.launchEvents {
+                        launchEvent(event)
+                    }
                 }
             }
         }
@@ -778,11 +780,14 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
             // QEMU inherits this pipe from the shell launcher and can outlive
             // it after a crash. Drain only bytes available now; waiting for
             // EOF here could strand process completion for the QEMU lifetime.
-            if self?.consumeAvailableStandardError(
+            let finalEvents = self?.consumeAvailableStandardError(
                 from: pipe.fileHandleForReading
-            ).reportsVirtualMachineStart == true {
+            ).launchEvents ?? []
+            if !finalEvents.isEmpty {
                 DispatchQueue.main.async {
-                    launchEvent(.virtualMachineReady)
+                    for event in finalEvents {
+                        launchEvent(event)
+                    }
                 }
             }
             self?.clear(process)
@@ -856,13 +861,13 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
         guard !drain.data.isEmpty else {
             return StandardErrorConsumption(
                 reachedEnd: drain.reachedEnd,
-                reportsVirtualMachineStart: false
+                launchEvents: []
             )
         }
         try? FileHandle.standardError.write(contentsOf: drain.data)
         return StandardErrorConsumption(
             reachedEnd: drain.reachedEnd,
-            reportsVirtualMachineStart: recordStandardError(drain.data)
+            launchEvents: recordStandardError(drain.data)
         )
     }
 
@@ -939,17 +944,57 @@ final class QEMUGPUProcessSupervisor: @unchecked Sendable {
         }
     }
 
-    private func recordStandardError(_ data: Data) -> Bool {
+    private func recordStandardError(_ data: Data) -> [LaunchEvent] {
         lock.lock()
         defer { lock.unlock() }
         errorBuffer += String(decoding: data, as: UTF8.self)
+        var launchEvents: [LaunchEvent] = []
+        if !didReportVirtualMachineStart,
+           let event = Self.virtualMachineReadyEvent(in: errorBuffer) {
+            didReportVirtualMachineStart = true
+            launchEvents.append(event)
+        }
         if errorBuffer.count > 4_096 {
             errorBuffer = String(errorBuffer.suffix(4_096))
         }
-        guard !didReportVirtualMachineStart,
-              errorBuffer.contains("[qemu-gpu] Ready") else { return false }
-        didReportVirtualMachineStart = true
-        return true
+        return launchEvents
+    }
+
+    /// Extracts only a complete launcher-owned readiness line. Waiting for its
+    /// newline matters because FileHandle can split the socket pathname across
+    /// arbitrary readability callbacks.
+    static func virtualMachineReadyEvent(in standardError: String) -> LaunchEvent? {
+        let marker = "[qemu-gpu] Ready. QMP: "
+        var lineStart = standardError.startIndex
+        while let newline = standardError[lineStart...].firstIndex(of: "\n") {
+            var line = String(standardError[lineStart..<newline])
+            if line.last == "\r" {
+                line.removeLast()
+            }
+            if line.hasPrefix(marker) {
+                return .virtualMachineReady(
+                    qmpSocketPath: qmpSocketPath(inReadyLine: line)
+                )
+            }
+            lineStart = standardError.index(after: newline)
+        }
+        return nil
+    }
+
+    static func qmpSocketPath(inReadyLine line: String) -> String? {
+        let linePrefix = "[qemu-gpu] Ready. QMP: "
+        guard line.hasPrefix(linePrefix) else { return nil }
+        let path = String(line.dropFirst(linePrefix.count))
+        let pathPrefix = "/tmp/omarchy-qemu-gpu."
+        let pathSuffix = "/qmp.sock"
+        guard path.hasPrefix(pathPrefix), path.hasSuffix(pathSuffix) else { return nil }
+        let token = path
+            .dropFirst(pathPrefix.count)
+            .dropLast(pathSuffix.count)
+        guard token.count == 6,
+              token.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber) })
+        else { return nil }
+        return path
     }
 
     private static func status(for process: Process) -> Int32 {

--- a/macos/Sources/OmarchyVMHelper/QMPConnection.swift
+++ b/macos/Sources/OmarchyVMHelper/QMPConnection.swift
@@ -1,0 +1,373 @@
+import Darwin
+import Foundation
+
+/// One authenticated connection to QEMU's private machine-protocol socket.
+///
+/// QMP can interleave asynchronous events with command replies, so every
+/// request carries an identifier and waits for the response with that exact
+/// identifier. Calls are serialized because a QMP connection is an ordered
+/// byte stream.
+final class QMPConnection: @unchecked Sendable {
+    struct CommandExecution {
+        let result: [String: Any]
+        let events: [String]
+    }
+
+    private struct MatchedResponse {
+        let object: [String: Any]
+        let events: [String]
+    }
+
+    private let descriptor: Int32
+    private let identifierPrefix: String
+    private let queue = DispatchQueue(label: "dev.tryomarchy.qmp-connection", qos: .userInteractive)
+    private var nextIdentifier: UInt64 = 1
+    private var closed = false
+
+    init(
+        socketPath: String,
+        identifierPrefix: String,
+        timeoutMilliseconds: Int32 = 2_000
+    ) throws {
+        let descriptor = try Self.connectSecureSocket(path: socketPath)
+        self.descriptor = descriptor
+        self.identifierPrefix = identifierPrefix
+        do {
+            try negotiateCapabilities(timeoutMilliseconds: timeoutMilliseconds)
+        } catch {
+            Darwin.close(descriptor)
+            closed = true
+            throw error
+        }
+    }
+
+    /// Test seam for a connected local socket. Production callers must use
+    /// the pathname initializer so ownership, permissions, and type are
+    /// checked before connecting.
+    init(
+        connectedDescriptor descriptor: Int32,
+        identifierPrefix: String,
+        timeoutMilliseconds: Int32 = 2_000
+    ) throws {
+        self.descriptor = descriptor
+        self.identifierPrefix = identifierPrefix
+        do {
+            try negotiateCapabilities(timeoutMilliseconds: timeoutMilliseconds)
+        } catch {
+            Darwin.close(descriptor)
+            closed = true
+            throw error
+        }
+    }
+
+    deinit {
+        if !closed {
+            Darwin.close(descriptor)
+        }
+    }
+
+    func execute(
+        _ command: String,
+        arguments: [String: Any]? = nil,
+        timeoutMilliseconds: Int32 = 2_000
+    ) throws -> [String: Any] {
+        try executeCapturingEvents(
+            command,
+            arguments: arguments,
+            timeoutMilliseconds: timeoutMilliseconds
+        ).result
+    }
+
+    func executeCapturingEvents(
+        _ command: String,
+        arguments: [String: Any]? = nil,
+        timeoutMilliseconds: Int32 = 2_000
+    ) throws -> CommandExecution {
+        try queue.sync { [self] in
+            guard !closed else {
+                throw HelperError.io("QMP control is unavailable")
+            }
+            let identifier = nextCommandIdentifier()
+            var request: [String: Any] = [
+                "execute": command,
+                "id": identifier,
+            ]
+            if let arguments {
+                request["arguments"] = arguments
+            }
+            do {
+                try Self.writeJSON(request, to: descriptor)
+                guard let matched = try Self.readResponse(
+                    id: identifier,
+                    from: descriptor,
+                    timeoutMilliseconds: timeoutMilliseconds
+                ) else {
+                    throw HelperError.io("QMP command \(command) timed out")
+                }
+                let response = matched.object
+                if let error = response["error"] as? [String: Any] {
+                    let detail = error["desc"] as? String ?? "unknown QMP error"
+                    throw HelperError.io("QMP command \(command) failed: \(detail)")
+                }
+                guard let result = response["return"] as? [String: Any] else {
+                    throw HelperError.io("QMP command \(command) returned an invalid response")
+                }
+                return CommandExecution(result: result, events: matched.events)
+            } catch {
+                closeWithoutSynchronization()
+                throw error
+            }
+        }
+    }
+
+    /// Sends a latency-sensitive command after negotiating QMP, without
+    /// waiting for its reply. The currently available response/event bytes are
+    /// drained so a long-lived input connection cannot grow without bound.
+    func send(
+        _ command: String,
+        arguments: [String: Any]? = nil
+    ) throws {
+        try queue.sync { [self] in
+            guard !closed else {
+                throw HelperError.io("QMP control is unavailable")
+            }
+            var request: [String: Any] = [
+                "execute": command,
+                "id": nextCommandIdentifier(),
+            ]
+            if let arguments {
+                request["arguments"] = arguments
+            }
+            do {
+                try Self.writeJSON(request, to: descriptor)
+                Self.drainAvailableInput(from: descriptor)
+            } catch {
+                closeWithoutSynchronization()
+                throw error
+            }
+        }
+    }
+
+    func close() {
+        queue.sync { [self] in
+            closeWithoutSynchronization()
+        }
+    }
+
+    private func negotiateCapabilities(timeoutMilliseconds: Int32) throws {
+        guard let greeting = try Self.readJSONObject(
+            from: descriptor,
+            timeoutMilliseconds: timeoutMilliseconds
+        ), greeting["QMP"] != nil else {
+            throw HelperError.io("QMP socket did not send a valid greeting")
+        }
+        let identifier = "\(identifierPrefix)-capabilities"
+        try Self.writeJSON([
+            "execute": "qmp_capabilities",
+            "id": identifier,
+        ], to: descriptor)
+        guard let matched = try Self.readResponse(
+            id: identifier,
+            from: descriptor,
+            timeoutMilliseconds: timeoutMilliseconds
+        ), matched.object["return"] != nil, matched.object["error"] == nil else {
+            throw HelperError.io("QMP capability negotiation failed")
+        }
+    }
+
+    private func nextCommandIdentifier() -> String {
+        defer { nextIdentifier += 1 }
+        return "\(identifierPrefix)-\(nextIdentifier)"
+    }
+
+    private func closeWithoutSynchronization() {
+        guard !closed else { return }
+        closed = true
+        Darwin.close(descriptor)
+    }
+
+    private static func connectSecureSocket(path: String) throws -> Int32 {
+        guard path.hasPrefix("/"), !path.utf8.contains(0) else {
+            throw HelperError.io("QMP socket path must be an absolute pathname")
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard url.path == path else {
+            throw HelperError.io("QMP socket path must already be standardized")
+        }
+        let parent = url.deletingLastPathComponent()
+        var parentInfo = stat()
+        guard lstat(parent.path, &parentInfo) == 0,
+              (parentInfo.st_mode & S_IFMT) == S_IFDIR,
+              parentInfo.st_uid == getuid(),
+              (parentInfo.st_mode & 0o077) == 0 else {
+            throw HelperError.io("QMP socket parent must be a private directory owned by this user")
+        }
+        var socketInfo = stat()
+        guard lstat(path, &socketInfo) == 0,
+              (socketInfo.st_mode & S_IFMT) == S_IFSOCK,
+              socketInfo.st_uid == getuid() else {
+            throw HelperError.io("QMP endpoint must be a Unix socket owned by this user")
+        }
+
+        let pathBytes = Array(path.utf8)
+        var address = sockaddr_un()
+        guard pathBytes.count < MemoryLayout.size(ofValue: address.sun_path) else {
+            throw HelperError.io("QMP socket path is too long")
+        }
+        address.sun_family = sa_family_t(AF_UNIX)
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: UInt8.self, repeating: 0)
+            buffer.copyBytes(from: pathBytes)
+        }
+
+        let fileDescriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fileDescriptor >= 0 else { throw HelperError.io("cannot create QMP socket") }
+        var noSignal: Int32 = 1
+        guard withUnsafePointer(to: &noSignal, {
+            setsockopt(
+                fileDescriptor,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                $0,
+                socklen_t(MemoryLayout<Int32>.size)
+            )
+        }) == 0 else {
+            Darwin.close(fileDescriptor)
+            throw HelperError.io("cannot make QMP socket resilient to guest exit")
+        }
+        let offset = MemoryLayout.offset(of: \sockaddr_un.sun_path) ?? 0
+        let length = socklen_t(offset + pathBytes.count + 1)
+        let result = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(fileDescriptor, $0, length)
+            }
+        }
+        guard result == 0 else {
+            let detail = String(cString: strerror(errno))
+            Darwin.close(fileDescriptor)
+            throw HelperError.io("cannot connect to QMP socket: \(detail)")
+        }
+        return fileDescriptor
+    }
+
+    static func writeJSON(_ object: [String: Any], to descriptor: Int32) throws {
+        var data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        data.append(contentsOf: [0x0D, 0x0A])
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < rawBuffer.count {
+                let result = Darwin.write(
+                    descriptor,
+                    base.advanced(by: written),
+                    rawBuffer.count - written
+                )
+                if result > 0 {
+                    written += result
+                } else if result < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw HelperError.io("cannot write QMP command")
+                }
+            }
+        }
+    }
+
+    private static func readResponse(
+        id: String,
+        from descriptor: Int32,
+        timeoutMilliseconds: Int32
+    ) throws -> MatchedResponse? {
+        let deadline = deadline(afterMilliseconds: timeoutMilliseconds)
+        var events: [String] = []
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            guard let object = try readJSONObject(
+                from: descriptor,
+                deadline: deadline
+            ) else {
+                return nil
+            }
+            if let event = object["event"] as? String {
+                events.append(event)
+            }
+            if object["id"] as? String == id {
+                return MatchedResponse(object: object, events: events)
+            }
+        }
+        return nil
+    }
+
+    private static func readJSONObject(
+        from descriptor: Int32,
+        timeoutMilliseconds: Int32
+    ) throws -> [String: Any]? {
+        try readJSONObject(
+            from: descriptor,
+            deadline: deadline(afterMilliseconds: timeoutMilliseconds)
+        )
+    }
+
+    private static func readJSONObject(
+        from descriptor: Int32,
+        deadline: UInt64
+    ) throws -> [String: Any]? {
+        var bytes = Data()
+        while bytes.count <= 1_048_576 {
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now < deadline else { return nil }
+            let remainingNanoseconds = deadline - now
+            let roundedMilliseconds = remainingNanoseconds / 1_000_000
+                + (remainingNanoseconds % 1_000_000 == 0 ? 0 : 1)
+            let remainingMilliseconds = Int32(min(
+                UInt64(Int32.max),
+                roundedMilliseconds
+            ))
+            var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let ready = Darwin.poll(&descriptorPoll, 1, remainingMilliseconds)
+            if ready == 0 { return nil }
+            if ready < 0 {
+                if errno == EINTR { continue }
+                throw HelperError.io("cannot poll QMP socket")
+            }
+            guard descriptorPoll.revents & Int16(POLLIN) != 0 else {
+                throw HelperError.io("QMP socket closed while awaiting a response")
+            }
+            var byte: UInt8 = 0
+            let count = Darwin.read(descriptor, &byte, 1)
+            if count == 1 {
+                if byte == 0x0A {
+                    guard let object = try JSONSerialization.jsonObject(with: bytes)
+                        as? [String: Any] else {
+                        throw HelperError.io("QMP response is not a JSON object")
+                    }
+                    return object
+                }
+                if byte != 0x0D { bytes.append(byte) }
+            } else if count == 0 {
+                throw HelperError.io("QMP socket closed while awaiting a response")
+            } else if errno != EINTR {
+                throw HelperError.io("cannot read QMP socket")
+            }
+        }
+        throw HelperError.io("QMP response exceeds one MiB")
+    }
+
+    private static func deadline(afterMilliseconds milliseconds: Int32) -> UInt64 {
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard milliseconds > 0 else { return now }
+        let delta = UInt64(milliseconds) * 1_000_000
+        let (deadline, overflow) = now.addingReportingOverflow(delta)
+        return overflow ? UInt64.max : deadline
+    }
+
+    private static func drainAvailableInput(from descriptor: Int32) {
+        var descriptorPoll = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while Darwin.poll(&descriptorPoll, 1, 0) > 0,
+              descriptorPoll.revents & Int16(POLLIN) != 0 {
+            let count = Darwin.read(descriptor, &buffer, buffer.count)
+            if count <= 0 { return }
+            descriptorPoll.revents = 0
+        }
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -63,8 +63,6 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private var volumeObserver: NSObjectProtocol?
     private var hostPowerObserver: HostPowerNotificationObserver?
     private let hostSleepCoordinator = VMHostSleepCoordinator()
-    private var hostWakeRetryWorkItem: DispatchWorkItem?
-    private var hostWakeRetryPolicy = VMHostWakeRetryPolicy()
 
     /// The workspace the running VM is writing to, so an unmount of its volume
     /// can be recognized as the disk disappearing under QEMU.
@@ -712,30 +710,17 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
                   childRunning,
                   !lifecycle.isStopping
             else { return }
-            guard let delay = hostWakeRetryPolicy.nextDelay() else {
+            guard hostSleepCoordinator.scheduleWakeRetry({ [weak self] in
+                self?.resumeAfterHostWake()
+            }) else {
                 presentHostWakeRecovery(error: error)
                 return
             }
-
-            let workItem = DispatchWorkItem { [weak self] in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    self.hostWakeRetryWorkItem = nil
-                    self.resumeAfterHostWake()
-                }
-            }
-            hostWakeRetryWorkItem = workItem
-            DispatchQueue.main.asyncAfter(
-                deadline: .now() + delay,
-                execute: workItem
-            )
         }
     }
 
     private func cancelHostWakeRetry() {
-        hostWakeRetryWorkItem?.cancel()
-        hostWakeRetryWorkItem = nil
-        hostWakeRetryPolicy.reset()
+        hostSleepCoordinator.cancelWakeRetry()
     }
 
     private func presentHostWakeRecovery(error: Error) {

--- a/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMApplicationController.swift
@@ -4,6 +4,47 @@ import Darwin
 import Foundation
 
 @MainActor
+final class HostPowerNotificationObserver {
+    private let center: NotificationCenter
+    private var tokens: [NSObjectProtocol] = []
+
+    init(
+        center: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        onWillSleep: @escaping @MainActor () -> Void,
+        onDidWake: @escaping @MainActor () -> Void
+    ) {
+        self.center = center
+        tokens = [
+            center.addObserver(
+                forName: NSWorkspace.willSleepNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                MainActor.assumeIsolated {
+                    onWillSleep()
+                }
+            },
+            center.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                MainActor.assumeIsolated {
+                    onDidWake()
+                }
+            },
+        ]
+    }
+
+    func stop() {
+        for token in tokens {
+            center.removeObserver(token)
+        }
+        tokens = []
+    }
+}
+
+@MainActor
 final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let launcherURL: URL
     private let initialArguments: [String]
@@ -20,6 +61,10 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private let bundledMetrics: BundledGuestMetrics?
     private var startMenuWindow: StartMenuWindow?
     private var volumeObserver: NSObjectProtocol?
+    private var hostPowerObserver: HostPowerNotificationObserver?
+    private let hostSleepCoordinator = VMHostSleepCoordinator()
+    private var hostWakeRetryWorkItem: DispatchWorkItem?
+    private var hostWakeRetryPolicy = VMHostWakeRetryPolicy()
 
     /// The workspace the running VM is writing to, so an unmount of its volume
     /// can be recognized as the disk disappearing under QEMU.
@@ -30,6 +75,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private var applicationTerminationPending = false
     private var virtualMachineReachedStart = false
     private var activeLaunchAllowedBootRecovery = false
+    private var pendingHostSleepControlFailure: String?
 
     /// True while a modal alert this controller opened itself (rather than
     /// AppKit) is on screen awaiting a click. `finish()`'s watchdog checks
@@ -71,6 +117,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         observeVolumeUnmounts()
+        observeHostPowerEvents()
         showStartMenu()
     }
 
@@ -171,7 +218,9 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     }
 
     private func startVirtualMachine(allowBootRecovery: Bool = false) {
+        cancelHostWakeRetry()
         virtualMachineReachedStart = false
+        pendingHostSleepControlFailure = nil
         do {
             let accessibilityDecision = AccessibilityLaunchDecision.make(
                 for: AXIsProcessTrusted() ? .authorized : .unavailable
@@ -289,6 +338,8 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
     private func resetDidExit(status: Int32) {
         guard childRunning else { return }
         childRunning = false
+        cancelHostWakeRetry()
+        hostSleepCoordinator.disconnect()
         let wasStopping = lifecycle.isStopping
         lifecycle.childExited()
         if applicationTerminationPending {
@@ -308,6 +359,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         guard childRunning else { return .terminateNow }
         guard !applicationTerminationPending else { return .terminateLater }
 
+        cancelHostWakeRetry()
         applicationTerminationPending = true
         lifecycle.requestQuit()
         supervisor.forward(signal: SIGTERM)
@@ -316,6 +368,7 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
 
     func handleTerminationSignal(_ signal: Int32) {
         guard !applicationTerminationPending else { return }
+        cancelHostWakeRetry()
         lifecycle.requestTermination(signal: signal)
         if childRunning {
             supervisor.forward(signal: signal)
@@ -398,8 +451,9 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
                 arguments: arguments,
                 environment: environment,
                 launchEvent: { [weak self] event in
-                    if event == .virtualMachineReady {
-                        self?.virtualMachineDidStart()
+                    switch event {
+                    case .virtualMachineReady(let qmpSocketPath):
+                        self?.virtualMachineDidStart(qmpSocketPath: qmpSocketPath)
                     }
                 }
             ) { [weak self] status in
@@ -412,10 +466,32 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         childRunning = true
     }
 
-    private func virtualMachineDidStart() {
+    private func virtualMachineDidStart(qmpSocketPath: String?) {
+        guard let qmpSocketPath else {
+            failHostSleepControlSetup(
+                detail: "the launcher did not provide a valid control socket"
+            )
+            return
+        }
+        do {
+            try hostSleepCoordinator.connect(to: qmpSocketPath)
+        } catch {
+            failHostSleepControlSetup(detail: error.localizedDescription)
+            return
+        }
         virtualMachineReachedStart = true
         startMenuWindow?.dismiss()
         startMenuWindow = nil
+    }
+
+    private func failHostSleepControlSetup(detail: String) {
+        fputs(
+            "omarchy-vm-helper: host sleep control is unavailable: \(detail)\n",
+            stderr
+        )
+        pendingHostSleepControlFailure = "The virtual machine started, but Try Omarchy could not enable safe Mac sleep. Please close and reopen the app. (\(detail))"
+        lifecycle.requestQuit()
+        supervisor.forward(signal: SIGTERM)
     }
 
     private static var homeDirectory: String {
@@ -586,6 +662,106 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         }
     }
 
+    private func observeHostPowerEvents() {
+        hostPowerObserver = HostPowerNotificationObserver(
+            onWillSleep: { [weak self] in
+                self?.prepareForHostSleep()
+            },
+            onDidWake: { [weak self] in
+                self?.beginResumeAfterHostWake()
+            }
+        )
+    }
+
+    /// `willSleepNotification` observers may delay host sleep while they run.
+    /// Keep this synchronous so QEMU acknowledges `stop` before macOS freezes
+    /// the Hypervisor.framework process.
+    private func prepareForHostSleep() {
+        do {
+            try hostSleepCoordinator.prepareForHostSleep(
+                vmIsRunning: childRunning,
+                isStopping: lifecycle.isStopping
+            )
+        } catch {
+            fputs(
+                "omarchy-vm-helper: could not pause the VM before host sleep: \(error.localizedDescription)\n",
+                stderr
+            )
+        }
+    }
+
+    private func beginResumeAfterHostWake() {
+        cancelHostWakeRetry()
+        resumeAfterHostWake()
+    }
+
+    private func resumeAfterHostWake() {
+        do {
+            try hostSleepCoordinator.resumeAfterHostWake(
+                vmIsRunning: childRunning,
+                isStopping: lifecycle.isStopping
+            )
+            cancelHostWakeRetry()
+        } catch {
+            fputs(
+                "omarchy-vm-helper: could not resume the VM after host wake: \(error.localizedDescription)\n",
+                stderr
+            )
+            guard !(error is VMHostSleepControlError),
+                  hostSleepCoordinator.pausedForHostSleep,
+                  childRunning,
+                  !lifecycle.isStopping
+            else { return }
+            guard let delay = hostWakeRetryPolicy.nextDelay() else {
+                presentHostWakeRecovery(error: error)
+                return
+            }
+
+            let workItem = DispatchWorkItem { [weak self] in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    self.hostWakeRetryWorkItem = nil
+                    self.resumeAfterHostWake()
+                }
+            }
+            hostWakeRetryWorkItem = workItem
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + delay,
+                execute: workItem
+            )
+        }
+    }
+
+    private func cancelHostWakeRetry() {
+        hostWakeRetryWorkItem?.cancel()
+        hostWakeRetryWorkItem = nil
+        hostWakeRetryPolicy.reset()
+    }
+
+    private func presentHostWakeRecovery(error: Error) {
+        guard childRunning,
+              !lifecycle.isStopping,
+              hostSleepCoordinator.pausedForHostSleep
+        else { return }
+
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Omarchy is still paused"
+        alert.informativeText = "Try Omarchy could not reconnect after this Mac woke, so the VM remains paused to protect its state. Try again, or quit the app. (\(error.localizedDescription))"
+        alert.addButton(withTitle: "Try Again")
+        alert.addButton(withTitle: "Quit Try Omarchy")
+
+        isPresentingBlockingAlert = true
+        let response = alert.runModal()
+        isPresentingBlockingAlert = false
+        if response == .alertFirstButtonReturn {
+            beginResumeAfterHostWake()
+        } else {
+            NSApp.terminate(nil)
+        }
+    }
+
     private func handleVolumeUnmount(at volume: URL) {
         guard childRunning, !lifecycle.isStopping, let root = activeStateRoot else { return }
         let mountPoint = volume.standardizedFileURL.path
@@ -640,6 +816,8 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
         childRunning = false
         let launchAllowedBootRecovery = activeLaunchAllowedBootRecovery
         activeLaunchAllowedBootRecovery = false
+        cancelHostWakeRetry()
+        hostSleepCoordinator.disconnect()
         let recentStandardError = supervisor.recentStandardError
 
         let wasStopping = lifecycle.isStopping
@@ -648,9 +826,13 @@ final class VMApplicationController: NSObject, NSApplicationDelegate {
             reachedVirtualMachineStart: virtualMachineReachedStart,
             wasStopping: wasStopping
         )
+        let hostSleepControlFailure = pendingHostSleepControlFailure
+        pendingHostSleepControlFailure = nil
         lifecycle.childExited()
         if applicationTerminationPending {
             NSApp.reply(toApplicationShouldTerminate: true)
+        } else if let hostSleepControlFailure {
+            startMenuWindow?.launchDidFail(errorMessage: hostSleepControlFailure)
         } else {
             if presentation.showsStartupFailure,
                let startMenuWindow,

--- a/macos/Sources/OmarchyVMHelper/VMHostSleepController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMHostSleepController.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+enum VMHostSleepControlError: LocalizedError, Equatable {
+    case pauseOutcomeUnknown(String)
+    case unsafeResumeState(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .pauseOutcomeUnknown(let detail):
+            "QEMU may have paused before its acknowledgement was received: \(detail)"
+        case .unsafeResumeState(let state):
+            "QEMU is in the \(state) state; refusing to override that pause"
+        }
+    }
+}
+
+struct VMHostWakeRetryPolicy {
+    private let delays: [TimeInterval]
+    private var nextDelayIndex = 0
+
+    init(delays: [TimeInterval] = [0.25, 0.75, 1.5, 3.0]) {
+        self.delays = delays
+    }
+
+    mutating func nextDelay() -> TimeInterval? {
+        guard nextDelayIndex < delays.count else { return nil }
+        defer { nextDelayIndex += 1 }
+        return delays[nextDelayIndex]
+    }
+
+    mutating func reset() {
+        nextDelayIndex = 0
+    }
+}
+
+protocol VMHostSleepControlling: AnyObject {
+    /// Returns true only when STOP was observed while this call's stop command
+    /// was pending for a VM that had just reported itself running.
+    func pauseIfRunning() throws -> Bool
+    func resume() throws
+    func close()
+}
+
+final class QMPVMHostSleepController: VMHostSleepControlling {
+    typealias ConnectionFactory = () throws -> QMPConnection
+
+    private let makeConnection: ConnectionFactory
+    /// Retaining the QMP session that performed `stop` keeps QEMU's
+    /// single-client monitor occupied through wake. A second controller cannot
+    /// insert an ordinary pause between our STOP transition and matching cont.
+    private var sleepConnection: QMPConnection?
+
+    init(socketPath: String) throws {
+        let factory: ConnectionFactory = {
+            try QMPConnection(
+                socketPath: socketPath,
+                identifierPrefix: "omarchy-host-power"
+            )
+        }
+        makeConnection = factory
+        let probe = try factory()
+        probe.close()
+    }
+
+    init(connectionFactory: @escaping ConnectionFactory, validateImmediately: Bool = true) throws {
+        makeConnection = connectionFactory
+        if validateImmediately {
+            let probe = try connectionFactory()
+            probe.close()
+        }
+    }
+
+    func pauseIfRunning() throws -> Bool {
+        var lastError: Error?
+        // A connection can briefly lag while macOS is entering sleep. Retry
+        // only failures that happen before `stop`; once `stop` is sent, its
+        // outcome must remain ambiguous rather than issuing it again.
+        for _ in 0..<2 {
+            do {
+                return try pauseOnFreshConnection()
+            } catch let error as VMHostSleepControlError {
+                throw error
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? HelperError.io("QMP pause failed")
+    }
+
+    private func pauseOnFreshConnection() throws -> Bool {
+        let connection = try makeConnection()
+        var keepConnectionForWake = false
+        defer {
+            if !keepConnectionForWake {
+                connection.close()
+            }
+        }
+        let status = try connection.execute("query-status")
+        guard let running = status["running"] as? Bool else {
+            throw HelperError.io("QMP query-status response omitted the VM run state")
+        }
+        // A VM can already be paused for an I/O error or another control
+        // client. Host wake must never resume a pause it did not create.
+        guard running else { return false }
+        do {
+            let execution = try connection.executeCapturingEvents("stop")
+            // QEMU emits STOP while executing `stop`, before its matching
+            // response. Requiring an observed transition avoids claiming a
+            // VM that was already paused when this command reached QEMU.
+            let observedStop = execution.events.contains("STOP")
+            if observedStop {
+                sleepConnection?.close()
+                sleepConnection = connection
+                keepConnectionForWake = true
+            }
+            return observedStop
+        } catch {
+            // The write may have reached QEMU even if its acknowledgement did
+            // not reach us. The coordinator records possible ownership so a
+            // fresh connection will still attempt recovery after wake.
+            throw VMHostSleepControlError.pauseOutcomeUnknown(
+                error.localizedDescription
+            )
+        }
+    }
+
+    func resume() throws {
+        var lastError: Error?
+        // The clean path uses the session that owns the pause. If it broke
+        // across sleep, retry on a fresh session. A retry also resolves the
+        // case where `cont` succeeded but its response was lost: the second
+        // query observes an already-running VM.
+        for _ in 0..<2 {
+            do {
+                let connection: QMPConnection
+                if let heldConnection = sleepConnection {
+                    sleepConnection = nil
+                    connection = heldConnection
+                } else {
+                    connection = try makeConnection()
+                }
+                defer { connection.close() }
+                let status = try connection.execute("query-status")
+                guard let running = status["running"] as? Bool else {
+                    throw HelperError.io("QMP query-status response omitted the VM run state")
+                }
+                if !running {
+                    guard let runState = status["status"] as? String else {
+                        throw HelperError.io("QMP query-status response omitted the VM status")
+                    }
+                    // `cont` clears some QEMU error stops. Never turn an I/O,
+                    // watchdog, migration, or internal-error stop back into a
+                    // running VM merely because host sleep also paused it.
+                    guard runState == "paused" else {
+                        throw VMHostSleepControlError.unsafeResumeState(runState)
+                    }
+                    _ = try connection.execute("cont")
+                }
+                return
+            } catch let error as VMHostSleepControlError {
+                throw error
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? HelperError.io("QMP resume failed")
+    }
+
+    func close() {
+        sleepConnection?.close()
+        sleepConnection = nil
+    }
+}
+
+/// Owns the pause across exactly one host sleep/wake cycle.
+///
+/// Keeping this policy outside AppKit makes duplicate notifications, process
+/// exits, and pre-existing QEMU pauses deterministic and testable.
+final class VMHostSleepCoordinator {
+    private var controller: (any VMHostSleepControlling)?
+    private(set) var pausedForHostSleep = false
+
+    func connect(to socketPath: String) throws {
+        attach(try QMPVMHostSleepController(socketPath: socketPath))
+    }
+
+    func attach(_ controller: any VMHostSleepControlling) {
+        disconnect()
+        self.controller = controller
+    }
+
+    func disconnect() {
+        controller?.close()
+        controller = nil
+        pausedForHostSleep = false
+    }
+
+    func prepareForHostSleep(vmIsRunning: Bool, isStopping: Bool) throws {
+        guard vmIsRunning,
+              !isStopping,
+              !pausedForHostSleep,
+              let controller else { return }
+        do {
+            if try controller.pauseIfRunning() {
+                pausedForHostSleep = true
+            }
+        } catch let error as VMHostSleepControlError {
+            if case .pauseOutcomeUnknown = error {
+                pausedForHostSleep = true
+            }
+            throw error
+        }
+    }
+
+    func resumeAfterHostWake(vmIsRunning: Bool, isStopping: Bool) throws {
+        guard pausedForHostSleep else { return }
+        guard vmIsRunning, !isStopping, let controller else {
+            pausedForHostSleep = false
+            return
+        }
+        do {
+            try controller.resume()
+            pausedForHostSleep = false
+        } catch let error as VMHostSleepControlError {
+            // An abnormal QEMU stop supersedes this sleep cycle. Relinquish
+            // ownership without issuing cont so a later healthy cycle can be
+            // paused normally again.
+            if case .unsafeResumeState = error {
+                pausedForHostSleep = false
+            }
+            throw error
+        }
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/VMHostSleepController.swift
+++ b/macos/Sources/OmarchyVMHelper/VMHostSleepController.swift
@@ -33,6 +33,50 @@ struct VMHostWakeRetryPolicy {
     }
 }
 
+final class VMHostWakeRetryScheduler {
+    typealias Schedule = (TimeInterval, DispatchWorkItem) -> Void
+
+    private let scheduleWorkItem: Schedule
+    private var policy: VMHostWakeRetryPolicy
+    private var workItem: DispatchWorkItem?
+
+    init(
+        delays: [TimeInterval] = [0.25, 0.75, 1.5, 3.0],
+        scheduleWorkItem: @escaping Schedule = { delay, workItem in
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + delay,
+                execute: workItem
+            )
+        }
+    ) {
+        policy = VMHostWakeRetryPolicy(delays: delays)
+        self.scheduleWorkItem = scheduleWorkItem
+    }
+
+    @discardableResult
+    func schedule(_ action: @escaping @MainActor () -> Void) -> Bool {
+        guard let delay = policy.nextDelay() else { return false }
+        let workItem = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.workItem = nil
+                action()
+            }
+        }
+        self.workItem = workItem
+        scheduleWorkItem(delay, workItem)
+        return true
+    }
+
+    /// Cancels only the pending reconnect attempt. Pause ownership remains in
+    /// `VMHostSleepCoordinator` until a matching wake resumes it.
+    func cancel() {
+        workItem?.cancel()
+        workItem = nil
+        policy.reset()
+    }
+}
+
 protocol VMHostSleepControlling: AnyObject {
     /// Returns true only when STOP was observed while this call's stop command
     /// was pending for a VM that had just reported itself running.
@@ -178,7 +222,12 @@ final class QMPVMHostSleepController: VMHostSleepControlling {
 /// exits, and pre-existing QEMU pauses deterministic and testable.
 final class VMHostSleepCoordinator {
     private var controller: (any VMHostSleepControlling)?
+    private let wakeRetryScheduler: VMHostWakeRetryScheduler
     private(set) var pausedForHostSleep = false
+
+    init(wakeRetryScheduler: VMHostWakeRetryScheduler = VMHostWakeRetryScheduler()) {
+        self.wakeRetryScheduler = wakeRetryScheduler
+    }
 
     func connect(to socketPath: String) throws {
         attach(try QMPVMHostSleepController(socketPath: socketPath))
@@ -190,12 +239,14 @@ final class VMHostSleepCoordinator {
     }
 
     func disconnect() {
+        wakeRetryScheduler.cancel()
         controller?.close()
         controller = nil
         pausedForHostSleep = false
     }
 
     func prepareForHostSleep(vmIsRunning: Bool, isStopping: Bool) throws {
+        wakeRetryScheduler.cancel()
         guard vmIsRunning,
               !isStopping,
               !pausedForHostSleep,
@@ -230,5 +281,14 @@ final class VMHostSleepCoordinator {
             }
             throw error
         }
+    }
+
+    @discardableResult
+    func scheduleWakeRetry(_ action: @escaping @MainActor () -> Void) -> Bool {
+        wakeRetryScheduler.schedule(action)
+    }
+
+    func cancelWakeRetry() {
+        wakeRetryScheduler.cancel()
     }
 }

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -167,6 +167,47 @@ struct QEMUStandardErrorDrainTests {
         #expect(end.reachedEnd)
         #expect(Darwin.fcntl(descriptor, F_GETFL) == originalFlags)
     }
+
+    @Test("waits for a complete Ready line and carries its private QMP socket")
+    func parsesReadyControlSocket() {
+        let partial = "startup output\n[qemu-gpu] Ready. QMP: /tmp/omarchy-qemu-gpu.A1b2C3/qmp"
+        #expect(QEMUGPUProcessSupervisor.virtualMachineReadyEvent(in: partial) == nil)
+
+        let complete = partial + ".sock\nmore output\n"
+        #expect(QEMUGPUProcessSupervisor.virtualMachineReadyEvent(in: complete) ==
+            .virtualMachineReady(
+                qmpSocketPath: "/tmp/omarchy-qemu-gpu.A1b2C3/qmp.sock"
+            ))
+    }
+
+    @Test("ignores a Ready marker embedded inside another diagnostic line")
+    func readyMarkerMustStartItsLine() {
+        let output = """
+            shared folder: /tmp/[qemu-gpu] Ready. QMP: not-a-socket
+            [qemu-gpu] Ready. QMP: /tmp/omarchy-qemu-gpu.Z9y8X7/qmp.sock
+            """ + "\n"
+        #expect(QEMUGPUProcessSupervisor.virtualMachineReadyEvent(in: output) ==
+            .virtualMachineReady(
+                qmpSocketPath: "/tmp/omarchy-qemu-gpu.Z9y8X7/qmp.sock"
+            ))
+
+        let lookalike = "[qemu-gpu] Ready.bad QMP: /tmp/omarchy-qemu-gpu.Z9y8X7/qmp.sock\n"
+        #expect(QEMUGPUProcessSupervisor.virtualMachineReadyEvent(in: lookalike) == nil)
+    }
+
+    @Test("does not trust a malformed socket advertised by the launcher")
+    func rejectsMalformedReadyControlSocket() {
+        for path in [
+            "/tmp/omarchy-qemu-gpu.short/qmp.sock",
+            "/tmp/omarchy-qemu-gpu.A1b2C3/../qmp.sock",
+            "/private/tmp/omarchy-qemu-gpu.A1b2C3/qmp.sock",
+            "/tmp/other.A1b2C3/qmp.sock",
+        ] {
+            let output = "[qemu-gpu] Ready. QMP: \(path)\n"
+            #expect(QEMUGPUProcessSupervisor.virtualMachineReadyEvent(in: output) ==
+                .virtualMachineReady(qmpSocketPath: nil))
+        }
+    }
 }
 
 @Suite("QEMU storage-space estimate")

--- a/macos/Tests/OmarchyVMHelperTests/VMHostSleepControllerTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/VMHostSleepControllerTests.swift
@@ -1,0 +1,599 @@
+import Darwin
+import AppKit
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("VM host sleep lifecycle")
+struct VMHostSleepCoordinatorTests {
+    @Test("one successful pause owns exactly one matching resume")
+    func idempotentSleepWakeCycle() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        #expect(controller.pauseCalls == 1)
+        #expect(coordinator.pausedForHostSleep)
+
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        #expect(controller.resumeCalls == 1)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
+    @Test("a VM paused by another cause is never resumed on host wake")
+    func doesNotOwnExistingPause() throws {
+        let controller = FakeHostSleepController(pauseResult: false)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+
+        #expect(controller.pauseCalls == 1)
+        #expect(controller.resumeCalls == 0)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
+    @Test("pause failure and inactive lifecycle states cannot create resume ownership")
+    func failedAndInactivePausesDoNotResume() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+
+        try coordinator.prepareForHostSleep(vmIsRunning: false, isStopping: false)
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: true)
+        #expect(controller.pauseCalls == 0)
+
+        controller.pauseError = TestControlError.expected
+        #expect(throws: TestControlError.self) {
+            try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        }
+        #expect(!coordinator.pausedForHostSleep)
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        #expect(controller.resumeCalls == 0)
+    }
+
+    @Test("an ambiguous stop acknowledgement is recovered on wake")
+    func ambiguousPauseStillOwnsRecovery() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        controller.pauseError = VMHostSleepControlError.pauseOutcomeUnknown("reply lost")
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+
+        #expect(throws: VMHostSleepControlError.self) {
+            try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        }
+        #expect(coordinator.pausedForHostSleep)
+
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        #expect(controller.resumeCalls == 1)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
+    @Test("a failed wake retains ownership so a delayed retry can recover")
+    func failedWakeCanRetry() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+
+        controller.resumeError = TestControlError.expected
+        #expect(throws: TestControlError.self) {
+            try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        }
+        #expect(coordinator.pausedForHostSleep)
+
+        controller.resumeError = nil
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        #expect(controller.resumeCalls == 2)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
+    @Test("an abnormal QEMU stop is left untouched and releases sleep ownership")
+    func unsafeWakeRelinquishesOwnership() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+
+        controller.resumeError = VMHostSleepControlError.unsafeResumeState("io-error")
+        #expect(throws: VMHostSleepControlError.self) {
+            try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        }
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
+    @Test("wake retry backoff is bounded and resettable")
+    func boundedWakeRetryPolicy() {
+        var policy = VMHostWakeRetryPolicy(delays: [0.25, 0.75])
+        #expect(policy.nextDelay() == 0.25)
+        #expect(policy.nextDelay() == 0.75)
+        #expect(policy.nextDelay() == nil)
+        policy.reset()
+        #expect(policy.nextDelay() == 0.25)
+    }
+
+    @Test("child exit while asleep drops the control session without resuming it")
+    func exitWhileAsleepClearsOwnership() throws {
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+
+        coordinator.disconnect()
+        try coordinator.resumeAfterHostWake(vmIsRunning: false, isStopping: false)
+
+        #expect(controller.closeCalls == 1)
+        #expect(controller.resumeCalls == 0)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+}
+
+@Suite("Host power notifications")
+@MainActor
+struct HostPowerNotificationObserverTests {
+    @Test("sleep is synchronous and wake uses the workspace notification names")
+    func observesWorkspaceSleepAndWake() {
+        let center = NotificationCenter()
+        var events = ["before-sleep"]
+        let observer = HostPowerNotificationObserver(
+            center: center,
+            onWillSleep: {
+                events.append("pause-start")
+                events.append("pause-finished")
+            },
+            onDidWake: {
+                events.append("wake")
+            }
+        )
+        defer { observer.stop() }
+
+        center.post(name: NSWorkspace.willSleepNotification, object: nil)
+        events.append("after-sleep")
+        center.post(name: NSWorkspace.didWakeNotification, object: nil)
+
+        #expect(events == [
+            "before-sleep",
+            "pause-start",
+            "pause-finished",
+            "after-sleep",
+            "wake",
+        ])
+    }
+}
+
+@Suite("QMP host sleep control")
+struct QMPVMHostSleepControllerTests {
+    @Test("bundled Cocoa controls cannot bypass QMP pause ownership")
+    func cocoaPauseOwnershipContract() throws {
+        let patch = try Self.source(
+            named: "patches/qemu-cocoa-pause-ownership.patch"
+        )
+        let build = try Self.source(named: "build-qemu-gpu-runtime.sh")
+
+        #expect(patch.contains(
+            "-    [menu addItem: [[[NSMenuItem alloc] initWithTitle: @\"Pause\" " +
+            "action: @selector(pauseQEMU:)"
+        ))
+        #expect(patch.contains(
+            "-    menuItem = [[[NSMenuItem alloc] initWithTitle: @\"Resume\" " +
+            "action: @selector(resumeQEMU:)"
+        ))
+        #expect(patch.contains(
+            "[menu addItem: [[[NSMenuItem alloc] initWithTitle: @\"Reset\""
+        ))
+        #expect(build.contains(
+            "pause_ownership_patch=\"$native_dir/patches/" +
+            "qemu-cocoa-pause-ownership.patch\""
+        ))
+        #expect(build.contains(
+            "patch -d \"$source_dir\" -p1 -f -i \"$pause_ownership_patch\""
+        ))
+    }
+
+    @Test("negotiates capabilities and correlates stop and cont replies past events")
+    func pauseAndResumeTranscript() throws {
+        let transcript = LockedQMPTranscript()
+        let sessions = try [
+            Self.startServer(steps: [], transcript: transcript),
+            Self.startServer(steps: [
+                TestStep(
+                    command: "query-status",
+                    result: ["running": true, "status": "running"],
+                    events: ["RTC_CHANGE"]
+                ),
+                TestStep(command: "stop", result: [:], events: ["STOP"]),
+                TestStep(
+                    command: "query-status",
+                    result: ["running": false, "status": "paused"]
+                ),
+                TestStep(command: "cont", result: [:], events: ["RESUME"]),
+            ], transcript: transcript),
+        ]
+        let descriptors = LockedDescriptorQueue(sessions.map(\.clientDescriptor))
+        let controller = try QMPVMHostSleepController(connectionFactory: {
+            guard let descriptor = descriptors.take() else {
+                throw HelperError.io("unexpected extra QMP connection")
+            }
+            return try QMPConnection(
+                connectedDescriptor: descriptor,
+                identifierPrefix: "test-host-power"
+            )
+        })
+        #expect(try controller.pauseIfRunning())
+        try controller.resume()
+        controller.close()
+
+        for session in sessions {
+            #expect(session.finished.wait(timeout: .now() + 2) == .success)
+        }
+        #expect(transcript.errorDescription == nil)
+        #expect(transcript.commands == [
+            "qmp_capabilities",
+            "qmp_capabilities",
+            "query-status",
+            "stop",
+            "query-status",
+            "cont",
+        ])
+        #expect(descriptors.isEmpty)
+    }
+
+    @Test("retries a transient connection failure before sending stop")
+    func retriesBeforeStop() throws {
+        let transcript = LockedQMPTranscript()
+        let sessions = try [
+            Self.startServer(steps: [], transcript: transcript),
+            Self.startServer(steps: [
+                TestStep(
+                    command: "query-status",
+                    result: ["running": true, "status": "running"]
+                ),
+                TestStep(command: "stop", result: [:], events: ["STOP"]),
+            ], transcript: transcript),
+        ]
+        let descriptors = LockedDescriptorQueue(sessions.map(\.clientDescriptor))
+        let invocations = LockedInvocationCounter()
+        let controller = try QMPVMHostSleepController(connectionFactory: {
+            if invocations.next() == 2 {
+                throw TestControlError.expected
+            }
+            guard let descriptor = descriptors.take() else {
+                throw HelperError.io("unexpected extra QMP connection")
+            }
+            return try QMPConnection(
+                connectedDescriptor: descriptor,
+                identifierPrefix: "test-host-power"
+            )
+        })
+
+        #expect(try controller.pauseIfRunning())
+
+        for session in sessions {
+            #expect(session.finished.wait(timeout: .now() + 2) == .success)
+        }
+        #expect(transcript.errorDescription == nil)
+        #expect(transcript.commands == [
+            "qmp_capabilities",
+            "qmp_capabilities",
+            "query-status",
+            "stop",
+        ])
+        #expect(descriptors.isEmpty)
+    }
+
+    @Test("does not own a stop that produced no transition event")
+    func noStopTransitionMeansNoWakeResume() throws {
+        let transcript = LockedQMPTranscript()
+        let sessions = try [
+            Self.startServer(steps: [], transcript: transcript),
+            Self.startServer(steps: [
+                TestStep(
+                    command: "query-status",
+                    result: ["running": true, "status": "running"]
+                ),
+                TestStep(command: "stop", result: [:]),
+            ], transcript: transcript),
+        ]
+        let descriptors = LockedDescriptorQueue(sessions.map(\.clientDescriptor))
+        let controller = try QMPVMHostSleepController(connectionFactory: {
+            guard let descriptor = descriptors.take() else {
+                throw HelperError.io("unexpected extra QMP connection")
+            }
+            return try QMPConnection(
+                connectedDescriptor: descriptor,
+                identifierPrefix: "test-host-power"
+            )
+        })
+        let coordinator = VMHostSleepCoordinator()
+        coordinator.attach(controller)
+
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        #expect(!coordinator.pausedForHostSleep)
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+
+        for session in sessions {
+            #expect(session.finished.wait(timeout: .now() + 2) == .success)
+        }
+        #expect(transcript.errorDescription == nil)
+        #expect(transcript.commands == [
+            "qmp_capabilities",
+            "qmp_capabilities",
+            "query-status",
+            "stop",
+        ])
+        #expect(descriptors.isEmpty)
+    }
+
+    @Test("does not override a QEMU I/O-error stop on wake")
+    func refusesUnsafeResumeState() throws {
+        let transcript = LockedQMPTranscript()
+        let sessions = try [
+            Self.startServer(steps: [], transcript: transcript),
+            Self.startServer(steps: [
+                TestStep(
+                    command: "query-status",
+                    result: ["running": false, "status": "io-error"]
+                ),
+            ], transcript: transcript),
+        ]
+        let descriptors = LockedDescriptorQueue(sessions.map(\.clientDescriptor))
+        let controller = try QMPVMHostSleepController(connectionFactory: {
+            guard let descriptor = descriptors.take() else {
+                throw HelperError.io("unexpected extra QMP connection")
+            }
+            return try QMPConnection(
+                connectedDescriptor: descriptor,
+                identifierPrefix: "test-host-power"
+            )
+        })
+
+        #expect(throws: VMHostSleepControlError.self) {
+            try controller.resume()
+        }
+
+        for session in sessions {
+            #expect(session.finished.wait(timeout: .now() + 2) == .success)
+        }
+        #expect(transcript.errorDescription == nil)
+        #expect(transcript.commands == [
+            "qmp_capabilities",
+            "qmp_capabilities",
+            "query-status",
+        ])
+        #expect(descriptors.isEmpty)
+    }
+
+    private struct TestStep: @unchecked Sendable {
+        let command: String
+        let result: [String: Any]
+        let events: [String]
+
+        init(command: String, result: [String: Any], events: [String] = []) {
+            self.command = command
+            self.result = result
+            self.events = events
+        }
+    }
+
+    private struct TestSession {
+        let clientDescriptor: Int32
+        let finished: DispatchSemaphore
+    }
+
+    private static func startServer(
+        steps: [TestStep],
+        transcript: LockedQMPTranscript
+    ) throws -> TestSession {
+        var descriptors: [Int32] = [-1, -1]
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+            throw HelperError.io("cannot create test QMP socket pair")
+        }
+        let serverDescriptor = descriptors[1]
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer {
+                Darwin.close(serverDescriptor)
+                finished.signal()
+            }
+            do {
+                try QMPConnection.writeJSON([
+                    "QMP": [
+                        "version": [
+                            "qemu": ["major": 10, "minor": 2, "micro": 0],
+                            "package": "",
+                        ],
+                        "capabilities": [],
+                    ],
+                ], to: serverDescriptor)
+                let capabilities = try readJSON(from: serverDescriptor)
+                let capabilitiesCommand = try string("execute", in: capabilities)
+                guard capabilitiesCommand == "qmp_capabilities" else {
+                    throw HelperError.io(
+                        "expected qmp_capabilities, received \(capabilitiesCommand)"
+                    )
+                }
+                transcript.append(capabilitiesCommand)
+                try respond(
+                    id: try string("id", in: capabilities),
+                    result: [:],
+                    to: serverDescriptor
+                )
+
+                for step in steps {
+                    let request = try readJSON(from: serverDescriptor)
+                    let command = try string("execute", in: request)
+                    guard command == step.command else {
+                        throw HelperError.io(
+                            "expected QMP command \(step.command), received \(command)"
+                        )
+                    }
+                    transcript.append(command)
+                    for event in step.events {
+                        try QMPConnection.writeJSON(["event": event], to: serverDescriptor)
+                    }
+                    try respond(
+                        id: try string("id", in: request),
+                        result: step.result,
+                        to: serverDescriptor
+                    )
+                }
+            } catch {
+                transcript.record(error)
+            }
+        }
+        return TestSession(clientDescriptor: descriptors[0], finished: finished)
+    }
+
+    private static func readJSON(from descriptor: Int32) throws -> [String: Any] {
+        var data = Data()
+        while data.count <= 1_048_576 {
+            var byte: UInt8 = 0
+            let count = Darwin.read(descriptor, &byte, 1)
+            if count == 1 {
+                if byte == 0x0A {
+                    guard let object = try JSONSerialization.jsonObject(with: data)
+                        as? [String: Any] else {
+                        throw HelperError.io("test QMP request is not an object")
+                    }
+                    return object
+                }
+                if byte != 0x0D { data.append(byte) }
+            } else if count == 0 {
+                throw HelperError.io("test QMP client closed early")
+            } else if errno != EINTR {
+                throw HelperError.io("cannot read test QMP request")
+            }
+        }
+        throw HelperError.io("test QMP request is too large")
+    }
+
+    private static func string(_ key: String, in object: [String: Any]) throws -> String {
+        guard let value = object[key] as? String else {
+            throw HelperError.io("test QMP request omitted \(key)")
+        }
+        return value
+    }
+
+    private static func respond(
+        id: String,
+        result: [String: Any],
+        to descriptor: Int32
+    ) throws {
+        try QMPConnection.writeJSON([
+            "return": result,
+            "id": id,
+        ], to: descriptor)
+    }
+
+    private static func source(named relativePath: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let macosDirectory = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: macosDirectory.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}
+
+private enum TestControlError: Error {
+    case expected
+}
+
+private final class FakeHostSleepController: VMHostSleepControlling {
+    let pauseResult: Bool
+    var pauseError: Error?
+    var resumeError: Error?
+    private(set) var pauseCalls = 0
+    private(set) var resumeCalls = 0
+    private(set) var closeCalls = 0
+
+    init(pauseResult: Bool) {
+        self.pauseResult = pauseResult
+    }
+
+    func pauseIfRunning() throws -> Bool {
+        pauseCalls += 1
+        if let pauseError { throw pauseError }
+        return pauseResult
+    }
+
+    func resume() throws {
+        resumeCalls += 1
+        if let resumeError { throw resumeError }
+    }
+
+    func close() {
+        closeCalls += 1
+    }
+}
+
+private final class LockedQMPTranscript: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCommands: [String] = []
+    private var storedErrorDescription: String?
+
+    var commands: [String] {
+        lock.withLock { storedCommands }
+    }
+
+    var errorDescription: String? {
+        lock.withLock { storedErrorDescription }
+    }
+
+    func append(_ command: String) {
+        lock.withLock {
+            storedCommands.append(command)
+        }
+    }
+
+    func record(_ error: Error) {
+        lock.withLock {
+            storedErrorDescription = error.localizedDescription
+        }
+    }
+}
+
+private final class LockedDescriptorQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var descriptors: [Int32]
+
+    init(_ descriptors: [Int32]) {
+        self.descriptors = descriptors
+    }
+
+    deinit {
+        for descriptor in descriptors {
+            Darwin.close(descriptor)
+        }
+    }
+
+    var isEmpty: Bool {
+        lock.withLock { descriptors.isEmpty }
+    }
+
+    func take() -> Int32? {
+        lock.withLock {
+            guard !descriptors.isEmpty else { return nil }
+            return descriptors.removeFirst()
+        }
+    }
+}
+
+private final class LockedInvocationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func next() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/VMHostSleepControllerTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/VMHostSleepControllerTests.swift
@@ -116,6 +116,44 @@ struct VMHostSleepCoordinatorTests {
         #expect(policy.nextDelay() == 0.25)
     }
 
+    @Test("re-sleep cancels a wake retry without releasing pause ownership")
+    @MainActor
+    func resleepCancelsPendingWakeRetry() throws {
+        var pendingRetry: DispatchWorkItem?
+        let retryScheduler = VMHostWakeRetryScheduler(
+            delays: [0.25],
+            scheduleWorkItem: { _, workItem in
+                pendingRetry = workItem
+            }
+        )
+        let controller = FakeHostSleepController(pauseResult: true)
+        let coordinator = VMHostSleepCoordinator(wakeRetryScheduler: retryScheduler)
+        coordinator.attach(controller)
+
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        controller.resumeError = TestControlError.expected
+        #expect(throws: TestControlError.self) {
+            try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        }
+        #expect(coordinator.scheduleWakeRetry {
+            try? coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        })
+
+        // The new sleep cancels stale wake work while retaining the
+        // already-owned pause for the next wake.
+        try coordinator.prepareForHostSleep(vmIsRunning: true, isStopping: false)
+        pendingRetry?.perform()
+
+        #expect(controller.pauseCalls == 1)
+        #expect(controller.resumeCalls == 1)
+        #expect(coordinator.pausedForHostSleep)
+
+        controller.resumeError = nil
+        try coordinator.resumeAfterHostWake(vmIsRunning: true, isStopping: false)
+        #expect(controller.resumeCalls == 2)
+        #expect(!coordinator.pausedForHostSleep)
+    }
+
     @Test("child exit while asleep drops the control session without resuming it")
     func exitWhileAsleepClearsOwnership() throws {
         let controller = FakeHostSleepController(pauseResult: true)

--- a/macos/Tests/qemu-power-actions.test.sh
+++ b/macos/Tests/qemu-power-actions.test.sh
@@ -25,4 +25,58 @@ action_count=$(printf '%s\n' "$qemu_arguments" | grep -Ec -- \
   fail 'QEMU must not remain open after a guest shutdown'
 }
 
-printf 'qemu-power-actions.test: reboot/shutdown policy: PASS\n'
+qmp_argument_count=$(printf '%s\n' "$qemu_arguments" | grep -Fxc -- \
+  '  -qmp "unix:$qmp_socket,server=on,wait=off"' || true)
+[[ $qmp_argument_count == 1 ]] || {
+  fail 'QEMU must expose its private machine-protocol control socket exactly once'
+}
+
+monitor_argument_count=$(printf '%s\n' "$qemu_arguments" | grep -Ec -- \
+  '^[[:space:]]+-mon(itor)?[[:space:]]' || true)
+monitor_none_count=$(printf '%s\n' "$qemu_arguments" | grep -Fxc -- \
+  '  -monitor none' || true)
+[[ $monitor_argument_count == 1 && $monitor_none_count == 1 ]] || {
+  fail 'QMP must be the only QEMU monitor that can pause the VM'
+}
+
+gdb_argument_count=$(printf '%s\n' "$qemu_arguments" | grep -Ec -- \
+  '^[[:space:]]+(-gdb|-s)([[:space:]]|$)' || true)
+[[ $gdb_argument_count == 0 ]] || {
+  fail 'the production VM must not expose a second debugger pause controller'
+}
+
+qmp_assignment_count=$(grep -Fxc -- \
+  'qmp_socket="/tmp/${work_dir##*/}/qmp.sock"' "$launcher" || true)
+[[ $qmp_assignment_count == 1 ]] || {
+  fail 'the QMP socket pathname must match the validated launcher contract'
+}
+
+mktemp_template_count=$(grep -Fxc -- \
+  "work_dir=\$(mktemp -d '/private/tmp/omarchy-qemu-gpu.XXXXXX') || {" \
+  "$launcher" || true)
+[[ $mktemp_template_count == 1 ]] || {
+  fail 'the private runtime directory must retain its six-character token'
+}
+
+ready_control_count=$(grep -Fxc -- \
+  'echo "[qemu-gpu] Ready. QMP: $qmp_socket" >&2' "$launcher" || true)
+[[ $ready_control_count == 1 ]] || {
+  fail 'the Ready event must advertise the same private QMP socket used by QEMU'
+}
+
+ready_emission_count=$(grep -Ec -- \
+  '^[[:space:]]*echo .*\[qemu-gpu\] Ready\.' "$launcher" || true)
+[[ $ready_emission_count == 1 ]] || {
+  fail 'the launcher must emit exactly one Ready event'
+}
+
+qmp_check_line=$(grep -nF -- \
+  '[[ -S $qmp_socket ]] || fail "QEMU did not create its private QMP socket"' \
+  "$launcher" | cut -d: -f1)
+ready_line=$(grep -nF -- \
+  'echo "[qemu-gpu] Ready. QMP: $qmp_socket" >&2' "$launcher" | cut -d: -f1)
+[[ -n $qmp_check_line && -n $ready_line && $qmp_check_line -lt $ready_line ]] || {
+  fail 'the Ready event must follow QMP socket validation'
+}
+
+printf 'qemu-power-actions.test: reboot/shutdown and host-sleep control policy: PASS\n'

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -6,9 +6,9 @@ usage() {
   cat <<'EOF'
 Usage: macos/build-qemu-gpu-runtime.sh [--archive-dir DIR]
 
-Build the pinned QEMU/VirGL source stack with Try Omarchy's Cocoa
-identity, dynamic-display, and immersive-mode patches, then relocate, sign,
-validate, and
+Build the pinned QEMU/VirGL source stack with Try Omarchy's Cocoa identity,
+dynamic-display, immersive-mode, and pause-ownership patches, then relocate,
+sign, validate, and
 atomically stage it at:
   macos/.build/qemu-gpu-runtime
 
@@ -48,6 +48,7 @@ identity_patch="$native_dir/patches/qemu-cocoa-product-identity.patch"
 display_patch="$native_dir/patches/qemu-cocoa-dynamic-display.patch"
 immersive_patch="$native_dir/patches/qemu-cocoa-immersive-mode.patch"
 full_grab_patch="$native_dir/patches/qemu-cocoa-full-grab-focus.patch"
+pause_ownership_patch="$native_dir/patches/qemu-cocoa-pause-ownership.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
 shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 strchrnul_patch="$native_dir/patches/qemu-darwin-strchrnul-compat.patch"
@@ -66,6 +67,7 @@ identity_patch_sha256=5c9358c2858a74d6a678eacaae550a021f3e616c98c4e4e98c0e50bd86
 display_patch_sha256=1ce59350b6b8e6842bc0c9ca34c97f54cb75e85e2d7b35e5b483858654c4d693
 immersive_patch_sha256=2462463932f7db0d659f754f7f9c182884564dbcd7d4b8e523f1b57f0bd9fe5b
 full_grab_patch_sha256=d94aaa7b8b8b97eb25a5ace2b3a1268985e1b16e4e6201847b926b8ee709dbfb
+pause_ownership_patch_sha256=1a5729b36eb3e437395d41883a10c3c652df71d289d5df84d95aebd49c78a8f0
 audio_device_patch_sha256=03aca71c26163c337338cc3b2013c35430690fc0e8b66c5ce92a42f59a9b3334
 shared_folder_patch_sha256=41247692501655393ae3a40f56915472ab29b6e89c5173e33db1f62cca56632f
 strchrnul_patch_sha256=ec1048dd0e8ebe53bf7e8a3bca9bf2f5f4336cd607d4cd077437470e9a32094a
@@ -149,6 +151,8 @@ macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
   die "missing immersive-mode patch: $immersive_patch"
 [[ -f $full_grab_patch && ! -L $full_grab_patch ]] || \
   die "missing Cocoa full-grab patch: $full_grab_patch"
+[[ -f $pause_ownership_patch && ! -L $pause_ownership_patch ]] || \
+  die "missing Cocoa pause-ownership patch: $pause_ownership_patch"
 [[ -f $audio_device_patch && ! -L $audio_device_patch ]] || \
   die "missing SDL audio-device patch: $audio_device_patch"
 [[ -f $texture_patch && ! -L $texture_patch ]] || \
@@ -331,6 +335,8 @@ verify_file_sha "Try Omarchy Cocoa immersive-mode patch" \
   "$immersive_patch" "$immersive_patch_sha256"
 verify_file_sha "Try Omarchy Cocoa full-grab patch" \
   "$full_grab_patch" "$full_grab_patch_sha256"
+verify_file_sha "Try Omarchy Cocoa pause-ownership patch" \
+  "$pause_ownership_patch" "$pause_ownership_patch_sha256"
 verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
 verify_file_sha "Try Omarchy 9p shared-folder patch" \
@@ -338,13 +344,14 @@ verify_file_sha "Try Omarchy 9p shared-folder patch" \
 verify_file_sha "Try Omarchy Darwin strchrnul compatibility patch" \
   "$strchrnul_patch" "$strchrnul_patch_sha256"
 
-log "Applying the exact render, identity, display, immersive, audio, folder, and Darwin compatibility patches"
+log "Applying the exact render, identity, display, immersive, pause-ownership, audio, folder, and Darwin compatibility patches"
 patch -d "$source_dir" -p1 -f -i "$texture_patch"
 patch -d "$source_dir" -p1 -f -i "$gpu_fix_patch"
 patch -d "$source_dir" -p1 -f -i "$identity_patch"
 patch -d "$source_dir" -p1 -f -i "$display_patch"
 patch -d "$source_dir" -p1 -f -i "$immersive_patch"
 patch -d "$source_dir" -p1 -f -i "$full_grab_patch"
+patch -d "$source_dir" -p1 -f -i "$pause_ownership_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
 patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 patch -d "$source_dir" -p1 -f -i "$strchrnul_patch"

--- a/macos/patches/qemu-cocoa-pause-ownership.patch
+++ b/macos/patches/qemu-cocoa-pause-ownership.patch
@@ -1,0 +1,31 @@
+From: Try Omarchy contributors
+Subject: [PATCH] cocoa: reserve pause ownership for the host sleep controller
+
+Applies after the Try Omarchy Cocoa identity, dynamic-display, immersive-mode,
+and full-grab patches.
+
+The macOS helper attributes a QMP STOP transition to host sleep and resumes
+only that transition after wake. QEMU's Cocoa Machine menu calls qmp_stop and
+qmp_cont in-process, bypassing the private QMP socket. If its Pause action
+races the helper's stop command, both transitions produce the same global STOP
+event and the helper cannot prove which caller owns the paused state.
+
+Remove the Cocoa Pause and Resume items so the helper is the only ordinary
+controller capable of entering QEMU's paused run state. Reset and Power Down
+remain available, and abnormal run states are still left untouched on wake.
+
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -1872,11 +1872,6 @@ static void create_initial_menus(void)
+     // Machine menu
+     menu = [[NSMenu alloc] initWithTitle: @"Machine"];
+     [menu setAutoenablesItems: NO];
+-    [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Pause" action: @selector(pauseQEMU:) keyEquivalent: @""] autorelease]];
+-    menuItem = [[[NSMenuItem alloc] initWithTitle: @"Resume" action: @selector(resumeQEMU:) keyEquivalent: @""] autorelease];
+-    [menu addItem: menuItem];
+-    [menuItem setEnabled: NO];
+-    [menu addItem: [NSMenuItem separatorItem]];
+     [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Reset" action: @selector(restartQEMU:) keyEquivalent: @""] autorelease]];
+     [menu addItem: [[[NSMenuItem alloc] initWithTitle: @"Power Down" action: @selector(powerDownQEMU:) keyEquivalent: @""] autorelease]];
+     menuItem = [[[NSMenuItem alloc] initWithTitle: @"Machine" action:nil keyEquivalent:@""] autorelease];

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -1382,7 +1382,7 @@ done
 [[ -S $audio_bridge_socket ]] || fail "QEMU did not create its private audio bridge socket"
 [[ -S $camera_bridge_socket ]] || fail "QEMU did not create its private camera bridge socket"
 [[ -S $clipboard_bridge_socket ]] || fail "QEMU did not create its private clipboard bridge socket"
-echo "[qemu-gpu] Ready." >&2
+echo "[qemu-gpu] Ready. QMP: $qmp_socket" >&2
 
 # FD 9 deliberately remains open only in QEMU. Letting the sibling audio
 # bridge inherit it could keep a persistent workspace locked after QEMU exits.


### PR DESCRIPTION
## Summary

- pause the VM synchronously over a private QMP connection when macOS announces host sleep
- resume only pauses owned by the host-sleep transition, with bounded reconnect retries after wake
- remove Cocoa Pause and Resume menu actions so pause ownership cannot become ambiguous
- fail closed when safe host-sleep control cannot be established

## QEMU compatibility

- based on current main after #62
- rebuilt the complete patched QEMU 11.1.1 runtime with the current Cocoa patch chain

## Testing

- make runtime
- make test
- 198 Swift tests across 45 suites
- guest and native contract tests
- staged-QEMU crash-lock test

Closes #61