### PR TITLE
Guard omitted fcitx5 and bt-agent user units

### DIFF
--- a/guest/native-overlay/etc/systemd/user/bt-agent.service.d/10-guard.conf
+++ b/guest/native-overlay/etc/systemd/user/bt-agent.service.d/10-guard.conf
@@ -1,0 +1,5 @@
+[Unit]
+# bluez-tools is omitted from the trimmed guest. The unit already skips when
+# /sys/class/bluetooth is absent; guard the binary too so Bluetooth
+# passthrough cannot start a Restart=on-failure loop without bt-agent.
+ConditionPathExists=/usr/bin/bt-agent

--- a/guest/native-overlay/etc/systemd/user/omarchy-fcitx5.service.d/10-guard.conf
+++ b/guest/native-overlay/etc/systemd/user/omarchy-fcitx5.service.d/10-guard.conf
@@ -1,0 +1,5 @@
+[Unit]
+# The trimmed ARM64 guest omits fcitx5. Upstream enables this unit on first
+# run with Restart=always, so a missing binary would 203/EXEC-loop forever and
+# flood the journal. Skip cleanly until the package is installed.
+ConditionPathExists=/usr/bin/fcitx5

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -427,6 +427,20 @@ def main() -> None:
         and "omarchy-provision-autologin-once.service" in native_autologin,
         "native provisioning keeps direct graphical login across VM boots",
     )
+    fcitx_guard = read(
+        GUEST / "native-overlay/etc/systemd/user/omarchy-fcitx5.service.d/10-guard.conf"
+    )
+    check(
+        "ConditionPathExists=/usr/bin/fcitx5" in fcitx_guard,
+        "fcitx5 user unit is inert until the omitted binary is installed",
+    )
+    bt_agent_guard = read(
+        GUEST / "native-overlay/etc/systemd/user/bt-agent.service.d/10-guard.conf"
+    )
+    check(
+        "ConditionPathExists=/usr/bin/bt-agent" in bt_agent_guard,
+        "bt-agent user unit is inert until the omitted binary is installed",
+    )
     check("omarchy-native-audio-bridge" in configure, "guest installs native host-audio integration")
     check(
         "default.target.wants/omarchy-native-camera-bridge.service" in configure,


### PR DESCRIPTION
## Summary

- add `ConditionPathExists` drop-ins for `omarchy-fcitx5.service` and `bt-agent.service` so units enabled by Omarchy's first-run script stay inert when their binaries are absent from the trimmed ARM64 guest
- cover both guards in the guest contract suite

Fixes https://github.com/omacom/try-omarchy/issues/91

## Problem

The guest materializes and enables `omarchy-fcitx5.service`, but `fcitx5` is not in the factory package set. With `Restart=always` / `RestartSec=2`, the unit 203/EXEC-loops and can dominate the journal. `bt-agent.service` has the same binary gap; it only stays quiet today because `/sys/class/bluetooth` is missing in the VM.

## Approach

Match the idiom already used by upstream `omarchy-tailscale-receive.service`: guest-side drop-ins under `etc/systemd/user/*.service.d/` with `ConditionPathExists` on the ExecStart binary. Installing either package later makes the existing enabled unit start normally.

## Test plan

- [x] `python3 -m unittest discover -s guest/tests -p 'test_*.py'`
- [x] `python3 guest/tests/verify.py`
- [ ] After guest rebuild: `systemctl --user status omarchy-fcitx5.service` shows skipped/condition rather than restarting; journal no longer floods with 203/EXEC
- [ ] Optional: install `fcitx5` and confirm the unit becomes startable without changing the drop-in