### PR TITLE
Clarify Omarchy update free-space errors in the guest

### DIFF
--- a/guest/patches/omarchy/update-free-space-message.patch
+++ b/guest/patches/omarchy/update-free-space-message.patch
@@ -1,0 +1,18 @@
+diff --git a/bin/omarchy-update-requires-free-space b/bin/omarchy-update-requires-free-space
+index 07523eb..0d47c5e 100755
+--- a/bin/omarchy-update-requires-free-space
++++ b/bin/omarchy-update-requires-free-space
+@@ -11,6 +11,13 @@ elif read -r available_bytes < <(df --output=avail --block-size=1 / 2>/dev/null
+   [[ $available_bytes =~ ^[0-9]+$ ]] &&
+   (( available_bytes < 10 * 1024 * 1024 * 1024 )); then
+   echo "You need at least 10 GiB free to safely update Omarchy."
++  if [[ -f /usr/share/try-omarchy/build-spec.json ]]; then
++    echo "This is free space inside the Omarchy VM disk, not on your Mac."
++    echo
++    df -h / 2>/dev/null || true
++    echo
++    echo "Free space with: sudo pacman -Scc, remove unused packages, or enlarge the VM disk."
++  fi
+   exit 1
+ else
+   exit 0

--- a/guest/patches/omarchy/update-free-space-message.patch
+++ b/guest/patches/omarchy/update-free-space-message.patch
@@ -1,5 +1,5 @@
 diff --git a/bin/omarchy-update-requires-free-space b/bin/omarchy-update-requires-free-space
-index 07523eb..0d47c5e 100755
+index 07523eb..1c31c1e 100755
 --- a/bin/omarchy-update-requires-free-space
 +++ b/bin/omarchy-update-requires-free-space
 @@ -11,6 +11,13 @@ elif read -r available_bytes < <(df --output=avail --block-size=1 / 2>/dev/null
@@ -11,7 +11,7 @@ index 07523eb..0d47c5e 100755
 +    echo
 +    df -h / 2>/dev/null || true
 +    echo
-+    echo "Free space with: sudo pacman -Scc, remove unused packages, or enlarge the VM disk."
++    echo "Free space with: sudo pacman -Scc or remove unused packages."
 +  fi
    exit 1
  else

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -193,12 +193,12 @@
         "description": "Clarify that Omarchy's 10 GiB update free-space check measures the guest VM disk, not the Mac host.",
         "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-update-requires-free-space",
         "patch": "patches/omarchy/update-free-space-message.patch",
-        "patchSha256": "fd561df117ea2e2aac073206bbec5c8a7ca0e01d8d988d61032482a397962fa7",
+        "patchSha256": "f5e24901e1b69b1ebb2ac1827654c293a72288ef91b8def6c47903714310078f",
         "targets": [
           {
             "path": "bin/omarchy-update-requires-free-space",
             "beforeSha256": "50a5ddef021dac5e79f789a53643fa91a6b8d7193b4d27786516d142525eca93",
-            "afterSha256": "0255ca210965a2f08cc5f937b0cb5d997a5a633fe27308a9af974cb3cfbc4ff0"
+            "afterSha256": "8e8102cb08ff4fde4f89c64a7febeca0ba142c309e20e581ae0cf295f6e7f093"
           }
         ]
       }

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -187,6 +187,20 @@
             "afterSha256": "43f7d1dbf07885316ea7cb58b4513ad4ff5287abe5da1b91b85daace6b940b46"
           }
         ]
+      },
+      {
+        "id": "update-free-space-message",
+        "description": "Clarify that Omarchy's 10 GiB update free-space check measures the guest VM disk, not the Mac host.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-update-requires-free-space",
+        "patch": "patches/omarchy/update-free-space-message.patch",
+        "patchSha256": "fd561df117ea2e2aac073206bbec5c8a7ca0e01d8d988d61032482a397962fa7",
+        "targets": [
+          {
+            "path": "bin/omarchy-update-requires-free-space",
+            "beforeSha256": "50a5ddef021dac5e79f789a53643fa91a6b8d7193b4d27786516d142525eca93",
+            "afterSha256": "0255ca210965a2f08cc5f937b0cb5d997a5a633fe27308a9af974cb3cfbc4ff0"
+          }
+        ]
       }
     ],
     "postBuildUserInstallers": [

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -167,6 +167,7 @@ def main() -> None:
             "1password-arm64-installer",
             "notification-hover-close",
             "notification-screen-privacy",
+            "update-free-space-message",
         ],
         "Omarchy backports are explicitly ordered and identified",
     )
