### PR TITLE
[feat] Proposal: opt-in hide for aarch64-unavailable Install apps

### DIFF
--- a/guest/native-overlay/usr/local/bin/omarchy-arch-aarch64
+++ b/guest/native-overlay/usr/local/bin/omarchy-arch-aarch64
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# omarchy:summary=Returns true when the guest architecture is aarch64
+# omarchy:hidden=true
+
+[[ $(uname -m) == aarch64 ]]

--- a/guest/native-overlay/usr/local/bin/omarchy-install-has-hidden
+++ b/guest/native-overlay/usr/local/bin/omarchy-install-has-hidden
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# omarchy:summary=True when the user has hidden any aarch64-unavailable Install items
+# omarchy:hidden=true
+
+/usr/local/bin/omarchy-arch-aarch64 || exit 1
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+[[ -f $state_dir/hide-all-aarch64-unavailable && ! -L $state_dir/hide-all-aarch64-unavailable ]] && exit 0
+[[ -f $state_dir/hidden-install-packages && ! -L $state_dir/hidden-install-packages ]] || exit 1
+grep -q '[^[:space:]]' "$state_dir/hidden-install-packages"

--- a/guest/native-overlay/usr/local/bin/omarchy-install-hide
+++ b/guest/native-overlay/usr/local/bin/omarchy-install-hide
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# omarchy:summary=Hide one Install-menu id from future aarch64 Install menus
+# omarchy:args=<install-id>
+# omarchy:hidden=true
+
+id=${1-}
+if [[ -z $id ]]; then
+  echo "Usage: omarchy-install-hide <install-id>" >&2
+  exit 2
+fi
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+mkdir -p "$state_dir"
+hidden_list="$state_dir/hidden-install-packages"
+touch "$hidden_list"
+if ! grep -qxF -- "$id" "$hidden_list"; then
+  printf '%s\n' "$id" >>"$hidden_list"
+fi

--- a/guest/native-overlay/usr/local/bin/omarchy-install-hide-all-unavailable
+++ b/guest/native-overlay/usr/local/bin/omarchy-install-hide-all-unavailable
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Hide all known aarch64-unavailable Install-menu apps
+# omarchy:hidden=true
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+mkdir -p "$state_dir"
+: >"$state_dir/hide-all-aarch64-unavailable"

--- a/guest/native-overlay/usr/local/bin/omarchy-install-menu-visible
+++ b/guest/native-overlay/usr/local/bin/omarchy-install-menu-visible
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# omarchy:summary=True when an Install-menu id should stay visible on this guest
+# omarchy:args=<install-id>
+# omarchy:hidden=true
+
+id=${1-}
+[[ -n $id ]] || exit 0
+
+# Non-aarch64 guests never hide via this helper.
+/usr/local/bin/omarchy-arch-aarch64 || exit 0
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+hidden_list="$state_dir/hidden-install-packages"
+hide_all="$state_dir/hide-all-aarch64-unavailable"
+known=/usr/local/share/try-omarchy/aarch64-unavailable-install-ids
+
+if [[ -f $hide_all && ! -L $hide_all ]]; then
+  if [[ -f $known && ! -L $known ]] && grep -qxF -- "$id" "$known"; then
+    exit 1
+  fi
+fi
+
+if [[ -f $hidden_list && ! -L $hidden_list ]] && grep -qxF -- "$id" "$hidden_list"; then
+  exit 1
+fi
+
+exit 0

--- a/guest/native-overlay/usr/local/bin/omarchy-install-restore-hidden
+++ b/guest/native-overlay/usr/local/bin/omarchy-install-restore-hidden
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# omarchy:summary=Restore Install-menu apps previously hidden on aarch64
+# omarchy:examples=omarchy-install-restore-hidden
+
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+rm -f "$state_dir/hide-all-aarch64-unavailable" "$state_dir/hidden-install-packages"
+echo "Restored previously hidden Install menu apps."

--- a/guest/native-overlay/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable
+++ b/guest/native-overlay/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Refuse known aarch64-unavailable packages with the shared message
+# omarchy:args=<packages...>
+# omarchy:hidden=true
+
+[[ $(uname -m) == aarch64 ]] || exit 0
+
+map=/usr/local/share/try-omarchy/aarch64-unavailable-packages
+[[ -f $map && ! -L $map ]] || exit 0
+
+for package in "$@"; do
+  [[ -n $package ]] || continue
+  name=$(awk -F '\t' -v package="$package" '$1 == package { print $2; exit }' "$map")
+  if [[ -n $name ]]; then
+    exec /usr/local/bin/omarchy-pkg-unavailable-arm "$name"
+  fi
+done
+
+exit 0

--- a/guest/native-overlay/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable
+++ b/guest/native-overlay/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable
@@ -13,7 +13,7 @@ for package in "$@"; do
   [[ -n $package ]] || continue
   name=$(awk -F '\t' -v package="$package" '$1 == package { print $2; exit }' "$map")
   if [[ -n $name ]]; then
-    exec /usr/local/bin/omarchy-pkg-unavailable-arm "$name"
+    exec /usr/local/bin/omarchy-pkg-unavailable-arm "$name" "$package"
   fi
 done
 

--- a/guest/native-overlay/usr/local/bin/omarchy-pkg-unavailable-arm
+++ b/guest/native-overlay/usr/local/bin/omarchy-pkg-unavailable-arm
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# omarchy:summary=Report that a named app is unavailable on aarch64 and exit unsuccessfully
+# omarchy:args=<display-name>
+# omarchy:examples=omarchy-pkg-unavailable-arm Ghostty
+# omarchy:hidden=true
+
+name=${1-}
+if [[ -z $name ]]; then
+  echo "Usage: omarchy-pkg-unavailable-arm <display-name>" >&2
+  exit 2
+fi
+
+echo "The ${name} app is not available via pacman/AUR for aarch64 at this time." >&2
+exit 1

--- a/guest/native-overlay/usr/local/bin/omarchy-pkg-unavailable-arm
+++ b/guest/native-overlay/usr/local/bin/omarchy-pkg-unavailable-arm
@@ -1,15 +1,51 @@
 #!/bin/bash
 
-# omarchy:summary=Report that a named app is unavailable on aarch64 and exit unsuccessfully
-# omarchy:args=<display-name>
-# omarchy:examples=omarchy-pkg-unavailable-arm Ghostty
+# omarchy:summary=Report that a named app is unavailable on aarch64 and optionally hide it
+# omarchy:args=<display-name> [install-id]
+# omarchy:examples=omarchy-pkg-unavailable-arm Ghostty ghostty
 # omarchy:hidden=true
 
 name=${1-}
+install_id=${2-}
 if [[ -z $name ]]; then
-  echo "Usage: omarchy-pkg-unavailable-arm <display-name>" >&2
+  echo "Usage: omarchy-pkg-unavailable-arm <display-name> [install-id]" >&2
   exit 2
 fi
 
