### PR TITLE
[feat] Expose Vivaldi in Install/Remove/Default Browser menus

### DIFF
--- a/guest/patches/omarchy/vivaldi-menu-entries.patch
+++ b/guest/patches/omarchy/vivaldi-menu-entries.patch
@@ -1,0 +1,26 @@
+--- a/default/omarchy/omarchy-menu.jsonc
++++ b/default/omarchy/omarchy-menu.jsonc
+@@ -147,6 +147,7 @@
+   "setup.default.browser.edge": {"icon":"󰇩","label":"Edge","when":"omarchy-cmd-present microsoft-edge-stable","checked":"[[ \"$(omarchy-default-browser)\" == \"edge\" ]]","action":"omarchy-default-browser edge"},
+   "setup.default.browser.firefox": {"icon":"","label":"Firefox","when":"omarchy-cmd-present firefox","checked":"[[ \"$(omarchy-default-browser)\" == \"firefox\" ]]","action":"omarchy-default-browser firefox"},
+   "setup.default.browser.zen": {"icon":"󰖟","label":"Zen","when":"omarchy-cmd-present zen-browser","checked":"[[ \"$(omarchy-default-browser)\" == \"zen\" ]]","action":"omarchy-default-browser zen"},
++  "setup.default.browser.vivaldi": {"icon":"󰆟","label":"Vivaldi","when":"omarchy-cmd-present vivaldi-stable","checked":"[[ \"$(omarchy-default-browser)\" == \"vivaldi\" ]]","action":"omarchy-default-browser vivaldi"},
+   "setup.default.terminal": {"icon":"","label":"Terminal","title":"Default Terminal"},
+   "setup.default.terminal.alacritty": {"icon":"","label":"Alacritty","when":"omarchy-cmd-present alacritty","checked":"[[ \"$(omarchy-default-terminal)\" == \"alacritty\" ]]","action":"omarchy-default-terminal alacritty"},
+   "setup.default.terminal.foot": {"icon":"","label":"Foot","when":"omarchy-cmd-present foot","checked":"[[ \"$(omarchy-default-terminal)\" == \"foot\" ]]","action":"omarchy-default-terminal foot"},
+@@ -210,6 +211,7 @@
+   "install.browser.brave-origin": {"icon":"","label":"Brave Origin","when":"! omarchy-pkg-present brave-origin-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser brave-origin'"},
+   "install.browser.firefox": {"icon":"","label":"Firefox","when":"! omarchy-pkg-present firefox","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser firefox'"},
+   "install.browser.zen": {"icon":"󰖟","label":"Zen","when":"! omarchy-pkg-present zen-browser-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser zen'"},
++  "install.browser.vivaldi": {"icon":"󰆟","label":"Vivaldi","when":"! omarchy-pkg-present vivaldi","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser vivaldi'"},
+   "install.service.1password": {"icon":"󰢁","label":"1Password","when":"! omarchy-pkg-present 1password","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-1password"},
+   "install.service.dropbox": {"icon":"","label":"Dropbox","when":"! omarchy-pkg-present dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-dropbox"},
+   "install.service.spotify": {"icon":"󰓇","label":"Spotify","when":"! omarchy-pkg-present spotify","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify"},
+@@ -291,6 +293,7 @@
+   "remove.browser.brave-origin": {"icon":"","label":"Brave Origin","when":"omarchy-pkg-present brave-origin-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser brave-origin'"},
+   "remove.browser.firefox": {"icon":"","label":"Firefox","when":"omarchy-pkg-present firefox","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser firefox'"},
+   "remove.browser.zen": {"icon":"","label":"Zen","when":"omarchy-pkg-present zen-browser-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser zen'"},
++  "remove.browser.vivaldi": {"icon":"󰆟","label":"Vivaldi","when":"omarchy-pkg-present vivaldi","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-remove-browser vivaldi'"},
+   "remove.service.dropbox": {"icon":"","label":"Dropbox","when":"omarchy-pkg-present dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-service-dropbox"},
+   "remove.service.tailscale": {"icon":"","label":"Tailscale","when":"omarchy-pkg-present tailscale","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-service-tailscale"},
+   "remove.gaming.steam": {"icon":"","label":"Steam","when":"omarchy-pkg-present steam","action":"omarchy-launch-floating-terminal-with-presentation omarchy-remove-gaming-steam"},

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -208,6 +208,20 @@
         ]
       },
       {
+        "id": "vivaldi-menu-entries",
+        "description": "Expose Vivaldi in Install/Remove/Default Browser menus for the Try Omarchy ARM64 installer.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/default/omarchy/omarchy-menu.jsonc",
+        "patch": "patches/omarchy/vivaldi-menu-entries.patch",
+        "patchSha256": "29fe08729d6285b07682fadd8cecc4687ba2f93aa8bda4d8eb13ff75001d5852",
+        "targets": [
+          {
+            "path": "default/omarchy/omarchy-menu.jsonc",
+            "beforeSha256": "027096cc20b52f3073c7d61ad43ff1fc8fddeb127b05b41c129b0a97826cecb2",
+            "afterSha256": "ec8a95d63b83a5c47dd0c1e3aceadb949b1f16895f8be855e756912731964ee8"
+          }
+        ]
+      },
+      {
         "id": "notification-hover-close",
         "description": "Restore the upstream hover-revealed notification dismiss control omitted from v4.0.2.",
         "reference": "https://github.com/basecamp/omarchy/commit/9b72edcc94513cba016f145b1ac4ffdaea54b577",

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -166,6 +166,7 @@ def main() -> None:
         == [
             "1password-arm64-installer",
             "vivaldi-arm64-browser",
+            "vivaldi-menu-entries",
             "notification-hover-close",
             "notification-screen-privacy",
             "update-free-space-message",
@@ -1444,6 +1445,18 @@ HOTPLUG=1
                 and "set_fallback_default_browser vivaldi-stable.desktop" in remove_browser
                 and "omarchy-pkg-drop vivaldi" in remove_browser,
                 "Vivaldi participates in Omarchy install, default, and removal workflows",
+            )
+            menu = read(staged_omarchy / "default/omarchy/omarchy-menu.jsonc")
+            check(
+                '"install.browser.vivaldi"' in menu
+                and '"remove.browser.vivaldi"' in menu
+                and '"setup.default.browser.vivaldi"' in menu
+                and 'omarchy-install-browser vivaldi' in menu
+                and 'omarchy-remove-browser vivaldi' in menu
+                and 'omarchy-default-browser vivaldi' in menu
+                and 'omarchy-pkg-present vivaldi' in menu
+                and 'omarchy-cmd-present vivaldi-stable' in menu,
+                "Vivaldi appears in Install, Remove, and Default Browser menus",
             )
             check(
                 "/opt/vivaldi/" in theme_browser


### PR DESCRIPTION
## Summary
- Adds a small Omarchy menu backport so Vivaldi appears under Install → Browser, Remove → Browser, and Setup → Default Browser.
- Completes the UX gap left by #80: the signed ARM64 installer existed, but there was no menu entry to launch it.
- Pins patch digests and extends `verify.py` contract coverage for the three menu IDs.

## Test plan
- [ ] `python3 guest/tests/verify.py` (backport metadata / digests)
- [ ] Optional: `python3 guest/tests/verify.py --source <pinned-omarchy-checkout>` to exercise staged menu postimage checks
- [ ] In an aarch64 guest: Omarchy menu → Install → Browser → Vivaldi launches the existing ARM64 installer path
- [ ] After install: Default Browser → Vivaldi and Remove → Browser → Vivaldi appear as expected
- [ ] Confirm Chromium/Firefox/Zen menu rows are unchanged
