### PR TITLE
Give the start menu Omarchy styling

### DIFF
--- a/macos/Sources/OmarchyVMHelper/OmarchyLauncherControls.swift
+++ b/macos/Sources/OmarchyVMHelper/OmarchyLauncherControls.swift
@@ -1,0 +1,252 @@
+import AppKit
+
+enum OmarchyControlStyle {
+    case primary
+    case secondary
+    case danger
+}
+
+final class OmarchyActionButton: NSButton {
+    private let omarchyStyle: OmarchyControlStyle
+    private let displayTitle: String
+    private var hoverTrackingArea: NSTrackingArea?
+    private var isPointerInside = false
+    private var isPointerDown = false
+
+    init(
+        title: String,
+        style: OmarchyControlStyle,
+        target: AnyObject?,
+        action: Selector?
+    ) {
+        displayTitle = title.uppercased()
+        omarchyStyle = style
+        super.init(frame: .zero)
+        self.target = target
+        self.action = action
+        setAccessibilityLabel(title)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var isEnabled: Bool {
+        didSet { refreshAppearance() }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        hoverTrackingArea = trackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        refreshAppearance()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        refreshAppearance()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isEnabled else {
+            super.mouseDown(with: event)
+            return
+        }
+        isPointerDown = true
+        refreshAppearance()
+        super.mouseDown(with: event)
+        isPointerDown = false
+        refreshAppearance()
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(bounds, cursor: isEnabled ? .pointingHand : .arrow)
+    }
+
+    private func configure() {
+        setButtonType(.momentaryPushIn)
+        isBordered = false
+        focusRingType = .exterior
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+        translatesAutoresizingMaskIntoConstraints = false
+        refreshAppearance()
+    }
+
+    private func refreshAppearance() {
+        guard let layer else { return }
+
+        let background: NSColor
+        let foreground: NSColor
+        let border: NSColor
+
+        if !isEnabled {
+            background = OmarchyStartMenuTheme.lighterBackground.withAlphaComponent(0.45)
+            foreground = OmarchyStartMenuTheme.muted.withAlphaComponent(0.48)
+            border = OmarchyStartMenuTheme.lighterBackground.withAlphaComponent(0.7)
+        } else {
+            switch omarchyStyle {
+            case .primary:
+                background = isPointerDown
+                    ? OmarchyStartMenuTheme.cyan
+                    : (isPointerInside ? OmarchyStartMenuTheme.hover : OmarchyStartMenuTheme.accent)
+                foreground = OmarchyStartMenuTheme.background
+                border = background
+            case .secondary:
+                background = isPointerDown
+                    ? OmarchyStartMenuTheme.lighterBackground
+                    : OmarchyStartMenuTheme.darkBackground
+                foreground = isPointerInside
+                    ? OmarchyStartMenuTheme.hover
+                    : OmarchyStartMenuTheme.foreground
+                border = isPointerInside
+                    ? OmarchyStartMenuTheme.accent
+                    : OmarchyStartMenuTheme.lighterBackground
+            case .danger:
+                background = isPointerDown || isPointerInside
+                    ? OmarchyStartMenuTheme.danger
+                    : OmarchyStartMenuTheme.darkBackground
+                foreground = isPointerDown || isPointerInside
+                    ? OmarchyStartMenuTheme.background
+                    : OmarchyStartMenuTheme.danger
+                border = OmarchyStartMenuTheme.danger
+            }
+        }
+
+        layer.backgroundColor = background.cgColor
+        layer.borderColor = border.cgColor
+        layer.shadowOpacity = omarchyStyle == .primary && isEnabled ? 0.22 : 0
+        layer.shadowColor = NSColor.black.cgColor
+        layer.shadowOffset = NSSize(width: 0, height: -2)
+        layer.shadowRadius = 0
+        attributedTitle = NSAttributedString(
+            string: displayTitle,
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .bold),
+                .foregroundColor: foreground,
+                .kern: 0.35,
+            ]
+        )
+    }
+}
+
+final class OmarchyToggleButton: NSButton {
+    private var hoverTrackingArea: NSTrackingArea?
+    private var isPointerInside = false
+
+    init(isOn: Bool, target: AnyObject?, action: Selector?) {
+        super.init(frame: .zero)
+        self.target = target
+        self.action = action
+        setButtonType(.toggle)
+        state = isOn ? .on : .off
+        setAccessibilityLabel("Immersive mode")
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var state: NSControl.StateValue {
+        didSet { refreshAppearance() }
+    }
+
+    override var isEnabled: Bool {
+        didSet { refreshAppearance() }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let hoverTrackingArea {
+            removeTrackingArea(hoverTrackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        hoverTrackingArea = trackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        refreshAppearance()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        refreshAppearance()
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(bounds, cursor: isEnabled ? .pointingHand : .arrow)
+    }
+
+    func refreshAppearance() {
+        guard let layer else { return }
+        let isOn = state == .on
+        let background: NSColor
+        let foreground: NSColor
+        let border: NSColor
+
+        if !isEnabled {
+            background = OmarchyStartMenuTheme.lighterBackground.withAlphaComponent(0.4)
+            foreground = OmarchyStartMenuTheme.muted.withAlphaComponent(0.48)
+            border = OmarchyStartMenuTheme.lighterBackground
+        } else if isOn {
+            background = isPointerInside ? OmarchyStartMenuTheme.hover : OmarchyStartMenuTheme.accent
+            foreground = OmarchyStartMenuTheme.background
+            border = background
+        } else {
+            background = OmarchyStartMenuTheme.darkBackground
+            foreground = isPointerInside ? OmarchyStartMenuTheme.hover : OmarchyStartMenuTheme.foreground
+            border = isPointerInside ? OmarchyStartMenuTheme.accent : OmarchyStartMenuTheme.lighterBackground
+        }
+
+        layer.backgroundColor = background.cgColor
+        layer.borderColor = border.cgColor
+        attributedTitle = NSAttributedString(
+            string: isOn ? "[ ON ]" : "[ OFF ]",
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .bold),
+                .foregroundColor: foreground,
+                .kern: 0.25,
+            ]
+        )
+        setAccessibilityValue(isOn ? "On" : "Off")
+    }
+
+    private func configure() {
+        isBordered = false
+        focusRingType = .exterior
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: 66),
+            heightAnchor.constraint(equalToConstant: 30),
+        ])
+        refreshAppearance()
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -1,5 +1,30 @@
 import AppKit
 