-echo "The ${name} app is not available via pacman/AUR for aarch64 at this time." >&2
-exit 1
+echo "The ${name} app is not available via pacman/AUR for aarch64 at this time."
+
+# Offer hide prompts only in an interactive Install terminal on aarch64.
+if [[ -t 0 && -t 1 ]] && /usr/local/bin/omarchy-arch-aarch64; then
+  if [[ -z $install_id ]]; then
+    map=/usr/local/share/try-omarchy/aarch64-unavailable-packages
+    if [[ -f $map && ! -L $map ]]; then
+      install_id=$(awk -F '\t' -v name="$name" '$2 == name { print $1; exit }' "$map")
+    fi
+  fi
+
+  if [[ -n $install_id ]]; then
+    state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/try-omarchy"
+    hide_all="$state_dir/hide-all-aarch64-unavailable"
+
+    if [[ ! -f $hide_all ]]; then
+      read -r -p "Hide ${name} from the Install menu? [y/N] " reply || reply=
+      case ${reply,,} in
+        y|yes)
+          /usr/local/bin/omarchy-install-hide "$install_id"
+          echo "Hid ${name} from the Install menu."
+
+          read -r -p "Hide all known unavailable Install apps too? [y/N] " reply_all || reply_all=
+          case ${reply_all,,} in
+            y|yes)
+              /usr/local/bin/omarchy-install-hide-all-unavailable
+              echo "Hid all known unavailable Install apps."
+              ;;
+          esac
+          ;;
+      esac
+    fi
+  fi
+fi
+
+# 130 skips omarchy-show-done in the floating Install terminal (same as Ctrl-C).
+exit 130

--- a/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-install-ids
+++ b/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-install-ids
@@ -1,0 +1,25 @@
+# Install-menu ids that can be hidden on Try Omarchy aarch64.
+# These match omarchy-install-menu-visible arguments (usually package names).
+ghostty
+microsoft-edge-stable-bin
+spotify
+dropbox
+cursor-bin
+grok-bot
+lmstudio-bin
+steam
+minecraft-launcher
+heroic-games-launcher-bin
+geforce-now
+battlenet
+lutris
+retroarch
+sublime-text-4
+visual-studio-code-bin
+zed
+nordvpn-bin
+once-bin
+openai-codex-desktop
+xpadneo-dkms
+bitwarden
+ollama

--- a/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
+++ b/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
@@ -1,0 +1,20 @@
+# Packages that Install-menu paths cannot satisfy on Try Omarchy aarch64.
+# Format: package<TAB>display-name
+# Kept intentionally narrow: x86_64-only AUR/binaries, or repo-only names absent
+# from Arch Linux ARM (with no practical aarch64 install path today).
+ghostty	Ghostty
+microsoft-edge-stable-bin	Edge
+spotify	Spotify
+dropbox	Dropbox
+dropbox-cli	Dropbox
+nautilus-dropbox	Dropbox
+cursor-bin	Cursor
+grok-bot	Grok Bot
+lmstudio-bin	LM Studio
+steam	Steam
+minecraft-launcher	Minecraft
+heroic-games-launcher-bin	Heroic
+umu-launcher	Wine game launcher
+wine-staging	Wine
+wine-mono	Wine
+wine-gecko	Wine

--- a/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
+++ b/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
@@ -1,7 +1,7 @@
 # Packages that Install-menu paths cannot satisfy on Try Omarchy aarch64.
 # Format: package<TAB>display-name
-# Kept intentionally narrow: x86_64-only AUR/binaries, or repo-only names absent
-# from Arch Linux ARM (with no practical aarch64 install path today).
+# Includes x86_64-only AUR/binaries, and packages the Install path asks pacman for
+# that are absent from this guest's repos (often AUR / omarchy x86 channel only).
 ghostty	Ghostty
 microsoft-edge-stable-bin	Edge
 spotify	Spotify
@@ -18,3 +18,15 @@ umu-launcher	Wine game launcher
 wine-staging	Wine
 wine-mono	Wine
 wine-gecko	Wine
+sublime-text-4	Sublime Text
+visual-studio-code-bin	VSCode
+zed	Zed
+omazed	Zed
+nordvpn-bin	NordVPN
+once-bin	ONCE
+openai-codex-desktop	ChatGPT Desktop
+xpadneo-dkms	Xbox Controllers
+bitwarden	Bitwarden
+ollama	Ollama
+ollama-cuda	Ollama
+ollama-rocm	Ollama

--- a/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
+++ b/guest/native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages
@@ -2,6 +2,8 @@
 # Format: package<TAB>display-name
 # Includes x86_64-only AUR/binaries, and packages the Install path asks pacman for
 # that are absent from this guest's repos (often AUR / omarchy x86 channel only).
+# Wine/umu are NOT listed here: they are refused only from Battle.net / Lutris
+# installers so aarch64 pkg-add of those deps elsewhere is not blocked.
 ghostty	Ghostty
 microsoft-edge-stable-bin	Edge
 spotify	Spotify
@@ -14,10 +16,6 @@ lmstudio-bin	LM Studio
 steam	Steam
 minecraft-launcher	Minecraft
 heroic-games-launcher-bin	Heroic
-umu-launcher	Wine game launcher
-wine-staging	Wine
-wine-mono	Wine
-wine-gecko	Wine
 sublime-text-4	Sublime Text
 visual-studio-code-bin	VSCode
 zed	Zed

