### PR TITLE
Fix GTK icon cache generation

### DIFF
--- a/guest/scripts/materialize-omarchy.sh
+++ b/guest/scripts/materialize-omarchy.sh
@@ -185,9 +185,15 @@ install_file 0644 "$source_dir/etc/fastfetch/config.jsonc" "$root/etc/fastfetch/
 # Preserve the application metadata and artwork used by Quickshell's real app
 # provider. Normalize display-style artwork names to the lowercase, hyphenated
 # icon identifiers used by the desktop files and accepted by GTK's icon cache.
+# The stem is normalized separately so Battle.net.png becomes battle-net.png
+# rather than battle.net.png.
 mkdir -p "$root/usr/share/icons/hicolor/256x256/apps"
 while IFS= read -r icon; do
-  icon_name=$(basename "$icon" | LC_ALL=C tr '[:upper:] ' '[:lower:]-')
+  icon_base=$(basename "$icon")
+  icon_stem=${icon_base%.*}
+  icon_ext=${icon_base##*.}
+  icon_stem=$(printf '%s' "$icon_stem" | LC_ALL=C tr '[:upper:]. ' '[:lower:]--')
+  icon_name="$icon_stem.$icon_ext"
   icon_target="$root/usr/share/icons/hicolor/256x256/apps/$icon_name"
   [[ ! -e $icon_target ]] || fail "normalized icon name collides: $icon_name"
   install_file 0644 "$icon" "$icon_target"

--- a/guest/scripts/materialize-omarchy.sh
+++ b/guest/scripts/materialize-omarchy.sh
@@ -183,10 +183,14 @@ install_file 0644 "$source_dir/etc/profile.d/omarchy.sh" "$root/etc/profile.d/om
 install_file 0644 "$source_dir/etc/fastfetch/config.jsonc" "$root/etc/fastfetch/config.jsonc"
 
 # Preserve the application metadata and artwork used by Quickshell's real app
-# provider. A single scalable hicolor location works for these demo assets.
+# provider. Normalize display-style artwork names to the lowercase, hyphenated
+# icon identifiers used by the desktop files and accepted by GTK's icon cache.
 mkdir -p "$root/usr/share/icons/hicolor/256x256/apps"
 while IFS= read -r icon; do
-  install_file 0644 "$icon" "$root/usr/share/icons/hicolor/256x256/apps/$(basename "$icon")"
+  icon_name=$(basename "$icon" | LC_ALL=C tr '[:upper:] ' '[:lower:]-')
+  icon_target="$root/usr/share/icons/hicolor/256x256/apps/$icon_name"
+  [[ ! -e $icon_target ]] || fail "normalized icon name collides: $icon_name"
+  install_file 0644 "$icon" "$icon_target"
 done < <(find "$source_dir/applications/icons" -maxdepth 1 -type f | sort)
 install_file 0644 "$source_dir/icon.png" "$root/usr/share/pixmaps/omarchy.png"
 install_file 0644 "$source_dir/icon.png" "$root/usr/share/icons/hicolor/256x256/apps/omarchy.png"

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -1140,6 +1140,7 @@ HOTPLUG=1
             staged_icons = staged_root / "usr/share/icons/hicolor/256x256/apps"
             icon_names = {path.name for path in staged_icons.iterdir() if path.is_file()}
             expected_normalized_icons = {
+                "battle-net.png",
                 "disk-usage.png",
                 "google-contacts.png",
                 "google-maps.png",
@@ -1150,6 +1151,8 @@ HOTPLUG=1
             check(
                 expected_normalized_icons <= icon_names
                 and not {
+                    "Battle.net.png",
+                    "battle.net.png",
                     "Disk Usage.png",
                     "Google Contacts.png",
                     "Google Maps.png",

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -1120,6 +1120,54 @@ HOTPLUG=1
                 "fresh-user background sorting selects the Try Omarchy wallpaper by default",
             )
 
+        with tempfile.TemporaryDirectory() as temporary:
+            staged_root = Path(temporary) / "root"
+            subprocess.run(
+                [
+                    "bash",
+                    str(GUEST / "scripts/materialize-omarchy.sh"),
+                    "--root",
+                    str(staged_root),
+                    "--source",
+                    str(source),
+                    "--spec",
+                    str(GUEST / "spec.json"),
+                ],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            staged_icons = staged_root / "usr/share/icons/hicolor/256x256/apps"
+            icon_names = {path.name for path in staged_icons.iterdir() if path.is_file()}
+            expected_normalized_icons = {
+                "disk-usage.png",
+                "google-contacts.png",
+                "google-maps.png",
+                "google-messages.png",
+                "google-photos.png",
+                "retro-gaming.png",
+            }
+            check(
+                expected_normalized_icons <= icon_names
+                and not {
+                    "Disk Usage.png",
+                    "Google Contacts.png",
+                    "Google Maps.png",
+                    "Google Messages.png",
+                    "Google Photos.png",
+                    "Retro Gaming.png",
+                }
+                & icon_names,
+                "materialized application icons match their desktop icon names",
+            )
+            check(
+                all(
+                    all(0x21 <= byte <= 0x7E for byte in os.fsencode(path.name))
+                    for path in staged_icons.iterdir()
+                ),
+                "materialized application icon paths are GTK cache-safe",
+            )
+
         subprocess.run(
             [
                 "python3",


### PR DESCRIPTION
## Summary

- normalize copied Omarchy application artwork to the lowercase, hyphenated icon identifiers used by the corresponding desktop entries
- fail the guest build if two upstream artwork names normalize to the same target
- materialize the exact pinned Omarchy source in regression coverage and verify the resulting hicolor names and GTK cache-safety contract

## Problem

Omarchy 4.0.2 includes display-style artwork names such as `Google Messages.png`, `Disk Usage.png`, and `Retro Gaming.png`. Try Omarchy copied those basenames verbatim into `/usr/share/icons/hicolor/256x256/apps`, while the desktop entries reference `google-messages`, `disk-usage`, and `retro-gaming`.

Besides preventing those icon lookups from matching, the embedded spaces make `gtk-update-icon-cache` reject the generated cache. This surfaces during `omarchy-update` as:

```text
gtk-update-icon-cache: The generated cache was invalid.
error: command failed to execute correctly
```

The materializer now performs the same ASCII lowercase-and-hyphen normalization already reflected in the desktop icon identifiers.

## Validation

- Live v0.3.0 guest: reproduced the invalid cache with the six whitespace-bearing names; after applying the normalized mappings, `gtk-update-icon-cache -f -t /usr/share/icons/hicolor` reported `Cache file created successfully`, with no remaining cache-unsafe paths
- `guest/test --source <clean pinned Omarchy 4.0.2 checkout>`: 64 tests plus all guest/materialization contracts pass
- `make test`: build-cache tests, guest tests, macOS compatibility and relocation checks, 181 Swift tests across 42 suites, and QEMU networking/power/storage suites pass
- `git diff --check`, shell syntax, and Python compilation pass

`make build` was also attempted, but the guest build stops before materialization because the current Arch Linux ARM repository transaction has advanced beyond `packages.lock.json`. This PR deliberately does not mix an unrelated 24-package lock refresh into the icon fix.