+enum OmarchyStartMenuTheme {
+    // The launcher uses the same terminal-first palette as the Omarchy site.
+    static let background = color(0x1A1B26)
+    static let darkBackground = color(0x24283B)
+    static let lighterBackground = color(0x414868)
+    static let foreground = color(0xC0CAF5)
+    static let accent = color(0x7AA2F7)
+    static let muted = accent.withAlphaComponent(0.78)
+    static let cyan = color(0x7DCFFF)
+    static let hover = color(0xB4F9F8)
+    static let success = color(0x9ECE6A)
+    static let danger = color(0xF7768E)
+    static let border = lighterBackground.withAlphaComponent(0.88)
+    static let separator = lighterBackground.withAlphaComponent(0.7)
+
+    private static func color(_ value: UInt32) -> NSColor {
+        NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+}
+
 enum ResetConfirmationPolicy {
     static let requiredText = "Try Omarchy"
 
@@ -107,53 +132,16 @@ enum StartMenuWindowChrome {
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.backgroundColor = OmarchyStartMenuTheme.background
+        window.isOpaque = true
     }
-}
-
-private final class MouseIgnoringTextField: NSTextField {
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
 }
 
 private final class PointingHandButton: NSButton {
     override func resetCursorRects() {
         super.resetCursorRects()
         addCursorRect(bounds, cursor: .pointingHand)
-    }
-}
-
-private final class PermissionActionButton: NSButton {
-    override var alignmentRectInsets: NSEdgeInsets {
-        NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    }
-}
-
-final class PermissionCardView: NSView {
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        configureLayer()
-    }
-
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        configureLayer()
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        updateBorderColor()
-    }
-
-    private func configureLayer() {
-        wantsLayer = true
-        layer?.cornerRadius = 12
-        layer?.borderWidth = 1
-        updateBorderColor()
-    }
-
-    private func updateBorderColor() {
-        effectiveAppearance.performAsCurrentDrawingAppearance {
-            layer?.borderColor = NSColor.separatorColor.cgColor
-        }
     }
 }
 
@@ -319,6 +307,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
 
         StartMenuWindowChrome.apply(to: window)
         window.delegate = self
+        content.wantsLayer = true
+        content.layer?.backgroundColor = OmarchyStartMenuTheme.background.cgColor
         window.contentView = content
     }
 