--- a/guest/patches/omarchy/aarch64-hide-unavailable-installs.patch
+++ b/guest/patches/omarchy/aarch64-hide-unavailable-installs.patch
@@ -1,0 +1,102 @@
+--- a/default/omarchy/omarchy-menu.jsonc
++++ b/default/omarchy/omarchy-menu.jsonc
+@@ -178,6 +178,7 @@
+   "setup.config.hyprsunset": {"icon":"","label":"Hyprsunset","action":"omarchy-launch-config-editor ~/.config/hypr/hyprsunset.conf && omarchy-restart-hyprsunset"},
+   "setup.config.xcompose": {"icon":"󰞅","label":"XCompose","action":"omarchy-launch-config-editor ~/.XCompose && omarchy-restart-xcompose"},
+   "setup.direct-boot": {"icon":"","label":"Direct Boot","action":"omarchy-launch-floating-terminal-with-presentation omarchy-setup-direct-boot"},
++  "setup.restore-hidden-installs": {"icon":"󰀂","label":"Restore hidden Install apps","when":"omarchy-arch-aarch64 && omarchy-install-has-hidden","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-restore-hidden"},
+   "setup.reset": {"icon":"󰑓","label":"Reset Computer","when":"[[ $(findmnt -no FSTYPE /) == btrfs ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-system-factory-reset"},
+ 
+   // Install
+@@ -205,45 +206,68 @@
+   "install.windows": {"icon":"󰍲","label":"Windows","when":"[[ ! -f $HOME/.local/share/applications/windows-vm.desktop ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-windows-vm install'"},
+   "install.preinstalls": {"icon":"󰏓","label":"Preinstalls","when":"[[ -f $HOME/.local/state/omarchy/preinstalls-removed ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-preinstalls"},
+   "install.browser.chrome": {"icon":"","label":"Chrome","when":"! omarchy-pkg-present google-chrome","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser chrome'"},
+-  "install.browser.edge": {"icon":"󰇩","label":"Edge","when":"! omarchy-pkg-present microsoft-edge-stable-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser edge'"},
++  "install.browser.edge": {"icon":"󰇩","label":"Edge","when":"! omarchy-pkg-present microsoft-edge-stable-bin && omarchy-install-menu-visible microsoft-edge-stable-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser edge'"},
++
+   "install.browser.brave": {"icon":"","label":"Brave","when":"! omarchy-pkg-present brave-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser brave'"},
+   "install.browser.brave-origin": {"icon":"","label":"Brave Origin","when":"! omarchy-pkg-present brave-origin-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser brave-origin'"},
+   "install.browser.firefox": {"icon":"","label":"Firefox","when":"! omarchy-pkg-present firefox","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser firefox'"},
+   "install.browser.zen": {"icon":"󰖟","label":"Zen","when":"! omarchy-pkg-present zen-browser-bin","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-browser zen'"},
+   "install.service.1password": {"icon":"󰢁","label":"1Password","when":"! omarchy-pkg-present 1password","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-1password"},
+-  "install.service.dropbox": {"icon":"","label":"Dropbox","when":"! omarchy-pkg-present dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-dropbox"},
+-  "install.service.spotify": {"icon":"󰓇","label":"Spotify","when":"! omarchy-pkg-present spotify","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify"},
++  "install.service.dropbox": {"icon":"","label":"Dropbox","when":"! omarchy-pkg-present dropbox && omarchy-install-menu-visible dropbox","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-dropbox"},
++
++  "install.service.spotify": {"icon":"󰓇","label":"Spotify","when":"! omarchy-pkg-present spotify && omarchy-install-menu-visible spotify","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-spotify"},
++
+   "install.service.signal": {"icon":"󰭹","label":"Signal","when":"! omarchy-pkg-present signal-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-signal"},
+   "install.service.tailscale": {"icon":"","label":"Tailscale","when":"! omarchy-pkg-present tailscale","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-tailscale"},
+-  "install.service.nordvpn": {"icon":"󱇱","label":"NordVPN","when":"! omarchy-pkg-present nordvpn-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-nordvpn"},
+-  "install.service.once": {"icon":"󰏖","label":"ONCE","when":"! omarchy-pkg-present once-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-once"},
+-  "install.service.bitwarden": {"icon":"󰟵","label":"Bitwarden","when":"! omarchy-pkg-present bitwarden","action":"omarchy-install-and-launch Bitwarden 'bitwarden bitwarden-cli' bitwarden"},
++  "install.service.nordvpn": {"icon":"󱇱","label":"NordVPN","when":"! omarchy-pkg-present nordvpn-bin && omarchy-install-menu-visible nordvpn-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-nordvpn"},
++
++  "install.service.once": {"icon":"󰏖","label":"ONCE","when":"! omarchy-pkg-present once-bin && omarchy-install-menu-visible once-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-service-once"},
++
++  "install.service.bitwarden": {"icon":"󰟵","label":"Bitwarden","when":"! omarchy-pkg-present bitwarden && omarchy-install-menu-visible bitwarden","action":"omarchy-install-and-launch Bitwarden 'bitwarden bitwarden-cli' bitwarden"},
++
+   "install.service.chromium-account": {"icon":"","label":"Chromium Account","when":"[[ -f ~/.config/chromium-flags.conf ]] && ! grep -q oauth2-client-id ~/.config/chromium-flags.conf","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-chromium-google-account"},
+-  "install.editor.vscode": {"icon":"","label":"VSCode","when":"! omarchy-pkg-present visual-studio-code-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-vscode"},
+-  "install.editor.cursor": {"icon":"","label":"Cursor","when":"! omarchy-pkg-present cursor-bin","action":"omarchy-install-and-launch Cursor cursor-bin cursor"},
+-  "install.editor.zed": {"icon":"","label":"Zed","when":"! omarchy-pkg-present zed","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-zed"},
+-  "install.editor.sublime": {"icon":"","label":"Sublime Text","when":"! omarchy-pkg-present sublime-text-4","action":"omarchy-install-and-launch 'Sublime Text' sublime-text-4 sublime_text"},
++  "install.editor.vscode": {"icon":"","label":"VSCode","when":"! omarchy-pkg-present visual-studio-code-bin && omarchy-install-menu-visible visual-studio-code-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-vscode"},
++
++  "install.editor.cursor": {"icon":"","label":"Cursor","when":"! omarchy-pkg-present cursor-bin && omarchy-install-menu-visible cursor-bin","action":"omarchy-install-and-launch Cursor cursor-bin cursor"},
++
++  "install.editor.zed": {"icon":"","label":"Zed","when":"! omarchy-pkg-present zed && omarchy-install-menu-visible zed","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-zed"},
++
++  "install.editor.sublime": {"icon":"","label":"Sublime Text","when":"! omarchy-pkg-present sublime-text-4 && omarchy-install-menu-visible sublime-text-4","action":"omarchy-install-and-launch 'Sublime Text' sublime-text-4 sublime_text"},
++
+   "install.editor.helix": {"icon":"","label":"Helix","when":"! omarchy-pkg-present helix","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-helix"},
+   "install.editor.vim": {"icon":"","label":"Vim","when":"! omarchy-pkg-present vim","action":"omarchy-install-app Vim vim"},
+   "install.editor.emacs": {"icon":"","label":"Emacs","when":"! omarchy-pkg-present omarchy-emacs","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-editor-emacs"},
+   "install.terminal.alacritty": {"icon":"","label":"Alacritty","when":"! omarchy-pkg-present alacritty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal alacritty'"},
+   "install.terminal.foot": {"icon":"","label":"Foot","when":"! omarchy-pkg-present foot","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal foot'"},
+-  "install.terminal.ghostty": {"icon":"","label":"Ghostty","when":"! omarchy-pkg-present ghostty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal ghostty'"},
++  "install.terminal.ghostty": {"icon":"","label":"Ghostty","when":"! omarchy-pkg-present ghostty && omarchy-install-menu-visible ghostty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal ghostty'"},
++
+   "install.terminal.kitty": {"icon":"","label":"Kitty","when":"! omarchy-pkg-present kitty","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-terminal kitty'"},
+-  "install.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","when":"! omarchy-pkg-present openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
++  "install.ai.chatgpt": {"icon":"","iconFont":"omarchy","label":"ChatGPT Desktop","when":"! omarchy-pkg-present openai-codex-desktop && omarchy-install-menu-visible openai-codex-desktop","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-ai-chatgpt"},
++
+   "install.ai.dictation": {"icon":"","label":"Dictation","when":"! omarchy-pkg-present voxtype-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-voxtype-install"},
+-  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","when":"! omarchy-pkg-present grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
+-  "install.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","when":"! omarchy-pkg-present lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
+-  "install.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","when":"! omarchy-cmd-present ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},
+-  "install.gaming.steam": {"icon":"","label":"Steam","when":"! omarchy-pkg-present steam","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-steam"},
+-  "install.gaming.retroarch": {"icon":"󰯉","label":"RetroArch","when":"! omarchy-pkg-present retroarch","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-retroarch"},
+-  "install.gaming.minecraft": {"icon":"󰍳","label":"Minecraft","when":"! omarchy-pkg-present minecraft-launcher","action":"omarchy-install-and-launch Minecraft minecraft-launcher minecraft-launcher"},
+-  "install.gaming.geforce-now": {"icon":"󰢹","label":"NVIDIA GeForce NOW","when":"! flatpak info com.nvidia.geforcenow","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-geforce-now"},
++  "install.ai.grok-bot": {"icon":"","iconFont":"omarchy","label":"Grok Bot","when":"! omarchy-pkg-present grok-bot && omarchy-install-menu-visible grok-bot","action":"omarchy-install-and-launch 'Grok Bot' grok-bot grok-bot"},
++
++  "install.ai.lm-studio": {"icon":"","iconFont":"omarchy","label":"LM Studio","when":"! omarchy-pkg-present lmstudio-bin && omarchy-install-menu-visible lmstudio-bin","action":"omarchy-install-app 'LM Studio' lmstudio-bin"},
++
++  "install.ai.ollama": {"icon":"","iconFont":"omarchy","label":"Ollama","when":"! omarchy-cmd-present ollama && omarchy-install-menu-visible ollama","action":"if omarchy-cmd-present nvidia-smi; then ollama_pkg=ollama-cuda; elif omarchy-cmd-present rocminfo; then ollama_pkg=ollama-rocm; else ollama_pkg=ollama; fi; omarchy-install-app Ollama \"$ollama_pkg\""},
++
++  "install.gaming.steam": {"icon":"","label":"Steam","when":"! omarchy-pkg-present steam && omarchy-install-menu-visible steam","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-steam"},
++
++  "install.gaming.retroarch": {"icon":"󰯉","label":"RetroArch","when":"! omarchy-pkg-present retroarch && omarchy-install-menu-visible retroarch","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-retroarch"},
++
++  "install.gaming.minecraft": {"icon":"󰍳","label":"Minecraft","when":"! omarchy-pkg-present minecraft-launcher && omarchy-install-menu-visible minecraft-launcher","action":"omarchy-install-and-launch Minecraft minecraft-launcher minecraft-launcher"},
++
++  "install.gaming.geforce-now": {"icon":"󰢹","label":"NVIDIA GeForce NOW","when":"! flatpak info com.nvidia.geforcenow && omarchy-install-menu-visible geforce-now","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-geforce-now"},
++
+   "install.gaming.xbox-cloud": {"icon":"","label":"Xbox Cloud Gaming","when":"[[ ! -f \"$HOME/.local/share/applications/Xbox Cloud Gaming.desktop\" ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-xbox-cloud"},
+-  "install.gaming.xbox-controllers": {"icon":"󰂯","label":"Xbox Controllers","when":"! omarchy-pkg-present xpadneo-dkms","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-xbox-controllers"},
+-  "install.gaming.battlenet": {"icon":"","label":"Battle.net","when":"[[ ! -d $HOME/Games/battlenet ]]","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-battlenet"},
+-  "install.gaming.lutris": {"icon":"","label":"Lutris","when":"! omarchy-pkg-present lutris","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-lutris"},
+-  "install.gaming.heroic": {"icon":"󱓟","label":"Heroic (Epic Games)","when":"! omarchy-pkg-present heroic-games-launcher-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-heroic"},
++  "install.gaming.xbox-controllers": {"icon":"󰂯","label":"Xbox Controllers","when":"! omarchy-pkg-present xpadneo-dkms && omarchy-install-menu-visible xpadneo-dkms","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-xbox-controllers"},
++
++  "install.gaming.battlenet": {"icon":"","label":"Battle.net","when":"[[ ! -d $HOME/Games/battlenet ]] && omarchy-install-menu-visible battlenet","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-battlenet"},
++
++  "install.gaming.lutris": {"icon":"","label":"Lutris","when":"! omarchy-pkg-present lutris && omarchy-install-menu-visible lutris","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-lutris"},
++
++  "install.gaming.heroic": {"icon":"󱓟","label":"Heroic (Epic Games)","when":"! omarchy-pkg-present heroic-games-launcher-bin && omarchy-install-menu-visible heroic-games-launcher-bin","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-gaming-heroic"},
++
+   "install.gaming.retro-launcher": {"icon":"󰯉","label":"RetroArch Game Launcher","action":"omarchy-games-retro-install"},
+   "install.development.rails": {"icon":"󰫏","label":"Ruby on Rails","when":"[[ ! -d $HOME/.local/share/mise/installs/ruby ]]","action":"omarchy-launch-floating-terminal-with-presentation 'omarchy-install-dev-env ruby'"},
+   "install.development.docker-dbs": {"icon":"","label":"Docker DB","action":"omarchy-launch-floating-terminal-with-presentation omarchy-install-docker-dbs"},

