### PR TITLE
[fix] Hold aquamarine with the pinned Hyprland ABI

### DIFF
--- a/guest/pacman.aarch64.conf
+++ b/guest/pacman.aarch64.conf
@@ -10,8 +10,10 @@ HoldPkg = pacman glibc
 # QEMU direct-boots the kernel and initramfs paired with this VM disk. Keep its
 # installed modules and DKMS headers on that exact ABI. Hyprland is likewise
 # held until upstream includes our rounded-border coverage backport; otherwise
-# a routine full-system update can silently restore the defect.
-IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland
+# a routine full-system update can silently restore the defect. Keep aquamarine
+# on the same hold: newer ALARM aquamarine bumps libaquamarine.so past what the
+# pinned Hyprland was built against and aborts Omarchy's updater mid-transaction.
+IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland aquamarine
 Architecture = auto
 CheckSpace
 ParallelDownloads = 5

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -247,8 +247,9 @@ def main() -> None:
         "factory pacman retains the ARM Omarchy keyring repository",
     )
     check(
-        "IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland" in pacman_conf,
-        "factory pacman holds the QEMU-booted kernel, matching headers, and patched compositor",
+        "IgnorePkg = linux-aarch64 linux-aarch64-headers hyprland aquamarine"
+        in pacman_conf,
+        "factory pacman holds the QEMU-booted kernel, matching headers, patched compositor, and its aquamarine ABI",
     )
     arm_mirrorlist = read(GUEST / "mirrorlist.aarch64")
     check(


### PR DESCRIPTION
## Summary
- Fixes https://github.com/omacom/try-omarchy/issues/134: Omarchy updates fail when pacman tries to install `aquamarine 0.15.0-2` (`libaquamarine.so=14`) while `IgnorePkg` keeps the patched Hyprland that still requires `libaquamarine.so=13`.
- Add `aquamarine` to the existing kernel/Hyprland `IgnorePkg` hold and document the ABI coupling.
- Extend the guest contract test to require the new hold.

## Test plan
- [x] `python3 guest/tests/verify.py`
- [ ] Fresh or reset guest: confirm `/etc/pacman.conf` (via restored `/usr/share/try-omarchy/pacman.conf`) lists `aquamarine` on `IgnorePkg`
- [ ] Run Omarchy update and confirm it no longer fails on the aquamarine / hyprland SONAME conflict

**Note for existing VMs:** this lands in new/reset guest images. Already-provisioned disks still have the old baked `pacman.conf`; they can add `aquamarine` to `IgnorePkg` in both `/usr/share/try-omarchy/pacman.conf` and `/etc/pacman.conf` (or reset) until they pick up a new image.