@@ -472,9 +462,20 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         ])
 
         let title = NSTextField(labelWithString: "Try Omarchy")
-        title.font = .systemFont(ofSize: 27, weight: .bold)
+        title.font = .monospacedSystemFont(ofSize: 27, weight: .bold)
+        title.textColor = OmarchyStartMenuTheme.foreground
+        title.identifier = NSUserInterfaceItemIdentifier("app-title")
 
-        let headingStack = NSStackView(views: [icon, title])
+        let subtitle = NSTextField(labelWithString: "OMARCHY  ·  APPLE SILICON")
+        subtitle.font = .monospacedSystemFont(ofSize: 10, weight: .semibold)
+        subtitle.textColor = OmarchyStartMenuTheme.accent
+
+        let titleStack = NSStackView(views: [title, subtitle])
+        titleStack.orientation = .vertical
+        titleStack.alignment = .leading
+        titleStack.spacing = 3
+
+        let headingStack = NSStackView(views: [icon, titleStack])
         headingStack.orientation = .horizontal
         headingStack.alignment = .centerY
         headingStack.spacing = 14
@@ -610,11 +611,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             )
         }
 
-        var permissionRowViews = [accessibilityRow, microphoneRow, cameraRow, sharedFolderRow]
+        let permissionRowViews = [accessibilityRow, microphoneRow, cameraRow]
+        var integrationRowViews = [sharedFolderRow]
         if let storageRow {
-            permissionRowViews.append(storageRow)
+            integrationRowViews.append(storageRow)
         }