--- a/guest/patches/omarchy/battlenet-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/battlenet-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-install-gaming-battlenet
++++ b/bin/omarchy-install-gaming-battlenet
+@@ -8,6 +8,11 @@
+ PREFIX="$HOME/Games/battlenet"
+ LAUNCHER="$PREFIX/drive_c/Program Files (x86)/Battle.net/Battle.net Launcher.exe"
+ INSTALLER_URL="https://downloader.battle.net/download/getInstallerForGame?os=win&gameProgram=BATTLENET_APP&version=Live"
++
++# Battle.net standalone depends on umu-launcher / Wine, which Install cannot satisfy on aarch64.
++if [[ $(uname -m) == aarch64 ]]; then
++  exec omarchy-pkg-unavailable-arm 'Battle.net' battlenet
++fi
+ 
+ echo "Installing Battle.net..."
+ 

--- a/guest/patches/omarchy/dropbox-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/dropbox-aarch64-unavailable.patch
@@ -6,7 +6,7 @@
  
 +# Dropbox ships x86_64-only binaries; refuse before post-install tray setup.
 +if [[ $(uname -m) == aarch64 ]]; then
-+  exec omarchy-pkg-unavailable-arm Dropbox
++  exec omarchy-pkg-unavailable-arm Dropbox dropbox
 +fi
 +
  echo "Installing all dependencies..."

--- a/guest/patches/omarchy/dropbox-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/dropbox-aarch64-unavailable.patch
@@ -1,0 +1,17 @@
+--- a/bin/omarchy-install-service-dropbox
++++ b/bin/omarchy-install-service-dropbox
+@@ -2,8 +2,13 @@
+ 
+ # omarchy:summary=Install and start the Dropbox service. Must then be authenticated via the web.
+ 
++# Dropbox ships x86_64-only binaries; refuse before post-install tray setup.
++if [[ $(uname -m) == aarch64 ]]; then
++  exec omarchy-pkg-unavailable-arm Dropbox
++fi
++
+ echo "Installing all dependencies..."
+-omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox
++omarchy-pkg-add dropbox dropbox-cli libappindicator-gtk3 python-gpgme nautilus-dropbox || exit $?
+ 
+ echo "Adding Dropbox to the bar..."
+ omarchy-plugin-enable omarchy.dropbox

--- a/guest/patches/omarchy/geforce-now-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/geforce-now-aarch64-unavailable.patch
@@ -1,14 +1,14 @@
 --- a/bin/omarchy-install-gaming-geforce-now
 +++ b/bin/omarchy-install-gaming-geforce-now
-@@ -6,6 +6,11 @@
+@@ -5,6 +5,11 @@
+ # omarchy:name=gaming geforce-now
  
  set -e
- 
++
 +# GeForce NOW ships an x86_64 Linux installer only.
 +if [[ $(uname -m) == aarch64 ]]; then
-+  exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW'
++  exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW' geforce-now
 +fi
-+
+ 
  echo "Installing GeForce NOW..."
  omarchy-pkg-add flatpak
- cd /tmp

--- a/guest/patches/omarchy/geforce-now-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/geforce-now-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-install-gaming-geforce-now
++++ b/bin/omarchy-install-gaming-geforce-now
+@@ -6,6 +6,11 @@
+ 
+ set -e
+ 
++# GeForce NOW ships an x86_64 Linux installer only.
++if [[ $(uname -m) == aarch64 ]]; then
++  exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW'
++fi
++
+ echo "Installing GeForce NOW..."
+ omarchy-pkg-add flatpak
+ cd /tmp

--- a/guest/patches/omarchy/lutris-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/lutris-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-install-gaming-lutris
++++ b/bin/omarchy-install-gaming-lutris
+@@ -4,6 +4,11 @@
+ # omarchy:requires-sudo=true
+ 
+ set -e
++
++# Lutris Install pulls Wine/umu packages that are not a workable Try Omarchy aarch64 path.
++if [[ $(uname -m) == aarch64 ]]; then
++  exec omarchy-pkg-unavailable-arm Lutris lutris
++fi
+ 
+ echo "Installing Lutris..."
+ omarchy-pkg-add lutris umu-launcher wine-staging wine-mono wine-gecko winetricks python-protobuf