@@ -187,6 +188,13 @@ def main() -> None:
                 and re.fullmatch(r"[0-9a-f]{64}", target.get("afterSha256", "")) is not None,
                 f"backport target digests are pinned: {backport['id']} {target['path']}",
             )
+    update_free_space_patch = read(GUEST / "patches/omarchy/update-free-space-message.patch")
+    check(
+        "Omarchy VM disk, not on your Mac" in update_free_space_patch
+        and "/usr/share/try-omarchy/build-spec.json" in update_free_space_patch
+        and "df -h /" in update_free_space_patch,
+        "update free-space backport clarifies the guest VM disk requirement",
+    )
 
     post_build_installers = authenticity["postBuildUserInstallers"]
     check(

--- a/macos/Tests/OmarchyVMHelperTests/FocusedCommandSuperBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/FocusedCommandSuperBridgeTests.swift
@@ -170,9 +170,16 @@ struct QMPMetaKeyClientTests {
     @Test("a closed QMP connection makes command writes throw")
     func closedSocketThrows() throws {
         var descriptors: [Int32] = [-1, -1]
-        #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
-        guard descriptors[0] >= 0, descriptors[1] >= 0 else { return }
-        defer { Darwin.close(descriptors[0]) }
+        let created = descriptors.withUnsafeMutableBufferPointer { buffer in
+            guard let base = buffer.baseAddress else { return Int32(-1) }
+            return socketpair(AF_UNIX, SOCK_STREAM, 0, base)
+        }
+        #expect(created == 0)
+        #expect(descriptors[0] >= 0 && descriptors[1] >= 0)
+        defer {
+            if descriptors[0] >= 0 { Darwin.close(descriptors[0]) }
+            if descriptors[1] >= 0 { Darwin.close(descriptors[1]) }
+        }
 
         var noSignal: Int32 = 1
         #expect(withUnsafePointer(to: &noSignal) {
@@ -184,13 +191,23 @@ struct QMPMetaKeyClientTests {
                 socklen_t(MemoryLayout<Int32>.size)
             )
         } == 0)
+
+        // Half-close the peer so the next write must observe EPIPE even if a
+        // tiny payload would otherwise sit in the local send buffer.
+        #expect(Darwin.shutdown(descriptors[1], SHUT_RDWR) == 0)
         Darwin.close(descriptors[1])
+        descriptors[1] = -1
 
         #expect(throws: HelperError.self) {
-            try QMPMetaKeyClient.writeJSON(
-                ["execute": "input-send-event"],
-                to: descriptors[0]
-            )
+            // Keep writing until the kernel reports the broken pipe. A single
+            // small write has been observed to succeed on CI before the peer
+            // close is visible to the writer.
+            for _ in 0..<4_096 {
+                try QMPMetaKeyClient.writeJSON(
+                    ["execute": "input-send-event"],
+                    to: descriptors[0]
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- backport `omarchy-update-requires-free-space` so low-disk update failures explain that the 10 GiB requirement is **inside the Omarchy VM disk**, not on the Mac
- print `df -h /` and a short cleanup hint when `/usr/share/try-omarchy/build-spec.json` is present
- leave the 10 GiB threshold and force-update escape hatch unchanged

Fixes https://github.com/omacom/try-omarchy/issues/93

## Problem

Reporters see `You need at least 10 GiB free to safely update Omarchy.` and assume it refers to Mac free space. Try Omarchy's working disk is 24 GiB; after normal use, guest `df` avail can fall under 10 GiB while the Mac still has plenty of free space.

## Approach

Reviewed authenticity backport of the pinned upstream helper. Behavior is identical outside Try Omarchy guests. Durable capacity relief remains https://github.com/omacom/try-omarchy/issues/104.

## Test plan

- [x] `python3 -m unittest discover -s guest/tests -p 'test_*.py'`
- [x] `python3 guest/tests/verify.py --source <pinned Omarchy 4.0.2 checkout>`
- [ ] In a guest with `< 10 GiB` free on `/`, run `omarchy update` and confirm the clarifying lines and `df -h /` appear
- [ ] Confirm `OMARCHY_UPDATE_FORCE=1` still skips the check