-        permissionRowViews.append(contentsOf: [portForwardingRow, immersiveRow])
+        integrationRowViews.append(contentsOf: [portForwardingRow, immersiveRow])
 
         var permissionRowsAndSeparators: [NSView] = []
         for (index, row) in permissionRowViews.enumerated() {
@@ -632,24 +634,48 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         for row in permissionRowViews {
             row.widthAnchor.constraint(equalTo: permissionRows.widthAnchor).isActive = true
         }
+        for divider in permissionRowsAndSeparators where divider.identifier?.rawValue == "themed-separator" {
+            divider.widthAnchor.constraint(equalTo: permissionRows.widthAnchor).isActive = true
+        }
 
-        let permissionCard = PermissionCardView(frame: .zero)
-        permissionCard.addSubview(permissionRows)
-        NSLayoutConstraint.activate([
-            permissionRows.leadingAnchor.constraint(equalTo: permissionCard.leadingAnchor, constant: 20),
-            permissionRows.trailingAnchor.constraint(equalTo: permissionCard.trailingAnchor, constant: -20),
-            permissionRows.topAnchor.constraint(equalTo: permissionCard.topAnchor, constant: 5),
-            permissionRows.bottomAnchor.constraint(equalTo: permissionCard.bottomAnchor, constant: -5),
-        ])
+        let permissionCard = themedCard(
+            containing: permissionRows,
+            identifier: "permission-card"
+        )
 
-        let reset = NSButton(
+        var integrationRowsAndSeparators: [NSView] = []
+        for (index, row) in integrationRowViews.enumerated() {
+            if index > 0 {
+                integrationRowsAndSeparators.append(separator())
+            }
+            integrationRowsAndSeparators.append(row)
+        }
+        let integrationRows = NSStackView(views: integrationRowsAndSeparators)
+        integrationRows.orientation = .vertical
+        integrationRows.alignment = .leading
+        integrationRows.spacing = 0
+        integrationRows.translatesAutoresizingMaskIntoConstraints = false
+        for row in integrationRowViews {
+            row.widthAnchor.constraint(equalTo: integrationRows.widthAnchor).isActive = true
+        }
+        for divider in integrationRowsAndSeparators where divider.identifier?.rawValue == "themed-separator" {
+            divider.widthAnchor.constraint(equalTo: integrationRows.widthAnchor).isActive = true
+        }
+        let integrationCard = themedCard(
+            containing: integrationRows,
+            identifier: "integration-card"
+        )
+
+        let permissionHeading = sectionHeading("PERMISSIONS")
+        let integrationHeading = sectionHeading("INTEGRATIONS")
+
+        let reset = OmarchyActionButton(
             title: resetInProgress ? "Resetting Omarchy…" : "Reset Omarchy",
+            style: .danger,
             target: self,
             action: #selector(resetOmarchy)
         )
-        reset.bezelStyle = .rounded
-        reset.controlSize = .small
-        reset.contentTintColor = .systemRed
+        reset.identifier = NSUserInterfaceItemIdentifier("reset-button")
         reset.isEnabled = canResetStorage
             && !launchInProgress
             && !resetInProgress
@@ -658,45 +684,28 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         reset.toolTip = canResetStorage
             ? "Erase this VM and return it to factory settings"
             : "Reset is unavailable for a disposable VM"
+        reset.heightAnchor.constraint(equalToConstant: 30).isActive = true
+        reset.widthAnchor.constraint(greaterThanOrEqualToConstant: 154).isActive = true
 
         let resetViews: [NSView] = [reset]
         let resetSection = NSStackView(views: resetViews)
         resetSection.orientation = .vertical
-        resetSection.alignment = .leading
+        resetSection.alignment = .centerX
         resetSection.spacing = 4
 
         let launchButtonTitle = launchInProgress ? "Launching Omarchy…" : "Launch Omarchy"
-        let launchButtonFont = NSFont.systemFont(ofSize: 16, weight: .semibold)
-        let launchButton = NSButton(
+        let launchButton = OmarchyActionButton(
             title: launchButtonTitle,
+            style: .primary,
             target: self,
             action: #selector(launchOmarchy)
         )
         launchButton.keyEquivalent = launchInProgress ? "" : "\r"
-        launchButton.bezelStyle = .rounded
-        launchButton.controlSize = .large
-        launchButton.font = launchButtonFont
         launchButton.isEnabled = !launchInProgress
             && !resetInProgress
             && !microphoneRequestInFlight
             && !cameraRequestInFlight
-        launchButton.title = ""
         launchButton.identifier = NSUserInterfaceItemIdentifier("launch-button")
-        let launchButtonLabel = MouseIgnoringTextField(labelWithString: launchButtonTitle)
-        launchButtonLabel.font = launchButtonFont
-        launchButtonLabel.textColor = launchButton.isEnabled
-            ? .alternateSelectedControlTextColor
-            : .controlTextColor
-        launchButtonLabel.alignment = .center
-        launchButtonLabel.setAccessibilityElement(false)
-        launchButtonLabel.identifier = NSUserInterfaceItemIdentifier("launch-button-label")
-        launchButtonLabel.translatesAutoresizingMaskIntoConstraints = false
-        launchButton.addSubview(launchButtonLabel)
-        NSLayoutConstraint.activate([
-            launchButtonLabel.centerXAnchor.constraint(equalTo: launchButton.centerXAnchor),
-            launchButtonLabel.centerYAnchor.constraint(equalTo: launchButton.centerYAnchor),
-        ])
-        launchButton.translatesAutoresizingMaskIntoConstraints = false
         launchButton.setAccessibilityLabel(launchInProgress ? "Launching Omarchy" : "Launch Omarchy")
         if launchInProgress {
             let spinner = NSProgressIndicator()
@@ -719,15 +728,15 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         let footerTitle = NSMutableAttributedString(
             string: footerText,
             attributes: [
-                .font: NSFont.systemFont(ofSize: 11),
-                .foregroundColor: NSColor.secondaryLabelColor,
+                .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+                .foregroundColor: OmarchyStartMenuTheme.muted,
             ]
         )
         let footerNSString = footerText as NSString
         footerTitle.addAttributes(
             [
                 .link: URL(string: "https://x.com/martiano")!,
-                .foregroundColor: NSColor.linkColor,
+                .foregroundColor: OmarchyStartMenuTheme.accent,
             ],
             range: footerNSString.range(of: "@martiano")
         )
@@ -744,14 +753,24 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             footer.bottomAnchor.constraint(equalTo: footerContainer.bottomAnchor),
         ])
 
-        let stack = NSStackView(
-            views: [headingStack, permissionCard, resetSection, launchButton, footerContainer]
-        )
+        let stack = NSStackView(views: [
+            headingStack,
+            permissionHeading,
+            permissionCard,
+            integrationHeading,
+            integrationCard,
+            resetSection,
+            launchButton,
+            footerContainer,
+        ])
         stack.orientation = .vertical
         stack.alignment = .leading
         stack.spacing = 18
-        stack.setCustomSpacing(14, after: headingStack)
-        stack.setCustomSpacing(12, after: permissionCard)
+        stack.setCustomSpacing(20, after: headingStack)
+        stack.setCustomSpacing(6, after: permissionHeading)
+        stack.setCustomSpacing(16, after: permissionCard)
+        stack.setCustomSpacing(6, after: integrationHeading)
+        stack.setCustomSpacing(12, after: integrationCard)
         stack.setCustomSpacing(12, after: resetSection)
         stack.setCustomSpacing(8, after: launchButton)
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -784,7 +803,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             stack.topAnchor.constraint(equalTo: document.topAnchor, constant: 26),
             stack.bottomAnchor.constraint(equalTo: document.bottomAnchor, constant: -20),
             permissionCard.widthAnchor.constraint(equalTo: stack.widthAnchor),
-            resetSection.widthAnchor.constraint(lessThanOrEqualTo: stack.widthAnchor),
+            integrationCard.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            resetSection.widthAnchor.constraint(equalTo: stack.widthAnchor),
             launchButton.widthAnchor.constraint(equalTo: stack.widthAnchor),
             footerContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
         ])