--- a/guest/patches/omarchy/omarchy-pkg-add-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/omarchy-pkg-add-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-pkg-add
++++ b/bin/omarchy-pkg-add
+@@ -4,6 +4,11 @@
+ # omarchy:args=<packages...>
+ # omarchy:examples=omarchy pkg add jq ripgrep
+ # omarchy:requires-sudo=true
++
++# Try Omarchy: refuse known aarch64-unavailable Install-menu packages.
++if [[ -x /usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable ]]; then
++  /usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable "$@" || exit $?
++fi
+ 
+ if omarchy-pkg-missing "$@"; then
+   if (( EUID == 0 )); then

--- a/guest/patches/omarchy/omarchy-pkg-aur-add-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/omarchy-pkg-aur-add-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-pkg-aur-add
++++ b/bin/omarchy-pkg-aur-add
+@@ -2,6 +2,11 @@
+ 
+ # omarchy:summary=Add the named packages to the system from the AUR if they're missing. Returns false if it couldn't be done.
+ # omarchy:args=<packages...>
++
++# Try Omarchy: refuse known aarch64-unavailable Install-menu packages.
++if [[ -x /usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable ]]; then
++  /usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable "$@" || exit $?
++fi
+ 
+ if omarchy-pkg-missing "$@"; then
+   yay -S --noconfirm --needed "$@" || exit 1

--- a/guest/patches/omarchy/retroarch-aarch64-unavailable.patch
+++ b/guest/patches/omarchy/retroarch-aarch64-unavailable.patch
@@ -1,0 +1,14 @@
+--- a/bin/omarchy-install-gaming-retroarch
++++ b/bin/omarchy-install-gaming-retroarch
+@@ -3,6 +3,11 @@
+ # omarchy:summary=Install RetroArch with the full libretro core set plus FBNeo and a ~/Games ROM directory.
+ 
+ set -e
++
++# Full RetroArch + libretro core set is not available on Try Omarchy aarch64.
++if [[ $(uname -m) == aarch64 ]]; then
++  exec omarchy-pkg-unavailable-arm RetroArch retroarch
++fi
+ 
+ echo "Installing RetroArch..."
+ omarchy-pkg-add \

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -76,6 +76,11 @@ chmod 0755 \
   "$root/usr/local/bin/omarchy-arch-aarch64" \
   "$root/usr/local/bin/omarchy-pkg-unavailable-arm" \
   "$root/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable" \
+  "$root/usr/local/bin/omarchy-install-menu-visible" \
+  "$root/usr/local/bin/omarchy-install-has-hidden" \
+  "$root/usr/local/bin/omarchy-install-hide" \
+  "$root/usr/local/bin/omarchy-install-hide-all-unavailable" \
+  "$root/usr/local/bin/omarchy-install-restore-hidden" \
   "$root/usr/local/bin/omarchy-native-audio-bridge" \
   "$root/usr/local/bin/omarchy-native-camera-bridge" \
   "$root/usr/local/bin/omarchy-native-clipboard-bridge" \
@@ -85,6 +90,7 @@ chmod 0755 \
   "$root/usr/local/lib/try-omarchy/install-vivaldi-arm64" \
   "$root/usr/lib/systemd/system-generators/try-omarchy-ssh-access"
 chmod 0644 "$root/usr/local/share/try-omarchy/aarch64-unavailable-packages"
+chmod 0644 "$root/usr/local/share/try-omarchy/aarch64-unavailable-install-ids"
 
 vivaldi_key=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["supplyChain"]["vivaldi"]["signingKey"])' "$spec")
 [[ $vivaldi_key == keys/vivaldi-package-composer-key11.asc ]] || fail "unexpected Vivaldi key path"

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -73,6 +73,9 @@ chmod 0755 \
   "$root/usr/bin/omarchy-audio-input-set-default" \
   "$root/usr/bin/omarchy-screensaver" \
   "$root/usr/bin/omarchy-theme-bg-switcher" \
+  "$root/usr/local/bin/omarchy-arch-aarch64" \
+  "$root/usr/local/bin/omarchy-pkg-unavailable-arm" \
+  "$root/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable" \
   "$root/usr/local/bin/omarchy-native-audio-bridge" \
   "$root/usr/local/bin/omarchy-native-camera-bridge" \
   "$root/usr/local/bin/omarchy-native-clipboard-bridge" \
@@ -81,6 +84,7 @@ chmod 0755 \
   "$root/usr/local/bin/omarchy-native-mac-share" \
   "$root/usr/local/lib/try-omarchy/install-vivaldi-arm64" \
   "$root/usr/lib/systemd/system-generators/try-omarchy-ssh-access"
+chmod 0644 "$root/usr/local/share/try-omarchy/aarch64-unavailable-packages"
 
 vivaldi_key=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["supplyChain"]["vivaldi"]["signingKey"])' "$spec")
 [[ $vivaldi_key == keys/vivaldi-package-composer-key11.asc ]] || fail "unexpected Vivaldi key path"

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -287,12 +287,12 @@
         "description": "Stop the Dropbox installer on aarch64 before tray setup, using the shared unavailable message.",
         "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-service-dropbox",
         "patch": "patches/omarchy/dropbox-aarch64-unavailable.patch",
-        "patchSha256": "c97a991a7ced28b0d02ce89497522a50198f6f9744fa5a44213e62c84bc422a5",
+        "patchSha256": "59e0d5159c1b56d443bc13a16b87a86a3366cfc7fc809c58774b115cf377711a",
         "targets": [
           {
             "path": "bin/omarchy-install-service-dropbox",
             "beforeSha256": "90f36082ab995dc5e124996da15d551d058892eedbc7d290c93ded4f495ba6af",
-            "afterSha256": "29b93859659093ef24338ee37136cf12ac61a9abd9dc9e0aa8b76033614be8f7"
+            "afterSha256": "fc0fd7504bcf9c27c05c29f26db9fdb3f1995c7dca5156a9337151f8d1dd17ed"
           }
         ]
       },
@@ -301,12 +301,40 @@
         "description": "Fail GeForce NOW install on aarch64 with the shared pacman/AUR unavailable message (vendor installer is x86_64-only).",
         "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-gaming-geforce-now",
         "patch": "patches/omarchy/geforce-now-aarch64-unavailable.patch",
-        "patchSha256": "64c3f52d990982c3003040289f91d6b9f718b9ffd3992a72ea6c37e9ad1037bd",
+        "patchSha256": "91c9f9d525b7b691b03cd5449d42c087b1ad52fd4244355469404d8de097da52",
         "targets": [
           {
             "path": "bin/omarchy-install-gaming-geforce-now",
             "beforeSha256": "c039bf511dc66a86af93c52b5445485ee9b592a7f54006e6dcdf637b35f0577c",
-            "afterSha256": "55821a3cc43f9161b58fb27f568cd1c58809e43cb2329f46e613a3c06e0eb884"
+            "afterSha256": "dabbcb2f85d110a1b35315257afb1f4b13acae12f316f27e1765feb448b4ee2f"
+          }
+        ]
+      },
+      {
+        "id": "retroarch-aarch64-unavailable",
+        "description": "Fail the full RetroArch+libretro Install path on aarch64 before pacman target-not-found spam.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-gaming-retroarch",
+        "patch": "patches/omarchy/retroarch-aarch64-unavailable.patch",
+        "patchSha256": "247f0206f3df5fce020ae5d03303baa72a69d1b7fbfdae2f5c19df0e27dc3b9d",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-gaming-retroarch",
+            "beforeSha256": "aa2602bf6252a3a67428860885ca19f6878d689ef679d60d65637bb8c429cbbb",
+            "afterSha256": "077671618259e111a34f27ef2c1a20b4e0484226b16502bb33d52c216d36e864"
+          }
+        ]
+      },
+      {
+        "id": "aarch64-hide-unavailable-installs",
+        "description": "Gate known aarch64-unavailable Install rows behind a hideable visibility helper, and add Setup restore.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/default/omarchy/omarchy-menu.jsonc",
+        "patch": "patches/omarchy/aarch64-hide-unavailable-installs.patch",
+        "patchSha256": "8d180bcfb5b9e9155bf4fef076afcf5e046ff6e2787a93c4f7e749fd3e7dea0c",
+        "targets": [
+          {
+            "path": "default/omarchy/omarchy-menu.jsonc",
+            "beforeSha256": "027096cc20b52f3073c7d61ad43ff1fc8fddeb127b05b41c129b0a97826cecb2",
+            "afterSha256": "d0a996d18aa7419aa9ff7b767f422557798bbf6508aa606c1244494136220671"
           }
         ]
       }

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -253,6 +253,62 @@
             "afterSha256": "8e8102cb08ff4fde4f89c64a7febeca0ba142c309e20e581ae0cf295f6e7f093"
           }
         ]