@@ -802,6 +822,34 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             )
         )
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    private func sectionHeading(_ text: String) -> NSTextField {
+        let heading = NSTextField(labelWithString: text)
+        heading.font = .monospacedSystemFont(ofSize: 10, weight: .semibold)
+        heading.textColor = OmarchyStartMenuTheme.muted
+        heading.identifier = NSUserInterfaceItemIdentifier(
+            "section-heading-\(text.lowercased())"
+        )
+        return heading
+    }
+
+    private func themedCard(containing body: NSView, identifier: String) -> NSView {
+        let card = NSView()
+        card.identifier = NSUserInterfaceItemIdentifier(identifier)
+        card.wantsLayer = true
+        card.layer?.backgroundColor = OmarchyStartMenuTheme.darkBackground.cgColor
+        card.layer?.cornerRadius = 6
+        card.layer?.borderWidth = 1
+        card.layer?.borderColor = OmarchyStartMenuTheme.border.cgColor
+        card.addSubview(body)
+        NSLayoutConstraint.activate([
+            body.leadingAnchor.constraint(equalTo: card.leadingAnchor, constant: 20),
+            body.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -20),
+            body.topAnchor.constraint(equalTo: card.topAnchor, constant: 5),
+            body.bottomAnchor.constraint(equalTo: card.bottomAnchor, constant: -5),
+        ])
+        return card
     }
 
     private func permissionRow(
@@ -837,7 +885,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         let symbol = NSImageView()
         symbol.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
         symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
-        symbol.contentTintColor = .controlAccentColor
+        symbol.contentTintColor = OmarchyStartMenuTheme.accent
         symbol.identifier = NSUserInterfaceItemIdentifier("permission-symbol-\(symbolName)")
         symbol.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -846,7 +894,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         ])
 
         let name = NSTextField(labelWithString: title)
-        name.font = .systemFont(ofSize: 14, weight: .semibold)
+        name.font = .monospacedSystemFont(ofSize: 13, weight: .bold)
+        name.textColor = OmarchyStartMenuTheme.foreground
         name.identifier = NSUserInterfaceItemIdentifier("permission-title-\(symbolName)")
 
         var explanations: [NSView] = []
@@ -859,8 +908,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
                     )
                 } else {
                     let explanation = NSTextField(labelWithString: line)
-                    explanation.font = .systemFont(ofSize: 12)
-                    explanation.textColor = .secondaryLabelColor
+                    explanation.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+                    explanation.textColor = OmarchyStartMenuTheme.muted
                     explanation.maximumNumberOfLines = 1
                     explanation.lineBreakMode = .byTruncatingMiddle
                     explanation.toolTip = line
@@ -878,8 +927,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             ]
         } else {
             let explanation = NSTextField(wrappingLabelWithString: detail)
-            explanation.font = .systemFont(ofSize: 12)
-            explanation.textColor = .secondaryLabelColor
+            explanation.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+            explanation.textColor = OmarchyStartMenuTheme.muted
             explanation.maximumNumberOfLines = 2
             explanation.identifier = NSUserInterfaceItemIdentifier(
                 "permission-detail-\(symbolName)"
@@ -899,7 +948,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         }
 
         let statusText = granted ? statusLabels.granted : statusLabels.denied
-        let statusFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        let statusFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .bold)
         let status = NSTextField(labelWithString: statusText)
         status.font = statusFont
         if granted {
@@ -907,17 +956,17 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
                 string: statusText,
                 attributes: [
                     .font: statusFont,
-                    .foregroundColor: NSColor.labelColor,
+                    .foregroundColor: OmarchyStartMenuTheme.foreground,
                 ]
             )
             attributedStatus.addAttribute(
                 .foregroundColor,
-                value: NSColor.systemGreen,
+                value: OmarchyStartMenuTheme.success,
                 range: NSRange(location: 0, length: 1)
             )
             status.attributedStringValue = attributedStatus
         } else {
-            status.textColor = .secondaryLabelColor
+            status.textColor = OmarchyStartMenuTheme.muted
         }
         status.alignment = .right
         status.identifier = NSUserInterfaceItemIdentifier("permission-status-\(symbolName)")