+      },
+      {
+        "id": "pkg-add-aarch64-unavailable",
+        "description": "Refuse known aarch64-unavailable packages from omarchy-pkg-add with the shared message.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-pkg-add",
+        "patch": "patches/omarchy/omarchy-pkg-add-aarch64-unavailable.patch",
+        "patchSha256": "da90db1be0f3b32426ad55991d971d71cb5811f598957fe55c3d9284aa0803df",
+        "targets": [
+          {
+            "path": "bin/omarchy-pkg-add",
+            "beforeSha256": "76bf74a1e4e65d07a29c06ebc5a621bf36662efc0a175ffc53b723bd80339a3e",
+            "afterSha256": "f9cfab3be6f9dbdc5a60915ea9eea55d0a44e3828a7ec0d098a3f7a48398a3c3"
+          }
+        ]
+      },
+      {
+        "id": "pkg-aur-add-aarch64-unavailable",
+        "description": "Refuse known aarch64-unavailable packages from omarchy-pkg-aur-add with the shared message.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-pkg-aur-add",
+        "patch": "patches/omarchy/omarchy-pkg-aur-add-aarch64-unavailable.patch",
+        "patchSha256": "58578eb598d9fded75fe5ff7ea64afb1a887faf6c8bd12adfa9eda2f2c2ff675",
+        "targets": [
+          {
+            "path": "bin/omarchy-pkg-aur-add",
+            "beforeSha256": "ec2f57b0d153bb814cae344618f61603282cbedce0012647b2c391d9000cd5f6",
+            "afterSha256": "8d230a2628a27ae690ef3b630f8c1e8bba6ba8a74254e175717509cfc21a802b"
+          }
+        ]
+      },
+      {
+        "id": "dropbox-aarch64-unavailable",
+        "description": "Stop the Dropbox installer on aarch64 before tray setup, using the shared unavailable message.",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-service-dropbox",
+        "patch": "patches/omarchy/dropbox-aarch64-unavailable.patch",
+        "patchSha256": "c97a991a7ced28b0d02ce89497522a50198f6f9744fa5a44213e62c84bc422a5",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-service-dropbox",
+            "beforeSha256": "90f36082ab995dc5e124996da15d551d058892eedbc7d290c93ded4f495ba6af",
+            "afterSha256": "29b93859659093ef24338ee37136cf12ac61a9abd9dc9e0aa8b76033614be8f7"
+          }
+        ]
+      },
+      {
+        "id": "geforce-now-aarch64-unavailable",
+        "description": "Fail GeForce NOW install on aarch64 with the shared pacman/AUR unavailable message (vendor installer is x86_64-only).",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-gaming-geforce-now",
+        "patch": "patches/omarchy/geforce-now-aarch64-unavailable.patch",
+        "patchSha256": "64c3f52d990982c3003040289f91d6b9f718b9ffd3992a72ea6c37e9ad1037bd",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-gaming-geforce-now",
+            "beforeSha256": "c039bf511dc66a86af93c52b5445485ee9b592a7f54006e6dcdf637b35f0577c",
+            "afterSha256": "55821a3cc43f9161b58fb27f568cd1c58809e43cb2329f46e613a3c06e0eb884"
+          }
+        ]
       }
     ],
     "postBuildUserInstallers": [

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -325,6 +325,34 @@
         ]
       },
       {
+        "id": "battlenet-aarch64-unavailable",
+        "description": "Fail Battle.net Install on aarch64 before umu-launcher/Wine setup (installer-only; not a global wine denylist).",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-gaming-battlenet",
+        "patch": "patches/omarchy/battlenet-aarch64-unavailable.patch",
+        "patchSha256": "3d456ecb2858709c122366a4492c22a17684620ed0fa5807d43b9005666dc013",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-gaming-battlenet",
+            "beforeSha256": "7d687f439d9ea1b5de6cc7b5c8c054e8276fe3357e9792a67a6c5304e06dcfbb",
+            "afterSha256": "a4be72fe6162747aa30f9f990e0b1cbb9ace4f7df1d95b84e1b8971e77513d89"
+          }
+        ]
+      },
+      {
+        "id": "lutris-aarch64-unavailable",
+        "description": "Fail Lutris Install on aarch64 before Wine/umu package pulls (installer-only; not a global wine denylist).",
+        "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/bin/omarchy-install-gaming-lutris",
+        "patch": "patches/omarchy/lutris-aarch64-unavailable.patch",
+        "patchSha256": "c4490194aa3e2956c80286807682b0dae1cffb1a2da188d5188c306415574817",
+        "targets": [
+          {
+            "path": "bin/omarchy-install-gaming-lutris",
+            "beforeSha256": "b742e54d9bda2da2a8e98e6b236fcd050302919e4e25836bedf3f8dfcf3edbc8",
+            "afterSha256": "d9e26a186fb6401eea179194ae40119293af7d230a473ec8e34964a1f93732a2"
+          }
+        ]
+      },
+      {
         "id": "aarch64-hide-unavailable-installs",
         "description": "Gate known aarch64-unavailable Install rows behind a hideable visibility helper, and add Setup restore.",
         "reference": "https://github.com/basecamp/omarchy/blob/346e69e1cec6c4e8924531874af6ba010a1bc99e/default/omarchy/omarchy-menu.jsonc",

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -174,6 +174,8 @@ def main() -> None:
             "dropbox-aarch64-unavailable",
             "geforce-now-aarch64-unavailable",
             "retroarch-aarch64-unavailable",
+            "battlenet-aarch64-unavailable",
+            "lutris-aarch64-unavailable",
             "aarch64-hide-unavailable-installs",
         ],
         "Omarchy backports are explicitly ordered and identified",
@@ -212,6 +214,16 @@ def main() -> None:
     check(
         "exec omarchy-pkg-unavailable-arm RetroArch retroarch" in retroarch_unavailable_patch,
         "RetroArch aarch64 backport fails via the shared unavailable helper",
+    )
+    battlenet_unavailable_patch = read(GUEST / "patches/omarchy/battlenet-aarch64-unavailable.patch")
+    check(
+        "exec omarchy-pkg-unavailable-arm 'Battle.net' battlenet" in battlenet_unavailable_patch,
+        "Battle.net aarch64 backport fails via the shared unavailable helper",
+    )
+    lutris_unavailable_patch = read(GUEST / "patches/omarchy/lutris-aarch64-unavailable.patch")
+    check(
+        "exec omarchy-pkg-unavailable-arm Lutris lutris" in lutris_unavailable_patch,
+        "Lutris aarch64 backport fails via the shared unavailable helper",
     )
     dropbox_unavailable_patch = read(GUEST / "patches/omarchy/dropbox-aarch64-unavailable.patch")
     check(
@@ -295,8 +307,10 @@ def main() -> None:
         and "steam\tSteam" in unavailable_package_text
         and "minecraft-launcher\tMinecraft" in unavailable_package_text
         and "heroic-games-launcher-bin\tHeroic" in unavailable_package_text
-        and "umu-launcher\tWine game launcher" in unavailable_package_text
-        and "wine-staging\tWine" in unavailable_package_text
+        and "umu-launcher\tWine game launcher" not in unavailable_package_text
+        and "wine-staging\tWine" not in unavailable_package_text
+        and "wine-mono\tWine" not in unavailable_package_text
+        and "wine-gecko\tWine" not in unavailable_package_text
         and "sublime-text-4\tSublime Text" in unavailable_package_text
         and "visual-studio-code-bin\tVSCode" in unavailable_package_text
         and "zed\tZed" in unavailable_package_text
@@ -307,7 +321,7 @@ def main() -> None:
         and "bitwarden\tBitwarden" in unavailable_package_text
         and "ollama\tOllama" in unavailable_package_text
         and "ollama-cuda\tOllama" in unavailable_package_text,
-        "aarch64 unavailable package denylist covers the audited Install-menu gaps",
+        "aarch64 unavailable package denylist covers Install gaps without globally blocking Wine/umu",
     )
 
     post_build_installers = authenticity["postBuildUserInstallers"]

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -173,6 +173,8 @@ def main() -> None:
             "pkg-aur-add-aarch64-unavailable",
             "dropbox-aarch64-unavailable",
             "geforce-now-aarch64-unavailable",
+            "retroarch-aarch64-unavailable",
+            "aarch64-hide-unavailable-installs",
         ],
         "Omarchy backports are explicitly ordered and identified",
     )
@@ -202,12 +204,18 @@ def main() -> None:
     )
     geforce_unavailable_patch = read(GUEST / "patches/omarchy/geforce-now-aarch64-unavailable.patch")
     check(
-        "exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW'" in geforce_unavailable_patch,
+        "exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW' geforce-now"
+        in geforce_unavailable_patch,
         "GeForce NOW aarch64 backport fails via the shared unavailable helper",
+    )
+    retroarch_unavailable_patch = read(GUEST / "patches/omarchy/retroarch-aarch64-unavailable.patch")
+    check(
+        "exec omarchy-pkg-unavailable-arm RetroArch retroarch" in retroarch_unavailable_patch,
+        "RetroArch aarch64 backport fails via the shared unavailable helper",
     )
     dropbox_unavailable_patch = read(GUEST / "patches/omarchy/dropbox-aarch64-unavailable.patch")
     check(
-        "exec omarchy-pkg-unavailable-arm Dropbox" in dropbox_unavailable_patch
+        "exec omarchy-pkg-unavailable-arm Dropbox dropbox" in dropbox_unavailable_patch
         and "omarchy-plugin-enable omarchy.dropbox" in dropbox_unavailable_patch,
         "Dropbox aarch64 backport stops before tray setup via the shared unavailable helper",
     )
@@ -232,15 +240,42 @@ def main() -> None:
         unavailable_helper.is_file()
         and unavailable_helper.stat().st_mode & stat.S_IXUSR != 0
         and "not available via pacman/AUR for aarch64 at this time."
-        in read(unavailable_helper),
+        in read(unavailable_helper)
+        and "Hide" in read(unavailable_helper)
+        and "omarchy-install-hide" in read(unavailable_helper)
+        and "omarchy-install-hide-all-unavailable" in read(unavailable_helper)
+        and "exit 130" in read(unavailable_helper),
         "shared aarch64 unavailable helper ships in the native overlay",
     )
     check(
         refuse_helper.is_file()
         and refuse_helper.stat().st_mode & stat.S_IXUSR != 0
         and "aarch64-unavailable-packages" in read(refuse_helper)
-        and "omarchy-pkg-unavailable-arm" in read(refuse_helper),
+        and 'omarchy-pkg-unavailable-arm "$name" "$package"' in read(refuse_helper),
         "aarch64 unavailable package refuse helper ships in the native overlay",
+    )
+    visible_helper = GUEST / "native-overlay/usr/local/bin/omarchy-install-menu-visible"
+    has_hidden_helper = GUEST / "native-overlay/usr/local/bin/omarchy-install-has-hidden"
+    restore_helper = GUEST / "native-overlay/usr/local/bin/omarchy-install-restore-hidden"
+    install_ids = GUEST / "native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-install-ids"
+    hide_menu_patch = read(GUEST / "patches/omarchy/aarch64-hide-unavailable-installs.patch")
+    check(
+        visible_helper.is_file()
+        and has_hidden_helper.is_file()
+        and restore_helper.is_file()
+        and install_ids.is_file()
+        and "hide-all-aarch64-unavailable" in read(visible_helper)
+        and "hidden-install-packages" in read(visible_helper)
+        and "ghostty" in read(install_ids)
+        and "geforce-now" in read(install_ids)
+        and "retroarch" in read(install_ids)
+        and "omarchy-install-menu-visible ghostty" in hide_menu_patch
+        and "omarchy-install-menu-visible retroarch" in hide_menu_patch
+        and "omarchy-install-menu-visible sublime-text-4" in hide_menu_patch
+        and "omarchy-install-menu-visible ollama" in hide_menu_patch
+        and '"setup.restore-hidden-installs"' in hide_menu_patch
+        and "omarchy-install-has-hidden" in hide_menu_patch,
+        "aarch64 Install hide helpers and menu gates ship in the overlay/backport",
     )
     check(
         not (GUEST / "native-overlay/usr/local/bin/omarchy-pkg-add").exists()
@@ -261,7 +296,17 @@ def main() -> None:
         and "minecraft-launcher\tMinecraft" in unavailable_package_text
         and "heroic-games-launcher-bin\tHeroic" in unavailable_package_text
         and "umu-launcher\tWine game launcher" in unavailable_package_text
-        and "wine-staging\tWine" in unavailable_package_text,
+        and "wine-staging\tWine" in unavailable_package_text
+        and "sublime-text-4\tSublime Text" in unavailable_package_text
+        and "visual-studio-code-bin\tVSCode" in unavailable_package_text
+        and "zed\tZed" in unavailable_package_text
+        and "nordvpn-bin\tNordVPN" in unavailable_package_text
+        and "once-bin\tONCE" in unavailable_package_text
+        and "openai-codex-desktop\tChatGPT Desktop" in unavailable_package_text
+        and "xpadneo-dkms\tXbox Controllers" in unavailable_package_text
+        and "bitwarden\tBitwarden" in unavailable_package_text
+        and "ollama\tOllama" in unavailable_package_text
+        and "ollama-cuda\tOllama" in unavailable_package_text,
         "aarch64 unavailable package denylist covers the audited Install-menu gaps",
     )
 
@@ -536,7 +581,10 @@ def main() -> None:
         '"$root/usr/local/bin/omarchy-arch-aarch64"' in configure
         and '"$root/usr/local/bin/omarchy-pkg-unavailable-arm"' in configure
         and '"$root/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable"' in configure