@@ -927,8 +976,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         var trailingViews: [NSView] = [status]
         for (index, actionDescription) in actions.enumerated() {
             let (actionTitle, action) = actionDescription
-            let button = PermissionActionButton(title: actionTitle, target: self, action: action)
-            button.controlSize = .regular
+            let button = OmarchyActionButton(
+                title: actionTitle,
+                style: .secondary,
+                target: self,
+                action: action
+            )
             button.isEnabled = actionsEnabled
                 && !microphoneRequestInFlight
                 && !cameraRequestInFlight
@@ -938,8 +991,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
                 ? "permission-action-\(symbolName)"
                 : "permission-action-\(symbolName)-\(index)"
             button.identifier = NSUserInterfaceItemIdentifier(identifier)
-            button.translatesAutoresizingMaskIntoConstraints = false
-            button.heightAnchor.constraint(greaterThanOrEqualToConstant: 28).isActive = true
+            button.heightAnchor.constraint(equalToConstant: 30).isActive = true
             trailingViews.append(button)
         }
 
@@ -1007,8 +1059,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         button.attributedTitle = NSAttributedString(
             string: text,
             attributes: [
-                .font: NSFont.systemFont(ofSize: 12),
-                .foregroundColor: NSColor.secondaryLabelColor,
+                .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+                .foregroundColor: OmarchyStartMenuTheme.muted,
             ]
         )
         button.toolTip = text
@@ -1020,8 +1072,12 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
     }
 
     private func separator() -> NSView {
-        let view = NSBox()
-        view.boxType = .separator
+        let view = NSView()
+        view.identifier = NSUserInterfaceItemIdentifier("themed-separator")
+        view.wantsLayer = true
+        view.layer?.backgroundColor = OmarchyStartMenuTheme.separator.cgColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: 1).isActive = true
         return view
     }
 
@@ -1032,7 +1088,7 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             accessibilityDescription: nil
         )
         symbol.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 19, weight: .medium)
-        symbol.contentTintColor = .controlAccentColor
+        symbol.contentTintColor = OmarchyStartMenuTheme.accent
         symbol.identifier = NSUserInterfaceItemIdentifier("immersive-symbol")
         symbol.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -1041,13 +1097,14 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         ])
 
         let title = NSTextField(labelWithString: "Immersive")
-        title.font = .systemFont(ofSize: 14, weight: .semibold)
+        title.font = .monospacedSystemFont(ofSize: 13, weight: .bold)
+        title.textColor = OmarchyStartMenuTheme.foreground
         title.identifier = NSUserInterfaceItemIdentifier("immersive-title")
 
         let detailText = StartMenuPresentation.immersiveDetail(isEnabled: isEnabled)
         let detail = NSTextField(wrappingLabelWithString: detailText)
-        detail.font = .systemFont(ofSize: 12)
-        detail.textColor = .secondaryLabelColor
+        detail.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+        detail.textColor = OmarchyStartMenuTheme.muted
         detail.maximumNumberOfLines = 2
         detail.identifier = NSUserInterfaceItemIdentifier("immersive-caption")
         immersiveCaption = detail
@@ -1058,10 +1115,11 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         labels.spacing = 3
         labels.translatesAutoresizingMaskIntoConstraints = false
 
-        let toggle = NSSwitch()
-        toggle.state = isEnabled ? .on : .off
-        toggle.target = self
-        toggle.action = #selector(changeImmersiveMode(_:))
+        let toggle = OmarchyToggleButton(
+            isOn: isEnabled,
+            target: self,
+            action: #selector(changeImmersiveMode(_:))
+        )
         toggle.isEnabled = !microphoneRequestInFlight && !launchInProgress && !resetInProgress
         toggle.identifier = NSUserInterfaceItemIdentifier("immersive-toggle")
         toggle.setAccessibilityLabel("Immersive mode")