-        and "aarch64-unavailable-packages" in configure,
+        and '"$root/usr/local/bin/omarchy-install-menu-visible"' in configure
+        and '"$root/usr/local/bin/omarchy-install-restore-hidden"' in configure
+        and "aarch64-unavailable-packages" in configure
+        and "aarch64-unavailable-install-ids" in configure,
         "rootfs configuration marks the aarch64 availability helpers executable",
     )
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -169,6 +169,10 @@ def main() -> None:
             "notification-hover-close",
             "notification-screen-privacy",
             "update-free-space-message",
+            "pkg-add-aarch64-unavailable",
+            "pkg-aur-add-aarch64-unavailable",
+            "dropbox-aarch64-unavailable",
+            "geforce-now-aarch64-unavailable",
         ],
         "Omarchy backports are explicitly ordered and identified",
     )
@@ -195,6 +199,70 @@ def main() -> None:
         and "/usr/share/try-omarchy/build-spec.json" in update_free_space_patch
         and "df -h /" in update_free_space_patch,
         "update free-space backport clarifies the guest VM disk requirement",
+    )
+    geforce_unavailable_patch = read(GUEST / "patches/omarchy/geforce-now-aarch64-unavailable.patch")
+    check(
+        "exec omarchy-pkg-unavailable-arm 'NVIDIA GeForce NOW'" in geforce_unavailable_patch,
+        "GeForce NOW aarch64 backport fails via the shared unavailable helper",
+    )
+    dropbox_unavailable_patch = read(GUEST / "patches/omarchy/dropbox-aarch64-unavailable.patch")
+    check(
+        "exec omarchy-pkg-unavailable-arm Dropbox" in dropbox_unavailable_patch
+        and "omarchy-plugin-enable omarchy.dropbox" in dropbox_unavailable_patch,
+        "Dropbox aarch64 backport stops before tray setup via the shared unavailable helper",
+    )
+    pkg_add_patch = read(GUEST / "patches/omarchy/omarchy-pkg-add-aarch64-unavailable.patch")
+    pkg_aur_patch = read(GUEST / "patches/omarchy/omarchy-pkg-aur-add-aarch64-unavailable.patch")
+    check(
+        "/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable" in pkg_add_patch
+        and "/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable" in pkg_aur_patch,
+        "pkg-add/pkg-aur-add backports refuse known aarch64-unavailable packages",
+    )
+    arch_helper = GUEST / "native-overlay/usr/local/bin/omarchy-arch-aarch64"
+    unavailable_helper = GUEST / "native-overlay/usr/local/bin/omarchy-pkg-unavailable-arm"
+    refuse_helper = GUEST / "native-overlay/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable"
+    unavailable_packages = GUEST / "native-overlay/usr/local/share/try-omarchy/aarch64-unavailable-packages"
+    check(
+        arch_helper.is_file()
+        and arch_helper.stat().st_mode & stat.S_IXUSR != 0
+        and '[[ $(uname -m) == aarch64 ]]' in read(arch_helper),
+        "aarch64 architecture predicate ships in the native overlay",
+    )
+    check(
+        unavailable_helper.is_file()
+        and unavailable_helper.stat().st_mode & stat.S_IXUSR != 0
+        and "not available via pacman/AUR for aarch64 at this time."
+        in read(unavailable_helper),
+        "shared aarch64 unavailable helper ships in the native overlay",
+    )
+    check(
+        refuse_helper.is_file()
+        and refuse_helper.stat().st_mode & stat.S_IXUSR != 0
+        and "aarch64-unavailable-packages" in read(refuse_helper)
+        and "omarchy-pkg-unavailable-arm" in read(refuse_helper),
+        "aarch64 unavailable package refuse helper ships in the native overlay",
+    )
+    check(
+        not (GUEST / "native-overlay/usr/local/bin/omarchy-pkg-add").exists()
+        and not (GUEST / "native-overlay/usr/local/bin/omarchy-pkg-aur-add").exists(),
+        "pkg-add refusal is authenticity-backed rather than PATH-wrapped",
+    )
+    unavailable_package_text = read(unavailable_packages)
+    check(
+        unavailable_packages.is_file()
+        and "ghostty\tGhostty" in unavailable_package_text
+        and "microsoft-edge-stable-bin\tEdge" in unavailable_package_text
+        and "spotify\tSpotify" in unavailable_package_text
+        and "dropbox\tDropbox" in unavailable_package_text
+        and "cursor-bin\tCursor" in unavailable_package_text
+        and "grok-bot\tGrok Bot" in unavailable_package_text
+        and "lmstudio-bin\tLM Studio" in unavailable_package_text
+        and "steam\tSteam" in unavailable_package_text
+        and "minecraft-launcher\tMinecraft" in unavailable_package_text
+        and "heroic-games-launcher-bin\tHeroic" in unavailable_package_text
+        and "umu-launcher\tWine game launcher" in unavailable_package_text
+        and "wine-staging\tWine" in unavailable_package_text,
+        "aarch64 unavailable package denylist covers the audited Install-menu gaps",
     )
 
     post_build_installers = authenticity["postBuildUserInstallers"]
@@ -464,6 +532,13 @@ def main() -> None:
     )
 
     configure = read(GUEST / "scripts/configure-rootfs.sh")
+    check(
+        '"$root/usr/local/bin/omarchy-arch-aarch64"' in configure
+        and '"$root/usr/local/bin/omarchy-pkg-unavailable-arm"' in configure
+        and '"$root/usr/local/bin/omarchy-pkg-refuse-aarch64-unavailable"' in configure
+        and "aarch64-unavailable-packages" in configure,
+        "rootfs configuration marks the aarch64 availability helpers executable",
+    )
     check("factory-overlay" in configure and "native-overlay" in configure, "rootfs receives only native factory overlays")
     check(
         "compat/ttfx-arm64" not in configure and not (GUEST / "compat/ttfx-arm64").exists(),


### PR DESCRIPTION
## Summary

@themartiano — proposed UX path for aarch64 Install failures on Try Omarchy (seeking your direction before treating this as merge-ready).

Today many Install-menu apps still fail with bare `target not found`. [#138](https://github.com/omacom/try-omarchy/pull/138) keeps those rows visible and fails with a shared message. This PR **includes that foundation** and proposes a small next step for decluttering:

1. Show the shared unavailable message (no fake `Done!`).
2. Opt-in prompts (default **N**):
   - `Hide <app> from the Install menu? [y/N]`
   - `Hide all known unavailable Install apps too? [y/N]`
3. Persist under `~/.local/state/try-omarchy/`.
4. Setup → **Restore hidden Install apps** to undo.
5. Expand the denylist for Install paths that still leaked `target not found` in local testing (RetroArch cores spam, Sublime, VSCode, Zed, NordVPN, ONCE, ChatGPT Desktop, Xbox Controllers, Bitwarden, Ollama, …).

Glyph overlays were tried locally and dropped (truncation / misaligned labels). Hide-on-refuse felt like the better product shape.

If you prefer the message-only change first, land/keep [#138](https://github.com/omacom/try-omarchy/pull/138) and we can rebase this on top — or close #138 in favor of this single proposal.

## Test plan
- [x] Ephemeral second VM (SSH 2223; reserved Codex VM untouched)
- [x] Steam / Minecraft / Ghostty: message + hide prompts; no `Done!`
- [x] Hide one / hide all → rows disappear from Install (+ Super+Space)
- [x] Setup → Restore hidden Install apps brings them back
- [x] RetroArch / Sublime / Ollama: shared message instead of `target not found`
- [ ] Maintainer UX sign-off on prompt copy + whether hide-all belongs in-flow vs Setup-only

Addresses #137; related to #57 and #18. Includes the message-only foundation from #138.