@@ -1318,12 +1376,13 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         editor.beginSheet(for: window)
     }
 
-    @objc private func changeImmersiveMode(_ sender: NSSwitch) {
+    @objc private func changeImmersiveMode(_ sender: NSButton) {
         guard !launchInProgress, !resetInProgress else { return }
         let isEnabled = sender.state == .on
         setImmersiveMode(isEnabled)
         let detailText = StartMenuPresentation.immersiveDetail(isEnabled: isEnabled)
         immersiveCaption?.stringValue = detailText
+        (sender as? OmarchyToggleButton)?.refreshAppearance()
         sender.setAccessibilityHelp(detailText)
         NSAccessibility.post(
             element: NSApplication.shared,

--- a/macos/Tests/OmarchyVMHelperTests/StartMenuAppearanceTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/StartMenuAppearanceTests.swift
@@ -5,28 +5,50 @@ import Testing
 @Suite("Start menu appearance", .serialized)
 @MainActor
 struct StartMenuAppearanceTests {
-    @Test("permission card border follows the effective appearance")
-    func permissionCardBorder() throws {
+    @Test("start menu keeps the Omarchy appearance across system themes")
+    func brandedWindowAppearance() throws {
         _ = NSApplication.shared
-        let lightAppearance = try #require(NSAppearance(named: .aqua))
-        let darkAppearance = try #require(NSAppearance(named: .darkAqua))
-        let card = PermissionCardView(frame: .zero)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 760),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
 
-        card.appearance = lightAppearance
-        let lightBorder = try #require(card.layer?.borderColor)
-        #expect(lightBorder == separatorColor(for: lightAppearance))
+        window.appearance = NSAppearance(named: .aqua)
+        StartMenuWindowChrome.apply(to: window)
 
-        card.appearance = darkAppearance
-        let darkBorder = try #require(card.layer?.borderColor)
-        #expect(darkBorder == separatorColor(for: darkAppearance))
-        #expect(darkBorder != lightBorder)
+        #expect(window.appearance?.name == .darkAqua)
+        #expect(window.backgroundColor == OmarchyStartMenuTheme.background)
+        #expect(window.isOpaque)
     }
 
-    private func separatorColor(for appearance: NSAppearance) -> CGColor {
-        var color = NSColor.clear.cgColor
-        appearance.performAsCurrentDrawingAppearance {
-            color = NSColor.separatorColor.cgColor
-        }
-        return color
+    @Test("Omarchy controls retain native keyboard and accessibility behavior")
+    func brandedControlBehavior() {
+        _ = NSApplication.shared
+        let action = OmarchyActionButton(
+            title: "Launch Omarchy",
+            style: .primary,
+            target: nil,
+            action: nil
+        )
+        action.keyEquivalent = "\r"
+
+        #expect(action.keyEquivalent == "\r")
+        #expect(action.accessibilityLabel() == "Launch Omarchy")
+        #expect(action.attributedTitle.string == "LAUNCH OMARCHY")
+        #expect(action.focusRingType == .exterior)
+        #expect(!action.isBordered)
+
+        let toggle = OmarchyToggleButton(isOn: true, target: nil, action: nil)
+        #expect(toggle.state == .on)
+        #expect(toggle.accessibilityLabel() == "Immersive mode")
+        #expect(toggle.accessibilityValue() as? String == "On")
+        #expect(toggle.attributedTitle.string == "[ ON ]")
+
+        toggle.state = .off
+        #expect(toggle.accessibilityValue() as? String == "Off")
+        #expect(toggle.attributedTitle.string == "[ OFF ]")
     }
 }


### PR DESCRIPTION
## Summary

- apply the official Omarchy dark palette and terminal typography to the start menu
- organize permissions and integrations into themed cards
- replace Apple-styled launcher actions with keyboard-accessible Omarchy buttons
- present immersive mode as an accessible `[ ON ]` or `[ OFF ]` control
- keep Try Omarchy branding, existing behavior, and upstream attribution unchanged

## Verification

- `make test`
- rendered the complete launcher document in a real AppKit window and checked the themed cards, statuses, reset action, launch action, and immersive toggle

Addresses #97.
