### PR TITLE
[feat] Add opt-in Touch ID authentication for guest sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,24 +249,34 @@ Loopback binding prevents devices on Wi-Fi, Ethernet, or the wider LAN from
 connecting. It does not isolate the listener from other users or processes on
 the same Mac; guest SSH authentication is still required.
 
-### Experimental Touch ID for sudo
+### Touch ID for sudo
 
-The experimental native authentication bridge can enroll this Mac and use
-Touch ID as a sufficient authentication method for guest `sudo`:
+The native authentication bridge can enroll this Mac and use
+Touch ID as a sufficient authentication method for guest `sudo`. Open
+**Omarchy Menu → Setup → Security → Touch ID for sudo**, or run:
 
 ```sh
-try-omarchy-touch-id-enroll
-try-omarchy-touch-id-test
+try-omarchy-touch-id
 ```
 
-Enrollment requires the normal guest sudo path once, then pins a public key for
-a Touch ID-protected Secure Enclave signing key. The Mac stores only the
-Secure Enclave's device-bound encrypted key representation. Every later approval is signed
-over a root-private guest ID, fresh challenge, the sudo user and requesting user,
-the interactive TTY, and a 15-second validity window. Each enrolled guest has a
-distinct host signing key. The QEMU window must be frontmost. Cancellation,
-invalid responses, missing enrollment, and unavailable Touch ID all fall back
-to the normal guest password; no login or screen-unlock PAM policy is changed.
+The integration ships disabled. Enabling first requires the normal guest sudo
+password, then Touch ID creates and proves possession of a Secure Enclave
+signing key. Only after that succeeds is the narrowly scoped sudo PAM rule
+installed. The menu then offers Test, Re-pair, and Disable actions.
+
+The Mac stores only the Secure Enclave's device-bound encrypted key
+representation. Every later approval is signed over a root-private guest ID,
+fresh challenge, the sudo user and requesting user, the interactive TTY, and a
+15-second validity window. Each enrolled guest has a distinct host signing key.
+The QEMU window must be frontmost. Cancellation, invalid responses, missing
+enrollment, and unavailable Touch ID all fall back to the normal guest password;
+no login or screen-unlock PAM policy is changed.
+
+Enrollment persists across guest and Mac restarts for the same persistent VM,
+Mac, and macOS account. Factory Reset, moving the VM to another Mac or account,
+or changing the enrolled Touch ID fingerprint set requires re-pairing. Disabling
+removes the guest enrollment and, while the host bridge is available, its wrapped
+Secure Enclave key representation.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,25 @@ Loopback binding prevents devices on Wi-Fi, Ethernet, or the wider LAN from
 connecting. It does not isolate the listener from other users or processes on
 the same Mac; guest SSH authentication is still required.
 
+### Experimental Touch ID for sudo
+
+The experimental native authentication bridge can enroll this Mac and use
+Touch ID as a sufficient authentication method for guest `sudo`:
+
+```sh
+try-omarchy-touch-id-enroll
+try-omarchy-touch-id-test
+```
+
+Enrollment requires the normal guest sudo path once, then pins a public key for
+a Touch ID-protected Secure Enclave signing key. The Mac stores only the
+Secure Enclave's device-bound encrypted key representation. Every later approval is signed
+over a root-private guest ID, fresh challenge, the sudo user and requesting user,
+the interactive TTY, and a 15-second validity window. Each enrolled guest has a
+distinct host signing key. The QEMU window must be frontmost. Cancellation,
+invalid responses, missing enrollment, and unavailable Touch ID all fall back
+to the normal guest password; no login or screen-unlock PAM policy is changed.
+
 ## Requirements
 
 - Apple Silicon Mac (`arm64`)

--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ The QEMU window must be frontmost. Cancellation, invalid responses, missing
 enrollment, and unavailable Touch ID all fall back to the normal guest password;
 no login or screen-unlock PAM policy is changed.
 
+If Touch ID falls back, sudo displays the reason before asking for the guest
+password. Signed approvals require synchronized Mac and guest clocks; factory
+images enable `systemd-timesyncd` at boot. On an existing guest with clock drift,
+run `sudo systemctl enable --now systemd-timesyncd.service`, then check
+`timedatectl` for `System clock synchronized: yes` before retrying.
+
 Enrollment persists across guest and Mac restarts for the same persistent VM,
 Mac, and macOS account. Factory Reset, moving the VM to another Mac or account,
 or changing the enrolled Touch ID fingerprint set requires re-pairing. Disabling

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ images enable `systemd-timesyncd` at boot. On an existing guest with clock drift
 run `sudo systemctl enable --now systemd-timesyncd.service`, then check
 `timedatectl` for `System clock synchronized: yes` before retrying.
 
+The Touch ID test refuses guest-password fallback and returns failure if sudo
+cannot authenticate. A passwordless sudo policy can also satisfy this check;
+the result only demonstrates Touch ID when its prompt appeared. Unanswered Mac
+prompts are canceled after 55 seconds, before the guest's 65-second timeout.
+Late responses are discarded without extending the current request's deadline.
+
 Enrollment persists across guest and Mac restarts for the same persistent VM,
 Mac, and macOS account. Factory Reset, moving the VM to another Mac or account,
 or changing the enrolled Touch ID fingerprint set requires re-pairing. Disabling

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,27 @@ is reading the camera. Camera permission, capture failure, or device removal is
 non-fatal to the VM; the launcher can restart the optional bridge without
 restarting Omarchy.
 
+An experimental root-only authentication port
+(`dev.tryomarchy.authentication`) lets the guest's `sudo` PAM policy request a
+fixed-purpose macOS Touch ID prompt. Enrollment creates a non-exportable P-256
+signing key in the Mac's Secure Enclave for a root-private random guest ID and
+pins its public key inside that guest. The host stores the Secure Enclave's
+device-bound encrypted key representation outside the Keychain, so local ad-hoc
+test builds do not need a provisioned Keychain access group. Each authentication uses a new 256-bit
+challenge. The host signs a
+canonical payload that binds the request ID, challenge, PAM user, requesting
+user, `sudo` service, interactive TTY, guest ID, signing-key ID, and a 15-second validity
+window. The guest verifies that signature with OpenSSL before PAM can return
+success. It never accepts an unsigned approval boolean.
+
+The QEMU window must be frontmost, the QEMU process identity must still match,
+and the host owns both enrollment and sudo prompt text. The PAM module is
+`sufficient`: a denial, missing enrollment, unavailable bridge, invalid
+signature, non-interactive request, or timeout falls through to Omarchy's
+normal password authentication. This prototype does not authenticate login or
+screen-unlock flows, cannot bind approval to the exact sudo command because PAM
+does not expose it, and is not a general guest-to-host approval service.
+
 When a folder is chosen on the start menu, QEMU exports it over virtio-9p with
 `security_model=none`, so every host file operation runs as the Mac user and
 the Mac keeps real modes and ownership. A small QEMU patch adds

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ is reading the camera. Camera permission, capture failure, or device removal is
 non-fatal to the VM; the launcher can restart the optional bridge without
 restarting Omarchy.
 
-An experimental root-only authentication port
+A root-only authentication port
 (`dev.tryomarchy.authentication`) lets the guest's `sudo` PAM policy request a
 fixed-purpose macOS Touch ID prompt. Enrollment creates a non-exportable P-256
 signing key in the Mac's Secure Enclave for a root-private random guest ID and
@@ -77,13 +77,22 @@ user, `sudo` service, interactive TTY, guest ID, signing-key ID, and a 15-second
 window. The guest verifies that signature with OpenSSL before PAM can return
 success. It never accepts an unsigned approval boolean.
 
+The integration's binaries and root-only device rule are present in the factory
+image, but the sudo PAM policy remains unchanged until the user opts in through
+**Setup → Security → Touch ID for sudo**. The root control enrolls first and
+atomically adds the PAM rule only after successful guest-password and Touch ID
+authentication. Disable removes that exact rule before deleting guest state and
+requesting deletion of the corresponding host key representation. Re-pair runs
+the disable and enable transitions while preserving password fallback.
+
 The QEMU window must be frontmost, the QEMU process identity must still match,
-and the host owns both enrollment and sudo prompt text. The PAM module is
-`sufficient`: a denial, missing enrollment, unavailable bridge, invalid
-signature, non-interactive request, or timeout falls through to Omarchy's
-normal password authentication. This prototype does not authenticate login or
-screen-unlock flows, cannot bind approval to the exact sudo command because PAM
-does not expose it, and is not a general guest-to-host approval service.
+and the host owns both enrollment and sudo prompt text. When enabled, the PAM
+module is `sufficient`: a denial, missing enrollment, unavailable bridge,
+invalid signature, non-interactive request, or timeout falls through to
+Omarchy's normal password authentication. This integration does not authenticate
+login or screen-unlock flows, cannot bind approval to the exact sudo command
+because PAM does not expose it, and is not a general guest-to-host approval
+service.
 
 When a folder is chosen on the start menu, QEMU exports it over virtio-9p with
 `security_model=none`, so every host file operation runs as the Mac user and

--- a/guest/native-overlay/etc/udev/rules.d/93-omarchy-native-authentication.rules
+++ b/guest/native-overlay/etc/udev/rules.d/93-omarchy-native-authentication.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="virtio-ports", ATTR{name}=="dev.tryomarchy.authentication", OWNER="root", GROUP="root", MODE="0600"

--- a/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
+++ b/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+CONTROL=/usr/local/sbin/try-omarchy-touch-id-control
+
+enabled() {
+  grep -Fxq "$PAM_LINE" /etc/pam.d/sudo 2>/dev/null
+}
+
+confirm() {
+  gum confirm "$1"
+}
+
+refresh_menu() {
+  omarchy menu refresh >/dev/null 2>&1 || true
+}
+
+enable_touch_id() {
+  if enabled; then
+    echo "Touch ID is already enabled for sudo."
+    return
+  fi
+  printf '%s\n' \
+    "Touch ID will approve sudo only while this Try Omarchy window is focused." \
+    "Your guest password remains available as fallback." \
+    "" \
+    "Enabling requires your guest sudo password, followed by Touch ID on this Mac."
+  confirm "Enable Touch ID for sudo?" || exit 130
+  sudo -k
+  sudo "$CONTROL" enable
+  refresh_menu
+  sudo -k
+  sudo true
+  echo "Touch ID for sudo is enabled and verified."
+}
+
+disable_touch_id() {
+  if ! enabled; then
+    echo "Touch ID is already disabled for sudo."
+    return
+  fi
+  confirm "Disable Touch ID for sudo?" || exit 130
+  sudo "$CONTROL" disable
+  refresh_menu
+}
+
+repair_touch_id() {
+  printf '%s\n' \
+    "Re-pairing removes the current guest enrollment and creates a new" \
+    "Touch ID-protected key for this guest."
+  confirm "Re-pair Touch ID for sudo?" || exit 130
+  sudo -k
+  sudo "$CONTROL" repair
+  refresh_menu
+  sudo -k
+  sudo true
+  echo "Touch ID for sudo was re-paired and verified."
+}
+
+manage_touch_id() {
+  if ! enabled; then
+    enable_touch_id
+    return
+  fi
+  local choice
+  choice=$(printf '%s\n' "Test Touch ID" "Re-pair Touch ID" "Disable Touch ID" | \
+    gum choose --header "Touch ID for sudo is enabled") || exit 130
+  case "$choice" in
+    "Test Touch ID")
+      exec try-omarchy-touch-id-test
+      ;;
+    "Re-pair Touch ID")
+      repair_touch_id
+      ;;
+    "Disable Touch ID")
+      disable_touch_id
+      ;;
+  esac
+}
+
+case "${1:-manage}" in
+  manage)
+    manage_touch_id
+    ;;
+  enable)
+    enable_touch_id
+    ;;
+  disable)
+    disable_touch_id
+    ;;
+  repair)
+    repair_touch_id
+    ;;
+  status)
+    if enabled; then
+      [[ ${2:-} == --quiet ]] || echo "enabled"
+      exit 0
+    fi
+    [[ ${2:-} == --quiet ]] || echo "disabled"
+    exit 1
+    ;;
+  *)
+    echo "Usage: try-omarchy-touch-id [manage|enable|disable|repair|status [--quiet]]" >&2
+    exit 64
+    ;;
+esac

--- a/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
+++ b/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
@@ -3,10 +3,11 @@
 set -euo pipefail
 
 PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+CURRENT_PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid stdout /usr/local/lib/try-omarchy/native-authentication-broker pam'
 CONTROL=/usr/local/sbin/try-omarchy-touch-id-control
 
 enabled() {
-  grep -Fxq "$PAM_LINE" /etc/pam.d/sudo 2>/dev/null
+  grep -Fxq -e "$PAM_LINE" -e "$CURRENT_PAM_LINE" /etc/pam.d/sudo 2>/dev/null
 }
 
 confirm() {

--- a/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
+++ b/guest/native-overlay/usr/local/bin/try-omarchy-touch-id
@@ -32,9 +32,8 @@ enable_touch_id() {
   sudo -k
   sudo "$CONTROL" enable
   refresh_menu
-  sudo -k
-  sudo true
-  echo "Touch ID for sudo is enabled and verified."
+  try-omarchy-touch-id-test
+  echo "Touch ID for sudo is enabled; the password-free sudo check passed."
 }
 
 disable_touch_id() {
@@ -55,9 +54,8 @@ repair_touch_id() {
   sudo -k
   sudo "$CONTROL" repair
   refresh_menu
-  sudo -k
-  sudo true
-  echo "Touch ID for sudo was re-paired and verified."
+  try-omarchy-touch-id-test
+  echo "Touch ID for sudo was re-paired; the password-free sudo check passed."
 }
 
 manage_touch_id() {

--- a/guest/native-overlay/usr/local/bin/try-omarchy-touch-id-test
+++ b/guest/native-overlay/usr/local/bin/try-omarchy-touch-id-test
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+sudo -k
+if sudo true; then
+  echo "sudo authenticated. Touch ID was used if no guest password was entered."
+fi

--- a/guest/native-overlay/usr/local/bin/try-omarchy-touch-id-test
+++ b/guest/native-overlay/usr/local/bin/try-omarchy-touch-id-test
@@ -3,6 +3,9 @@
 set -eu
 
 sudo -k
-if sudo true; then
-  echo "sudo authenticated. Touch ID was used if no guest password was entered."
+if SUDO_ASKPASS=/bin/false sudo -A true; then
+  echo "sudo authenticated without a guest password. Touch ID was used if its prompt appeared."
+else
+  echo "Touch ID sudo check failed; password fallback was not accepted." >&2
+  exit 1
 fi

--- a/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
@@ -23,7 +23,9 @@ import uuid
 PORT = Path("/dev/virtio-ports/dev.tryomarchy.authentication")
 STATE = Path("/var/lib/try-omarchy/native-authentication.json")
 OPENSSL = Path("/usr/bin/openssl")
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
+CURRENT_STATE_VERSIONS = frozenset({PROTOCOL_VERSION})
+MIGRATABLE_STATE_VERSIONS = frozenset({2, PROTOCOL_VERSION})
 MAXIMUM_LINE_BYTES = 4096
 APPROVAL_LIFETIME_SECONDS = 15
 CLOCK_SKEW_SECONDS = 5
@@ -91,7 +93,7 @@ def validate_request(request: dict[str, object]) -> None:
         set(request) != REQUEST_FIELDS
         or request.get("type") != "authorize"
         or request.get("version") != PROTOCOL_VERSION
-        or request.get("operation") not in {"enroll", "sudo"}
+        or request.get("operation") not in {"disable", "enroll", "sudo"}
         or request.get("service") != "sudo"
         or not isinstance(request.get("requestId"), str)
         or not isinstance(request.get("challenge"), str)
@@ -111,9 +113,9 @@ def validate_request(request: dict[str, object]) -> None:
         or not HEX_32_PATTERN.fullmatch(request["guestId"])
     ):
         raise AuthorizationError("invalid request identity")
-    if request["operation"] == "enroll":
+    if request["operation"] in {"disable", "enroll"}:
         if request["user"] or request["requestingUser"] or request["tty"]:
-            raise AuthorizationError("enrollment request carries sudo context")
+            raise AuthorizationError("control request carries sudo context")
     elif (
         not ACCOUNT_PATTERN.fullmatch(request["user"])
         or not ACCOUNT_PATTERN.fullmatch(request["requestingUser"])
@@ -142,6 +144,7 @@ def decode_response(line: bytes, request: dict[str, object]) -> dict[str, object
         raise AuthorizationError("host sent an invalid authentication response")
     for field in (
         "operation",
+        "guestId",
         "requestId",
         "challenge",
         "user",
@@ -151,6 +154,17 @@ def decode_response(line: bytes, request: dict[str, object]) -> dict[str, object
     ):
         if response.get(field) != request[field]:
             raise AuthorizationError("host response does not match the authentication request")
+    if request["operation"] == "disable":
+        if (
+            response.get("issuedAt") != 0
+            or response.get("expiresAt") != 0
+            or response.get("keyId") != ""
+            or response.get("publicKey") != ""
+            or response.get("signature") != ""
+        ):
+            raise AuthorizationError("host disable response contains authorization material")
+        return response
+
     if not response["approved"]:
         if (
             response.get("issuedAt") != 0
@@ -200,7 +214,7 @@ def authorization_payload(
     request: dict[str, object], response: dict[str, object]
 ) -> bytes:
     fields = [
-        "try-omarchy-native-authentication-v2",
+        "try-omarchy-native-authentication-v3",
         request["guestId"],
         request["operation"],
         request["requestId"],
@@ -282,6 +296,11 @@ def verify_approval(
     if not verify_signature(public_key, signature, authorization_payload(request, response)):
         raise AuthorizationError("host approval signature is invalid")
     return public_key
+
+
+def verify_disable_response(response: dict[str, object]) -> None:
+    if not response["approved"]:
+        raise AuthorizationError("macOS did not remove the Touch ID key")
 
 
 def write_all(descriptor: int, payload: bytes) -> None:
@@ -421,6 +440,7 @@ def load_state(
     path: Path = STATE,
     *,
     enforce_root_owner: bool = True,
+    accepted_versions: frozenset[int] = CURRENT_STATE_VERSIONS,
 ) -> tuple[bytes, str]:
     descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
     try:
@@ -443,7 +463,7 @@ def load_state(
     if (
         not isinstance(value, dict)
         or set(value) != STATE_FIELDS
-        or value.get("version") != PROTOCOL_VERSION
+        or value.get("version") not in accepted_versions
         or not isinstance(value.get("guestId"), str)
         or not HEX_32_PATTERN.fullmatch(value["guestId"])
         or not isinstance(value.get("keyId"), str)
@@ -461,6 +481,56 @@ def load_state(
     return public_key, value["guestId"]
 
 
+def migrate_state(
+    path: Path = STATE,
+    *,
+    enforce_root_owner: bool = True,
+) -> bool:
+    try:
+        public_key, guest_id = load_state(
+            path,
+            enforce_root_owner=enforce_root_owner,
+            accepted_versions=MIGRATABLE_STATE_VERSIONS,
+        )
+    except FileNotFoundError:
+        return False
+    save_state(
+        public_key,
+        guest_id,
+        path,
+        enforce_root_owner=enforce_root_owner,
+    )
+    return True
+
+
+def remove_state(path: Path = STATE, *, enforce_root_owner: bool = True) -> None:
+    parent = path.parent
+    try:
+        parent_info = parent.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISDIR(parent_info.st_mode) or (
+        enforce_root_owner and parent_info.st_uid != 0
+    ):
+        raise AuthorizationError("authentication state directory is unsafe")
+    directory = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        try:
+            info = os.stat(path.name, dir_fd=directory, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or stat.S_IMODE(info.st_mode) != 0o600
+            or (enforce_root_owner and info.st_uid != 0)
+        ):
+            raise AuthorizationError("authentication enrollment state is unsafe")
+        os.unlink(path.name, dir_fd=directory)
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
 def enroll() -> None:
     if STATE.exists():
         _, guest_id = load_state()
@@ -471,6 +541,31 @@ def enroll() -> None:
     public_key = verify_approval(request, response)
     save_state(public_key, guest_id)
     print(f"Touch ID sudo enrolled for host key {response['keyId'][:12]}.")
+
+
+def disable() -> None:
+    try:
+        _, guest_id = load_state()
+    except FileNotFoundError:
+        print("Touch ID sudo is already disabled.")
+        return
+
+    host_error: Exception | None = None
+    try:
+        request = make_request("disable", guest_id=guest_id)
+        response = exchange(request, timeout=5)
+        verify_disable_response(response)
+    except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError) as error:
+        host_error = error
+
+    remove_state()
+    if host_error is None:
+        print("Touch ID sudo enrollment removed from this guest and Mac.")
+    else:
+        print(
+            f"Touch ID sudo disabled locally; macOS key cleanup was unavailable: {host_error}",
+            file=sys.stderr,
+        )
 
 
 def authenticate_pam() -> bool:
@@ -504,8 +599,11 @@ def authenticate_pam() -> bool:
 
 
 def main() -> int:
-    if len(sys.argv) != 2 or sys.argv[1] not in {"enroll", "pam"}:
-        print("usage: native-authentication-broker enroll|pam", file=sys.stderr)
+    if len(sys.argv) != 2 or sys.argv[1] not in {"disable", "enroll", "migrate", "pam"}:
+        print(
+            "usage: native-authentication-broker disable|enroll|migrate|pam",
+            file=sys.stderr,
+        )
         return 2
     if sys.argv[1] == "pam":
         return 0 if authenticate_pam() else 1
@@ -513,10 +611,15 @@ def main() -> int:
         print("enrollment must run as root", file=sys.stderr)
         return 1
     try:
-        enroll()
+        if sys.argv[1] == "disable":
+            disable()
+        elif sys.argv[1] == "migrate":
+            migrate_state()
+        else:
+            enroll()
         return 0
     except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError) as error:
-        print(f"Touch ID enrollment failed: {error}", file=sys.stderr)
+        print(f"Touch ID {sys.argv[1]} failed: {error}", file=sys.stderr)
         return 1
 
 

--- a/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
@@ -1,0 +1,524 @@
+#!/usr/bin/python3 -I
+"""Root-only broker for signed Try Omarchy Touch ID sudo approvals."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import select
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+
+PORT = Path("/dev/virtio-ports/dev.tryomarchy.authentication")
+STATE = Path("/var/lib/try-omarchy/native-authentication.json")
+OPENSSL = Path("/usr/bin/openssl")
+PROTOCOL_VERSION = 2
+MAXIMUM_LINE_BYTES = 4096
+APPROVAL_LIFETIME_SECONDS = 15
+CLOCK_SKEW_SECONDS = 5
+ACCOUNT_PATTERN = re.compile(r"[a-z_][a-z0-9_-]{0,31}")
+TTY_PATTERN = re.compile(r"/dev/(?:pts/[0-9]+|tty[0-9]+)")
+VPORT_TARGET_PATTERN = re.compile(r"\.\./(vport[0-9]+p[0-9]+)")
+HEX_32_PATTERN = re.compile(r"[0-9a-f]{64}")
+P256_SPKI_PREFIX = bytes.fromhex(
+    "3059301306072a8648ce3d020106082a8648ce3d030107034200"
+)
+REQUEST_FIELDS = {
+    "challenge",
+    "guestId",
+    "operation",
+    "requestId",
+    "requestingUser",
+    "service",
+    "tty",
+    "type",
+    "user",
+    "version",
+}
+RESPONSE_FIELDS = REQUEST_FIELDS | {
+    "approved",
+    "expiresAt",
+    "issuedAt",
+    "keyId",
+    "publicKey",
+    "signature",
+}
+STATE_FIELDS = {"guestId", "keyId", "publicKey", "version"}
+
+
+class AuthorizationError(Exception):
+    pass
+
+
+def make_request(
+    operation: str,
+    *,
+    guest_id: str,
+    user: str = "",
+    requesting_user: str = "",
+    service: str = "sudo",
+    tty: str = "",
+) -> dict[str, object]:
+    request: dict[str, object] = {
+        "type": "authorize",
+        "version": PROTOCOL_VERSION,
+        "operation": operation,
+        "requestId": str(uuid.uuid4()),
+        "challenge": secrets.token_hex(32),
+        "guestId": guest_id,
+        "user": user,
+        "requestingUser": requesting_user,
+        "service": service,
+        "tty": tty,
+    }
+    validate_request(request)
+    return request
+
+
+def validate_request(request: dict[str, object]) -> None:
+    if (
+        set(request) != REQUEST_FIELDS
+        or request.get("type") != "authorize"
+        or request.get("version") != PROTOCOL_VERSION
+        or request.get("operation") not in {"enroll", "sudo"}
+        or request.get("service") != "sudo"
+        or not isinstance(request.get("requestId"), str)
+        or not isinstance(request.get("challenge"), str)
+        or not isinstance(request.get("guestId"), str)
+        or not isinstance(request.get("user"), str)
+        or not isinstance(request.get("requestingUser"), str)
+        or not isinstance(request.get("tty"), str)
+    ):
+        raise AuthorizationError("invalid authentication request")
+    try:
+        identifier = str(uuid.UUID(request["requestId"]))
+    except ValueError as error:
+        raise AuthorizationError("invalid request identifier") from error
+    if (
+        identifier != request["requestId"]
+        or not HEX_32_PATTERN.fullmatch(request["challenge"])
+        or not HEX_32_PATTERN.fullmatch(request["guestId"])
+    ):
+        raise AuthorizationError("invalid request identity")
+    if request["operation"] == "enroll":
+        if request["user"] or request["requestingUser"] or request["tty"]:
+            raise AuthorizationError("enrollment request carries sudo context")
+    elif (
+        not ACCOUNT_PATTERN.fullmatch(request["user"])
+        or not ACCOUNT_PATTERN.fullmatch(request["requestingUser"])
+        or not TTY_PATTERN.fullmatch(request["tty"])
+    ):
+        raise AuthorizationError("invalid sudo authentication context")
+
+
+def encode_request(request: dict[str, object]) -> bytes:
+    validate_request(request)
+    return json.dumps(request, separators=(",", ":"), sort_keys=True).encode("ascii") + b"\n"
+
+
+def decode_response(line: bytes, request: dict[str, object]) -> dict[str, object]:
+    try:
+        response = json.loads(line)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AuthorizationError("host sent invalid authentication JSON") from error
+    if (
+        not isinstance(response, dict)
+        or set(response) != RESPONSE_FIELDS
+        or response.get("type") != "authorization-result"
+        or response.get("version") != PROTOCOL_VERSION
+        or not isinstance(response.get("approved"), bool)
+    ):
+        raise AuthorizationError("host sent an invalid authentication response")
+    for field in (
+        "operation",
+        "requestId",
+        "challenge",
+        "user",
+        "requestingUser",
+        "service",
+        "tty",
+    ):
+        if response.get(field) != request[field]:
+            raise AuthorizationError("host response does not match the authentication request")
+    if not response["approved"]:
+        if (
+            response.get("issuedAt") != 0
+            or response.get("expiresAt") != 0
+            or response.get("keyId") != ""
+            or response.get("publicKey") != ""
+            or response.get("signature") != ""
+        ):
+            raise AuthorizationError("host denial contains unexpected authorization material")
+        return response
+
+    issued_at = response.get("issuedAt")
+    expires_at = response.get("expiresAt")
+    key_id = response.get("keyId")
+    public_key_text = response.get("publicKey")
+    signature_text = response.get("signature")
+    if (
+        not isinstance(issued_at, int)
+        or isinstance(issued_at, bool)
+        or not isinstance(expires_at, int)
+        or isinstance(expires_at, bool)
+        or not isinstance(key_id, str)
+        or not HEX_32_PATTERN.fullmatch(key_id)
+        or not isinstance(public_key_text, str)
+        or not isinstance(signature_text, str)
+    ):
+        raise AuthorizationError("host approval has invalid authorization material")
+    public_key = decode_base64(public_key_text, "public key")
+    signature = decode_base64(signature_text, "signature")
+    if len(public_key) != 65 or public_key[0] != 0x04:
+        raise AuthorizationError("host public key is not an uncompressed P-256 point")
+    if hashlib.sha256(public_key).hexdigest() != key_id:
+        raise AuthorizationError("host public key identifier does not match")
+    if not 64 <= len(signature) <= 80 or signature[0] != 0x30:
+        raise AuthorizationError("host signature is not DER-encoded P-256 ECDSA")
+    return response
+
+
+def decode_base64(value: str, label: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error) as error:
+        raise AuthorizationError(f"host {label} is not valid base64") from error
+
+
+def authorization_payload(
+    request: dict[str, object], response: dict[str, object]
+) -> bytes:
+    fields = [
+        "try-omarchy-native-authentication-v2",
+        request["guestId"],
+        request["operation"],
+        request["requestId"],
+        request["challenge"],
+        request["user"],
+        request["requestingUser"],
+        request["service"],
+        request["tty"],
+        str(response["issuedAt"]),
+        str(response["expiresAt"]),
+        response["keyId"],
+    ]
+    return "\0".join(fields).encode("ascii")
+
+
+def public_key_pem(public_key: bytes) -> bytes:
+    if len(public_key) != 65 or public_key[0] != 0x04:
+        raise AuthorizationError("host public key is not an uncompressed P-256 point")
+    encoded = base64.b64encode(P256_SPKI_PREFIX + public_key).decode("ascii")
+    lines = [encoded[offset : offset + 64] for offset in range(0, len(encoded), 64)]
+    return (
+        "-----BEGIN PUBLIC KEY-----\n"
+        + "\n".join(lines)
+        + "\n-----END PUBLIC KEY-----\n"
+    ).encode("ascii")
+
+
+def verify_signature(public_key: bytes, signature: bytes, payload: bytes) -> bool:
+    temporary_root = "/run" if Path("/run").is_dir() else None
+    with tempfile.TemporaryDirectory(prefix="try-omarchy-auth-", dir=temporary_root) as directory:
+        key_path = Path(directory) / "host-key.pem"
+        signature_path = Path(directory) / "approval.sig"
+        key_path.write_bytes(public_key_pem(public_key))
+        signature_path.write_bytes(signature)
+        key_path.chmod(0o600)
+        signature_path.chmod(0o600)
+        result = subprocess.run(
+            [
+                str(OPENSSL),
+                "dgst",
+                "-sha256",
+                "-verify",
+                str(key_path),
+                "-signature",
+                str(signature_path),
+            ],
+            input=payload,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+            env={"PATH": "/usr/bin"},
+        )
+        return result.returncode == 0
+
+
+def verify_approval(
+    request: dict[str, object],
+    response: dict[str, object],
+    *,
+    pinned_public_key: bytes | None = None,
+    now: int | None = None,
+) -> bytes:
+    if not response["approved"]:
+        raise AuthorizationError("Touch ID was not approved")
+    issued_at = response["issuedAt"]
+    expires_at = response["expiresAt"]
+    current_time = int(time.time()) if now is None else now
+    if (
+        expires_at - issued_at != APPROVAL_LIFETIME_SECONDS
+        or issued_at > current_time + CLOCK_SKEW_SECONDS
+        or expires_at < current_time
+    ):
+        raise AuthorizationError("host approval is outside its validity window")
+    public_key = decode_base64(response["publicKey"], "public key")
+    if pinned_public_key is not None and public_key != pinned_public_key:
+        raise AuthorizationError("host signing key does not match enrollment")
+    signature = decode_base64(response["signature"], "signature")
+    if not verify_signature(public_key, signature, authorization_payload(request, response)):
+        raise AuthorizationError("host approval signature is invalid")
+    return public_key
+
+
+def write_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = os.write(descriptor, payload[offset:])
+        if written <= 0:
+            raise AuthorizationError("authentication channel stopped accepting data")
+        offset += written
+
+
+def read_line(descriptor: int, timeout: float) -> bytes:
+    deadline = time.monotonic() + timeout
+    line = bytearray()
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("Touch ID request timed out")
+        readable, _, _ = select.select([descriptor], [], [], remaining)
+        if not readable:
+            raise TimeoutError("Touch ID request timed out")
+        chunk = os.read(descriptor, 1024)
+        if not chunk:
+            raise ConnectionError("macOS authentication bridge disconnected")
+        newline = chunk.find(b"\n")
+        if newline >= 0:
+            line.extend(chunk[:newline])
+            if chunk[newline + 1 :]:
+                raise AuthorizationError("host sent data after its authentication response")
+            if len(line) > MAXIMUM_LINE_BYTES:
+                raise AuthorizationError("host authentication response exceeds 4 KiB")
+            return bytes(line)
+        line.extend(chunk)
+        if len(line) > MAXIMUM_LINE_BYTES:
+            raise AuthorizationError("host authentication response exceeds 4 KiB")
+
+
+def exchange_on_descriptor(
+    descriptor: int, request: dict[str, object], timeout: float = 65
+) -> dict[str, object]:
+    write_all(descriptor, encode_request(request))
+    return decode_response(read_line(descriptor, timeout), request)
+
+
+def authentication_device_path(
+    path: Path = PORT,
+    *,
+    enforce_root_owner: bool = True,
+) -> Path:
+    info = path.lstat()
+    if not stat.S_ISLNK(info.st_mode):
+        return path
+    if enforce_root_owner and info.st_uid != 0:
+        raise AuthorizationError("authentication port symlink is not root-owned")
+    target = os.readlink(path)
+    match = VPORT_TARGET_PATTERN.fullmatch(target)
+    if match is None:
+        raise AuthorizationError("authentication port has an unexpected symlink target")
+    return path.parent.parent / match.group(1)
+
+
+def exchange(request: dict[str, object], timeout: float = 65) -> dict[str, object]:
+    device_path = authentication_device_path()
+    descriptor = os.open(
+        device_path,
+        os.O_RDWR | os.O_CLOEXEC | os.O_NOCTTY | os.O_NOFOLLOW,
+    )
+    try:
+        info = os.fstat(descriptor)
+        if (
+            not stat.S_ISCHR(info.st_mode)
+            or info.st_uid != 0
+            or info.st_gid != 0
+            or stat.S_IMODE(info.st_mode) != 0o600
+        ):
+            raise AuthorizationError("authentication endpoint is not a root-only character device")
+        return exchange_on_descriptor(descriptor, request, timeout)
+    finally:
+        os.close(descriptor)
+
+
+def state_payload(public_key: bytes, guest_id: str) -> dict[str, object]:
+    if not HEX_32_PATTERN.fullmatch(guest_id):
+        raise AuthorizationError("guest identifier is invalid")
+    return {
+        "version": PROTOCOL_VERSION,
+        "guestId": guest_id,
+        "keyId": hashlib.sha256(public_key).hexdigest(),
+        "publicKey": base64.b64encode(public_key).decode("ascii"),
+    }
+
+
+def save_state(
+    public_key: bytes,
+    guest_id: str,
+    path: Path = STATE,
+    *,
+    enforce_root_owner: bool = True,
+) -> None:
+    payload = (json.dumps(state_payload(public_key, guest_id), sort_keys=True) + "\n").encode("ascii")
+    parent = path.parent
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    parent.chmod(0o700)
+    parent_info = parent.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(parent_info.st_mode) or (
+        enforce_root_owner and parent_info.st_uid != 0
+    ):
+        raise AuthorizationError("authentication state directory is unsafe")
+
+    directory = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    temporary = f".{path.name}.{secrets.token_hex(8)}"
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=directory,
+        )
+        write_all(descriptor, payload)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary, path.name, src_dir_fd=directory, dst_dir_fd=directory)
+        os.fsync(directory)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary, dir_fd=directory)
+        except FileNotFoundError:
+            pass
+        os.close(directory)
+
+
+def load_state(
+    path: Path = STATE,
+    *,
+    enforce_root_owner: bool = True,
+) -> tuple[bytes, str]:
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        info = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or stat.S_IMODE(info.st_mode) != 0o600
+            or (enforce_root_owner and info.st_uid != 0)
+        ):
+            raise AuthorizationError("authentication enrollment state is unsafe")
+        data = os.read(descriptor, MAXIMUM_LINE_BYTES + 1)
+        if len(data) > MAXIMUM_LINE_BYTES:
+            raise AuthorizationError("authentication enrollment state is too large")
+    finally:
+        os.close(descriptor)
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AuthorizationError("authentication enrollment state is invalid") from error
+    if (
+        not isinstance(value, dict)
+        or set(value) != STATE_FIELDS
+        or value.get("version") != PROTOCOL_VERSION
+        or not isinstance(value.get("guestId"), str)
+        or not HEX_32_PATTERN.fullmatch(value["guestId"])
+        or not isinstance(value.get("keyId"), str)
+        or not HEX_32_PATTERN.fullmatch(value["keyId"])
+        or not isinstance(value.get("publicKey"), str)
+    ):
+        raise AuthorizationError("authentication enrollment state has an invalid schema")
+    public_key = decode_base64(value["publicKey"], "enrolled public key")
+    if (
+        len(public_key) != 65
+        or public_key[0] != 0x04
+        or hashlib.sha256(public_key).hexdigest() != value["keyId"]
+    ):
+        raise AuthorizationError("authentication enrollment state does not match its key")
+    return public_key, value["guestId"]
+
+
+def enroll() -> None:
+    if STATE.exists():
+        _, guest_id = load_state()
+    else:
+        guest_id = secrets.token_hex(32)
+    request = make_request("enroll", guest_id=guest_id)
+    response = exchange(request)
+    public_key = verify_approval(request, response)
+    save_state(public_key, guest_id)
+    print(f"Touch ID sudo enrolled for host key {response['keyId'][:12]}.")
+
+
+def authenticate_pam() -> bool:
+    if os.getuid() != 0 or os.geteuid() != 0:
+        return False
+    if os.environ.get("PAM_TYPE") != "auth" or os.environ.get("PAM_SERVICE") != "sudo":
+        return False
+    user = os.environ.get("PAM_USER", "")
+    requesting_user = os.environ.get("PAM_RUSER", "") or user
+    tty = os.environ.get("PAM_TTY", "")
+    if (
+        not ACCOUNT_PATTERN.fullmatch(user)
+        or not ACCOUNT_PATTERN.fullmatch(requesting_user)
+        or not TTY_PATTERN.fullmatch(tty)
+    ):
+        return False
+    try:
+        pinned_public_key, guest_id = load_state()
+        request = make_request(
+            "sudo",
+            guest_id=guest_id,
+            user=user,
+            requesting_user=requesting_user,
+            tty=tty,
+        )
+        response = exchange(request)
+        verify_approval(request, response, pinned_public_key=pinned_public_key)
+        return True
+    except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError):
+        return False
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in {"enroll", "pam"}:
+        print("usage: native-authentication-broker enroll|pam", file=sys.stderr)
+        return 2
+    if sys.argv[1] == "pam":
+        return 0 if authenticate_pam() else 1
+    if os.getuid() != 0 or os.geteuid() != 0:
+        print("enrollment must run as root", file=sys.stderr)
+        return 1
+    try:
+        enroll()
+        return 0
+    except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError) as error:
+        print(f"Touch ID enrollment failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
@@ -288,7 +288,10 @@ def verify_approval(
         or issued_at > current_time + CLOCK_SKEW_SECONDS
         or expires_at < current_time
     ):
-        raise AuthorizationError("host approval is outside its validity window")
+        raise AuthorizationError(
+            "approval expired or the guest and Mac clocks are out of sync; "
+            "check guest time synchronization and retry"
+        )
     public_key = decode_base64(response["publicKey"], "public key")
     if pinned_public_key is not None and public_key != pinned_public_key:
         raise AuthorizationError("host signing key does not match enrollment")
@@ -594,7 +597,14 @@ def authenticate_pam() -> bool:
         response = exchange(request)
         verify_approval(request, response, pinned_public_key=pinned_public_key)
         return True
-    except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError):
+    except AuthorizationError as error:
+        print(f"Touch ID: {error}. Falling back to your guest password.")
+        return False
+    except TimeoutError:
+        print("Touch ID: approval timed out. Falling back to your guest password.")
+        return False
+    except (OSError, subprocess.SubprocessError):
+        print("Touch ID: authentication bridge unavailable. Falling back to your guest password.")
         return False
 
 

--- a/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
@@ -63,6 +63,10 @@ class AuthorizationError(Exception):
     pass
 
 
+class StaleResponseError(AuthorizationError):
+    pass
+
+
 def make_request(
     operation: str,
     *,
@@ -142,6 +146,8 @@ def decode_response(line: bytes, request: dict[str, object]) -> dict[str, object
         or not isinstance(response.get("approved"), bool)
     ):
         raise AuthorizationError("host sent an invalid authentication response")
+    if response.get("requestId") != request["requestId"]:
+        raise StaleResponseError("host response belongs to an earlier authentication request")
     for field in (
         "operation",
         "guestId",
@@ -325,7 +331,7 @@ def read_line(descriptor: int, timeout: float) -> bytes:
         readable, _, _ = select.select([descriptor], [], [], remaining)
         if not readable:
             raise TimeoutError("Touch ID request timed out")
-        chunk = os.read(descriptor, 1024)
+        chunk = os.read(descriptor, 1)
         if not chunk:
             raise ConnectionError("macOS authentication bridge disconnected")
         newline = chunk.find(b"\n")
@@ -344,8 +350,14 @@ def read_line(descriptor: int, timeout: float) -> bytes:
 def exchange_on_descriptor(
     descriptor: int, request: dict[str, object], timeout: float = 65
 ) -> dict[str, object]:
+    deadline = time.monotonic() + timeout
     write_all(descriptor, encode_request(request))
-    return decode_response(read_line(descriptor, timeout), request)
+    while True:
+        line = read_line(descriptor, deadline - time.monotonic())
+        try:
+            return decode_response(line, request)
+        except StaleResponseError:
+            continue
 
 
 def authentication_device_path(

--- a/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-control
+++ b/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-control
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+
+fail() {
+  echo "try-omarchy-touch-id-control: $*" >&2
+  exit 1
+}
+
+usage() {
+  echo "Usage: try-omarchy-touch-id-control enable|disable|repair" >&2
+  exit 64
+}
+
+(( EUID == 0 )) || fail "run as root"
+[[ $# == 1 ]] || usage
+
+broker=/usr/local/lib/try-omarchy/native-authentication-broker
+pam_policy=/etc/pam.d/sudo
+[[ -x $broker && ! -L $broker ]] || fail "authentication broker is missing or unsafe"
+[[ -f $pam_policy && ! -L $pam_policy ]] || fail "sudo PAM policy is missing or unsafe"
+[[ $(sed -n '1p' "$pam_policy") == '#%PAM-1.0' ]] || fail "unexpected sudo PAM policy header"
+
+if grep -Fq '/usr/local/lib/try-omarchy/native-authentication-broker' "$pam_policy" &&
+  ! grep -Fxq "$PAM_LINE" "$pam_policy"; then
+  fail "sudo PAM policy contains a different authentication broker rule"
+fi
+
+rewrite_policy() {
+  local operation=$1
+  local directory temporary
+  directory=$(dirname "$pam_policy")
+  temporary=$(mktemp "$directory/.sudo.touch-id.XXXXXX")
+  cleanup() {
+    rm -f -- "$temporary"
+  }
+  trap cleanup EXIT
+
+  case "$operation" in
+    enable)
+      if grep -Fxq "$PAM_LINE" "$pam_policy"; then
+        cleanup
+        trap - EXIT
+        return
+      fi
+      awk -v line="$PAM_LINE" 'NR == 1 { print; print line; next } { print }' \
+        "$pam_policy" >"$temporary"
+      ;;
+    disable)
+      if ! grep -Fxq "$PAM_LINE" "$pam_policy"; then
+        cleanup
+        trap - EXIT
+        return
+      fi
+      awk -v line="$PAM_LINE" '$0 != line { print }' "$pam_policy" >"$temporary"
+      ;;
+    *)
+      fail "invalid PAM policy operation"
+      ;;
+  esac
+
+  chown --reference="$pam_policy" "$temporary"
+  chmod --reference="$pam_policy" "$temporary"
+  mv -f -- "$temporary" "$pam_policy"
+  trap - EXIT
+}
+
+enable_touch_id() {
+  "$broker" enroll
+  rewrite_policy enable
+  echo "Touch ID is enabled for sudo. The guest password remains available as fallback."
+}
+
+disable_touch_id() {
+  rewrite_policy disable
+  "$broker" disable
+  echo "Touch ID is disabled for sudo."
+}
+
+case "$1" in
+  enable)
+    enable_touch_id
+    ;;
+  disable)
+    disable_touch_id
+    ;;
+  repair)
+    disable_touch_id
+    enable_touch_id
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-control
+++ b/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-control
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+LEGACY_PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+PAM_LINE=$'auth\t\tsufficient\tpam_exec.so quiet seteuid stdout /usr/local/lib/try-omarchy/native-authentication-broker pam'
 
 fail() {
   echo "try-omarchy-touch-id-control: $*" >&2
@@ -10,7 +11,7 @@ fail() {
 }
 
 usage() {
-  echo "Usage: try-omarchy-touch-id-control enable|disable|repair" >&2
+  echo "Usage: try-omarchy-touch-id-control enable|disable|repair|migrate" >&2
   exit 64
 }
 
@@ -23,8 +24,8 @@ pam_policy=/etc/pam.d/sudo
 [[ -f $pam_policy && ! -L $pam_policy ]] || fail "sudo PAM policy is missing or unsafe"
 [[ $(sed -n '1p' "$pam_policy") == '#%PAM-1.0' ]] || fail "unexpected sudo PAM policy header"
 
-if grep -Fq '/usr/local/lib/try-omarchy/native-authentication-broker' "$pam_policy" &&
-  ! grep -Fxq "$PAM_LINE" "$pam_policy"; then
+if grep -F '/usr/local/lib/try-omarchy/native-authentication-broker' "$pam_policy" |
+  grep -Fvx -e "$PAM_LINE" -e "$LEGACY_PAM_LINE" >/dev/null; then
   fail "sudo PAM policy contains a different authentication broker rule"
 fi
 
@@ -49,12 +50,16 @@ rewrite_policy() {
         "$pam_policy" >"$temporary"
       ;;
     disable)
-      if ! grep -Fxq "$PAM_LINE" "$pam_policy"; then
+      if ! grep -Fxq -e "$PAM_LINE" -e "$LEGACY_PAM_LINE" "$pam_policy"; then
         cleanup
         trap - EXIT
         return
       fi
-      awk -v line="$PAM_LINE" '$0 != line { print }' "$pam_policy" >"$temporary"
+      awk -v line="$PAM_LINE" -v legacy="$LEGACY_PAM_LINE" '$0 != line && $0 != legacy { print }' "$pam_policy" >"$temporary"
+      ;;
+    migrate)
+      awk -v line="$PAM_LINE" -v legacy="$LEGACY_PAM_LINE" \
+        '$0 == legacy { print line; next } { print }' "$pam_policy" >"$temporary"
       ;;
     *)
       fail "invalid PAM policy operation"
@@ -69,6 +74,7 @@ rewrite_policy() {
 
 enable_touch_id() {
   "$broker" enroll
+  rewrite_policy migrate
   rewrite_policy enable
   echo "Touch ID is enabled for sudo. The guest password remains available as fallback."
 }
@@ -80,6 +86,9 @@ disable_touch_id() {
 }
 
 case "$1" in
+  migrate)
+    rewrite_policy migrate
+    ;;
   enable)
     enable_touch_id
     ;;

--- a/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll
+++ b/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll
@@ -1,9 +1,3 @@
 #!/bin/sh
 
-set -eu
-
-broker=/usr/local/lib/try-omarchy/native-authentication-broker
-if [ "$(id -u)" -eq 0 ]; then
-  exec "$broker" enroll
-fi
-exec sudo "$broker" enroll
+exec /usr/local/bin/try-omarchy-touch-id enable

--- a/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll
+++ b/guest/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+broker=/usr/local/lib/try-omarchy/native-authentication-broker
+if [ "$(id -u)" -eq 0 ]; then
+  exec "$broker" enroll
+fi
+exec sudo "$broker" enroll

--- a/guest/patches/omarchy/touch-id-sudo-menu.patch
+++ b/guest/patches/omarchy/touch-id-sudo-menu.patch
@@ -1,0 +1,10 @@
+diff --git a/config/omarchy/extensions/omarchy-menu.jsonc b/config/omarchy/extensions/omarchy-menu.jsonc
+--- a/config/omarchy/extensions/omarchy-menu.jsonc
++++ b/config/omarchy/extensions/omarchy-menu.jsonc
+@@ -27,4 +27,6 @@
+   // Example: replace the default About action by reusing the same id. Existing
+   // fields are kept unless overridden.
+   // "about": {"icon":"","label":"About","action":"omarchy-launch-or-focus-tui \"zsh -c 'fastfetch; read -k 1'\""},
++  // Try Omarchy host integration.
++  "setup.security.touch-id": {"icon":"󰈷","label":"Touch ID for sudo","when":"[[ -x /usr/local/bin/try-omarchy-touch-id ]]","checked":"/usr/local/bin/try-omarchy-touch-id status --quiet","action":"omarchy-launch-floating-terminal-with-presentation /usr/local/bin/try-omarchy-touch-id"},
+ }

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -69,7 +69,7 @@ cp -a "$guest_dir/factory-overlay/." "$root/"
 # The clipboard bridge mirrors the Mac pasteboard into the Wayland session,
 # and the Mac folder mount completes the host integration.
 cp -a "$guest_dir/native-overlay/." "$root/"
-"$guest_dir/scripts/install-touch-id-sudo-prototype.sh" \
+"$guest_dir/scripts/install-touch-id-sudo.sh" \
   --root "$root" \
   --guest-dir "$guest_dir"
 chmod 0755 \
@@ -82,8 +82,10 @@ chmod 0755 \
   "$root/usr/local/bin/omarchy-native-cursor-restore" \
   "$root/usr/local/bin/omarchy-native-display-sync" \
   "$root/usr/local/bin/omarchy-native-mac-share" \
+  "$root/usr/local/bin/try-omarchy-touch-id" \
   "$root/usr/local/bin/try-omarchy-touch-id-test" \
   "$root/usr/local/lib/try-omarchy/native-authentication-broker" \
+  "$root/usr/local/sbin/try-omarchy-touch-id-control" \
   "$root/usr/local/sbin/try-omarchy-touch-id-enroll" \
   "$root/usr/local/lib/try-omarchy/install-vivaldi-arm64" \
   "$root/usr/lib/systemd/system-generators/try-omarchy-ssh-access"

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -69,6 +69,9 @@ cp -a "$guest_dir/factory-overlay/." "$root/"
 # The clipboard bridge mirrors the Mac pasteboard into the Wayland session,
 # and the Mac folder mount completes the host integration.
 cp -a "$guest_dir/native-overlay/." "$root/"
+"$guest_dir/scripts/install-touch-id-sudo-prototype.sh" \
+  --root "$root" \
+  --guest-dir "$guest_dir"
 chmod 0755 \
   "$root/usr/bin/omarchy-audio-input-set-default" \
   "$root/usr/bin/omarchy-screensaver" \
@@ -79,6 +82,9 @@ chmod 0755 \
   "$root/usr/local/bin/omarchy-native-cursor-restore" \
   "$root/usr/local/bin/omarchy-native-display-sync" \
   "$root/usr/local/bin/omarchy-native-mac-share" \
+  "$root/usr/local/bin/try-omarchy-touch-id-test" \
+  "$root/usr/local/lib/try-omarchy/native-authentication-broker" \
+  "$root/usr/local/sbin/try-omarchy-touch-id-enroll" \
   "$root/usr/local/lib/try-omarchy/install-vivaldi-arm64" \
   "$root/usr/lib/systemd/system-generators/try-omarchy-ssh-access"
 

--- a/guest/scripts/finalize-rootfs.sh
+++ b/guest/scripts/finalize-rootfs.sh
@@ -23,6 +23,7 @@ locale-gen
 passwd --lock root >/dev/null
 systemctl enable NetworkManager.service
 systemctl enable systemd-resolved.service
+systemctl enable systemd-timesyncd.service
 
 # Avoid a systemctl introspection path that crashes under some ARM container
 # runtimes after it has already written the link.

--- a/guest/scripts/install-touch-id-menu-entry.py
+++ b/guest/scripts/install-touch-id-menu-entry.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Install the Try Omarchy Touch ID row into one user's menu extension."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import secrets
+import stat
+
+
+ENTRY_ID = '"setup.security.touch-id"'
+ENTRY = (
+    '  // Try Omarchy host integration.\n'
+    '  "setup.security.touch-id": {"icon":"󰈷","label":"Touch ID for sudo",'
+    '"when":"[[ -x /usr/local/bin/try-omarchy-touch-id ]]",'
+    '"checked":"/usr/local/bin/try-omarchy-touch-id status --quiet",'
+    '"action":"omarchy-launch-floating-terminal-with-presentation '
+    '/usr/local/bin/try-omarchy-touch-id"},\n'
+)
+MAXIMUM_BYTES = 256 * 1024
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"install-touch-id-menu-entry: {message}")
+
+
+def install(path: Path) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        info = path.stat(follow_symlinks=False)
+    except FileNotFoundError:
+        data = b"{\n}\n"
+        mode = 0o644
+    else:
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid():
+            fail("menu extension is not a safe user-owned regular file")
+        mode = stat.S_IMODE(info.st_mode)
+        data = path.read_bytes()
+        if len(data) > MAXIMUM_BYTES:
+            fail("menu extension is unexpectedly large")
+
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        fail("menu extension is not UTF-8")
+    if ENTRY_ID in text:
+        return
+
+    opening = text.find("{")
+    if opening < 0 or text[:opening].strip():
+        fail("menu extension does not start with a JSONC object")
+    line_end = text.find("\n", opening)
+    if line_end < 0 or text.rstrip()[-1:] != "}":
+        fail("menu extension is not a multiline JSONC object")
+    updated = text[: line_end + 1] + ENTRY + text[line_end + 1 :]
+
+    directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    temporary = f".{path.name}.{secrets.token_hex(8)}"
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            mode,
+            dir_fd=directory,
+        )
+        payload = updated.encode("utf-8")
+        offset = 0
+        while offset < len(payload):
+            written = os.write(descriptor, payload[offset:])
+            if written <= 0:
+                fail("menu extension stopped accepting data")
+            offset += written
+        os.fchmod(descriptor, mode)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary, path.name, src_dir_fd=directory, dst_dir_fd=directory)
+        os.fsync(directory)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary, dir_fd=directory)
+        except FileNotFoundError:
+            pass
+        os.close(directory)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    if not args.path.is_absolute():
+        fail("menu extension path must be absolute")
+    install(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/guest/scripts/install-touch-id-menu-entry.py
+++ b/guest/scripts/install-touch-id-menu-entry.py
@@ -51,10 +51,9 @@ def install(path: Path) -> None:
     opening = text.find("{")
     if opening < 0 or text[:opening].strip():
         fail("menu extension does not start with a JSONC object")
-    line_end = text.find("\n", opening)
-    if line_end < 0 or text.rstrip()[-1:] != "}":
-        fail("menu extension is not a multiline JSONC object")
-    updated = text[: line_end + 1] + ENTRY + text[line_end + 1 :]
+    if text.rstrip()[-1:] != "}":
+        fail("menu extension is not a JSONC object")
+    updated = text[: opening + 1] + "\n" + ENTRY + text[opening + 1 :]
 
     directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     temporary = f".{path.name}.{secrets.token_hex(8)}"

--- a/guest/scripts/install-touch-id-sudo-prototype.sh
+++ b/guest/scripts/install-touch-id-sudo-prototype.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: install-touch-id-sudo-prototype.sh [--root ROOT] [--guest-dir GUEST_DIR]" >&2
+  exit 64
+}
+
+fail() {
+  echo "install-touch-id-sudo-prototype: $*" >&2
+  exit 1
+}
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+guest_dir=$(cd "$script_dir/.." && pwd)
+root=/
+while (($#)); do
+  case "$1" in
+    --root)
+      root=${2:-}
+      shift 2
+      ;;
+    --guest-dir)
+      guest_dir=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+(( EUID == 0 )) || fail "run as root"
+[[ $root == /* ]] || fail "--root must be absolute"
+if [[ $root != / ]]; then
+  case "$root" in
+    /bin|/boot|/etc|/home|/opt|/root|/usr|/var)
+      fail "refusing unsafe staged root: $root"
+      ;;
+  esac
+  [[ -d $root ]] || fail "staged root does not exist: $root"
+  root=${root%/}
+else
+  root=
+fi
+[[ -d $guest_dir/native-overlay ]] || fail "guest overlay not found: $guest_dir"
+
+broker_source="$guest_dir/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker"
+enroll_source="$guest_dir/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll"
+test_source="$guest_dir/native-overlay/usr/local/bin/try-omarchy-touch-id-test"
+rule_source="$guest_dir/native-overlay/etc/udev/rules.d/93-omarchy-native-authentication.rules"
+for source_file in "$broker_source" "$enroll_source" "$test_source" "$rule_source"; do
+  [[ -f $source_file && ! -L $source_file ]] || fail "unsafe or missing source: $source_file"
+done
+
+[[ -x $root/usr/bin/python3 && ! -L $root/usr/bin/python3 ]] || {
+  [[ -L $root/usr/bin/python3 && -x $root/usr/bin/python3 ]] || fail "guest Python is unavailable"
+}
+[[ -x $root/usr/bin/openssl && ! -L $root/usr/bin/openssl ]] || fail "guest OpenSSL is unavailable"
+[[ -f $root/usr/lib/security/pam_exec.so && ! -L $root/usr/lib/security/pam_exec.so ]] || \
+  fail "pam_exec.so is unavailable"
+
+install -d -m 0755 "$root/usr/local/lib/try-omarchy" "$root/usr/local/sbin" "$root/usr/local/bin"
+install -d -m 0755 "$root/etc/udev/rules.d"
+install -m 0755 "$broker_source" \
+  "$root/usr/local/lib/try-omarchy/native-authentication-broker"
+install -m 0755 "$enroll_source" "$root/usr/local/sbin/try-omarchy-touch-id-enroll"
+install -m 0755 "$test_source" "$root/usr/local/bin/try-omarchy-touch-id-test"
+install -m 0644 "$rule_source" \
+  "$root/etc/udev/rules.d/93-omarchy-native-authentication.rules"
+
+sudo_pam="$root/etc/pam.d/sudo"
+[[ -f $sudo_pam && ! -L $sudo_pam ]] || fail "sudo PAM policy is missing or unsafe"
+[[ $(sed -n '1p' "$sudo_pam") == '#%PAM-1.0' ]] || fail "unexpected sudo PAM policy header"
+pam_command=/usr/local/lib/try-omarchy/native-authentication-broker
+pam_line=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
+if grep -Fq "$pam_command" "$sudo_pam"; then
+  grep -Fxq "$pam_line" "$sudo_pam" || fail "sudo PAM policy contains a different authentication broker rule"
+else
+  if [[ -z $root ]]; then
+    backup=/etc/pam.d/sudo.try-omarchy-before-touch-id
+    [[ -e $backup || -L $backup ]] || install -m 0644 "$sudo_pam" "$backup"
+  fi
+  pam_directory=$(dirname "$sudo_pam")
+  temporary=$(mktemp "$pam_directory/.sudo.touch-id.XXXXXX")
+  cleanup() {
+    rm -f -- "$temporary"
+  }
+  trap cleanup EXIT
+  awk -v line="$pam_line" 'NR == 1 { print; print line; next } { print }' \
+    "$sudo_pam" >"$temporary"
+  chown --reference="$sudo_pam" "$temporary"
+  chmod --reference="$sudo_pam" "$temporary"
+  mv -f -- "$temporary" "$sudo_pam"
+  trap - EXIT
+fi
+
+if [[ -z $root ]]; then
+  /usr/bin/udevadm control --reload-rules
+  /usr/bin/udevadm trigger --subsystem-match=virtio-ports --action=change
+fi
+
+echo "Installed the sudo-only Touch ID prototype."
+echo "Enroll with: try-omarchy-touch-id-enroll"
+echo "Test with:   try-omarchy-touch-id-test"

--- a/guest/scripts/install-touch-id-sudo.sh
+++ b/guest/scripts/install-touch-id-sudo.sh
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: install-touch-id-sudo-prototype.sh [--root ROOT] [--guest-dir GUEST_DIR]" >&2
+  echo "Usage: install-touch-id-sudo.sh [--root ROOT] [--guest-dir GUEST_DIR]" >&2
   exit 64
 }
 
 fail() {
-  echo "install-touch-id-sudo-prototype: $*" >&2
+  echo "install-touch-id-sudo: $*" >&2
   exit 1
 }
 
@@ -34,7 +34,6 @@ while (($#)); do
   esac
 done
 
-(( EUID == 0 )) || fail "run as root"
 [[ $root == /* ]] || fail "--root must be absolute"
 if [[ $root != / ]]; then
   case "$root" in
@@ -45,6 +44,7 @@ if [[ $root != / ]]; then
   [[ -d $root ]] || fail "staged root does not exist: $root"
   root=${root%/}
 else
+  (( EUID == 0 )) || fail "run as root"
   root=
 fi
 [[ -d $guest_dir/native-overlay ]] || fail "guest overlay not found: $guest_dir"
@@ -52,8 +52,11 @@ fi
 broker_source="$guest_dir/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker"
 enroll_source="$guest_dir/native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll"
 test_source="$guest_dir/native-overlay/usr/local/bin/try-omarchy-touch-id-test"
+menu_source="$guest_dir/native-overlay/usr/local/bin/try-omarchy-touch-id"
+control_source="$guest_dir/native-overlay/usr/local/sbin/try-omarchy-touch-id-control"
 rule_source="$guest_dir/native-overlay/etc/udev/rules.d/93-omarchy-native-authentication.rules"
-for source_file in "$broker_source" "$enroll_source" "$test_source" "$rule_source"; do
+menu_installer_source="$guest_dir/scripts/install-touch-id-menu-entry.py"
+for source_file in "$broker_source" "$enroll_source" "$test_source" "$menu_source" "$control_source" "$rule_source" "$menu_installer_source"; do
   [[ -f $source_file && ! -L $source_file ]] || fail "unsafe or missing source: $source_file"
 done
 
@@ -70,40 +73,31 @@ install -m 0755 "$broker_source" \
   "$root/usr/local/lib/try-omarchy/native-authentication-broker"
 install -m 0755 "$enroll_source" "$root/usr/local/sbin/try-omarchy-touch-id-enroll"
 install -m 0755 "$test_source" "$root/usr/local/bin/try-omarchy-touch-id-test"
+install -m 0755 "$menu_source" "$root/usr/local/bin/try-omarchy-touch-id"
+install -m 0755 "$control_source" "$root/usr/local/sbin/try-omarchy-touch-id-control"
 install -m 0644 "$rule_source" \
   "$root/etc/udev/rules.d/93-omarchy-native-authentication.rules"
 
-sudo_pam="$root/etc/pam.d/sudo"
-[[ -f $sudo_pam && ! -L $sudo_pam ]] || fail "sudo PAM policy is missing or unsafe"
-[[ $(sed -n '1p' "$sudo_pam") == '#%PAM-1.0' ]] || fail "unexpected sudo PAM policy header"
-pam_command=/usr/local/lib/try-omarchy/native-authentication-broker
-pam_line=$'auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam'
-if grep -Fq "$pam_command" "$sudo_pam"; then
-  grep -Fxq "$pam_line" "$sudo_pam" || fail "sudo PAM policy contains a different authentication broker rule"
-else
-  if [[ -z $root ]]; then
-    backup=/etc/pam.d/sudo.try-omarchy-before-touch-id
-    [[ -e $backup || -L $backup ]] || install -m 0644 "$sudo_pam" "$backup"
-  fi
-  pam_directory=$(dirname "$sudo_pam")
-  temporary=$(mktemp "$pam_directory/.sudo.touch-id.XXXXXX")
-  cleanup() {
-    rm -f -- "$temporary"
-  }
-  trap cleanup EXIT
-  awk -v line="$pam_line" 'NR == 1 { print; print line; next } { print }' \
-    "$sudo_pam" >"$temporary"
-  chown --reference="$sudo_pam" "$temporary"
-  chmod --reference="$sudo_pam" "$temporary"
-  mv -f -- "$temporary" "$sudo_pam"
-  trap - EXIT
-fi
-
 if [[ -z $root ]]; then
+  if ! /usr/local/lib/try-omarchy/native-authentication-broker migrate; then
+    /usr/local/sbin/try-omarchy-touch-id-control disable || true
+    fail "existing Touch ID state could not be migrated; sudo authentication was disabled"
+  fi
   /usr/bin/udevadm control --reload-rules
   /usr/bin/udevadm trigger --subsystem-match=virtio-ports --action=change
+  if [[ ${SUDO_USER:-root} != root ]]; then
+    [[ ${SUDO_USER:-} =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || fail "unsafe invoking user"
+    account=$(getent passwd "$SUDO_USER") || fail "cannot resolve invoking user"
+    IFS=: read -r _ _ account_uid _ _ account_home _ <<<"$account"
+    [[ $account_uid == "${SUDO_UID:-}" ]] || fail "invoking user identity changed"
+    [[ $account_home == /* && $account_home != / ]] || fail "unsafe invoking user home"
+    runuser --user "$SUDO_USER" -- \
+      "$menu_installer_source" \
+      "$account_home/.config/omarchy/extensions/omarchy-menu.jsonc"
+    runuser --user "$SUDO_USER" -- /usr/bin/omarchy menu refresh >/dev/null 2>&1 || true
+  fi
 fi
 
-echo "Installed the sudo-only Touch ID prototype."
-echo "Enroll with: try-omarchy-touch-id-enroll"
+echo "Installed the opt-in Touch ID sudo integration."
+echo "Enable with: try-omarchy-touch-id"
 echo "Test with:   try-omarchy-touch-id-test"

--- a/guest/scripts/install-touch-id-sudo.sh
+++ b/guest/scripts/install-touch-id-sudo.sh
@@ -83,6 +83,7 @@ if [[ -z $root ]]; then
     /usr/local/sbin/try-omarchy-touch-id-control disable || true
     fail "existing Touch ID state could not be migrated; sudo authentication was disabled"
   fi
+  /usr/local/sbin/try-omarchy-touch-id-control migrate
   /usr/bin/udevadm control --reload-rules
   /usr/bin/udevadm trigger --subsystem-match=virtio-ports --action=change
   if [[ ${SUDO_USER:-root} != root ]]; then

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -385,6 +385,19 @@
         "image/png"
       ]
     },
+    "authenticationExperiment": {
+      "approvalLifetimeSeconds": 15,
+      "authorizationScope": "sudo-authentication",
+      "device": "virtserialport",
+      "guestDeviceMode": "0600",
+      "guestIdentity": "root-private-random-256-bit",
+      "hostKey": "per-guest-secure-enclave-p256",
+      "pamService": "sudo",
+      "port": "dev.tryomarchy.authentication",
+      "protocolVersion": 2,
+      "requiresEnrollment": true,
+      "signature": "ecdsa-p256-sha256"
+    },
     "sharedFolder": {
       "device": "virtio-9p-pci",
       "fsdriver": "local",

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -139,16 +139,30 @@
   "authenticity": {
     "verbatimRuntimeTrees": [
       "applications",
-      "config",
       "default",
       "migrations"
     ],
     "backportedRuntimeTrees": [
       "bin",
+      "config",
       "install",
       "shell"
     ],
     "backports": [
+      {
+        "id": "touch-id-sudo-menu",
+        "description": "Add an explicit opt-in control for Try Omarchy Touch ID sudo authentication under Setup > Security.",
+        "reference": "https://github.com/omacom/try-omarchy/issues/133",
+        "patch": "patches/omarchy/touch-id-sudo-menu.patch",
+        "patchSha256": "9a415cd0fe2377b49b5ad78668158e167419bb88a537516e46fe4a3321689b6a",
+        "targets": [
+          {
+            "path": "config/omarchy/extensions/omarchy-menu.jsonc",
+            "beforeSha256": "1ca0fdf7d2c0976f0e4c5d8c8a5d5eeeddc693ad05c72809638eeb730c9f470c",
+            "afterSha256": "39b4fb16cdc9ab0812613d39530c5d44b7c5627926d57784b252cf501cda3c89"
+          }
+        ]
+      },
       {
         "id": "1password-arm64-installer",
         "description": "Install 1Password from its signed ARM64 release with VM-compatible launchers and Quick Access.",
@@ -385,7 +399,8 @@
         "image/png"
       ]
     },
-    "authenticationExperiment": {
+    "authentication": {
+      "activation": "explicit-menu-opt-in",
       "approvalLifetimeSeconds": 15,
       "authorizationScope": "sudo-authentication",
       "device": "virtserialport",
@@ -394,7 +409,7 @@
       "hostKey": "per-guest-secure-enclave-p256",
       "pamService": "sudo",
       "port": "dev.tryomarchy.authentication",
-      "protocolVersion": 2,
+      "protocolVersion": 3,
       "requiresEnrollment": true,
       "signature": "ecdsa-p256-sha256"
     },

--- a/guest/tests/test_native_authentication_bridge.py
+++ b/guest/tests/test_native_authentication_bridge.py
@@ -76,7 +76,7 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
         cls.keys.cleanup()
 
     def request(self, operation: str = "sudo") -> dict[str, object]:
-        if operation == "enroll":
+        if operation in {"disable", "enroll"}:
             user = requesting_user = tty = ""
         else:
             user = requesting_user = "test"
@@ -91,7 +91,7 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
             "tty": tty,
             "type": "authorize",
             "user": user,
-            "version": 2,
+            "version": 3,
         }
 
     def approved_response(
@@ -142,6 +142,26 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
         with self.assertRaises(broker.AuthorizationError):
             broker.validate_request(request)
 
+    def test_disable_response_is_nonauthorizing_and_exact(self) -> None:
+        request = self.request("disable")
+        response = {
+            **request,
+            "type": "authorization-result",
+            "approved": True,
+            "issuedAt": 0,
+            "expiresAt": 0,
+            "keyId": "",
+            "publicKey": "",
+            "signature": "",
+        }
+        decoded = broker.decode_response(json.dumps(response).encode(), request)
+        broker.verify_disable_response(decoded)
+
+        authorization_material = dict(response)
+        authorization_material["keyId"] = "ab" * 32
+        with self.assertRaises(broker.AuthorizationError):
+            broker.decode_response(json.dumps(authorization_material).encode(), request)
+
     def test_response_requires_the_original_request_identity(self) -> None:
         request = self.request()
         response = self.approved_response(request)
@@ -150,6 +170,7 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
         for field, value in (
             ("requestId", "33333333-3333-4333-8333-333333333333"),
             ("challenge", "cd" * 32),
+            ("guestId", "dc" * 32),
             ("tty", "/dev/pts/5"),
             ("user", "root"),
         ):
@@ -207,6 +228,37 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
             )
             value = json.loads(path.read_text())
             self.assertEqual(set(value), broker.STATE_FIELDS)
+            broker.remove_state(path, enforce_root_owner=False)
+            self.assertFalse(path.exists())
+            broker.remove_state(path, enforce_root_owner=False)
+
+    def test_version_two_enrollment_state_migrates_without_changing_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state" / "native-authentication.json"
+            broker.save_state(
+                self.public_key,
+                self.guest_id,
+                path,
+                enforce_root_owner=False,
+            )
+            legacy = json.loads(path.read_text(encoding="ascii"))
+            legacy["version"] = 2
+            path.write_text(json.dumps(legacy, sort_keys=True) + "\n", encoding="ascii")
+            path.chmod(0o600)
+
+            with self.assertRaises(broker.AuthorizationError):
+                broker.load_state(path, enforce_root_owner=False)
+            self.assertTrue(broker.migrate_state(path, enforce_root_owner=False))
+            self.assertEqual(
+                broker.load_state(path, enforce_root_owner=False),
+                (self.public_key, self.guest_id),
+            )
+            self.assertEqual(json.loads(path.read_text(encoding="ascii"))["version"], 3)
+
+    def test_state_migration_is_a_noop_when_not_enrolled(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state" / "native-authentication.json"
+            self.assertFalse(broker.migrate_state(path, enforce_root_owner=False))
 
     def test_fragmented_signed_round_trip(self) -> None:
         request = self.request()

--- a/guest/tests/test_native_authentication_bridge.py
+++ b/guest/tests/test_native_authentication_bridge.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Protocol tests for signed, sudo-only native authentication."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from importlib.machinery import SourceFileLoader
+import json
+from pathlib import Path
+import socket
+import subprocess
+import tempfile
+import threading
+import unittest
+from unittest import mock
+
+
+GUEST = Path(__file__).resolve().parents[1]
+BROKER_PATH = (
+    GUEST
+    / "native-overlay/usr/local/lib/try-omarchy/native-authentication-broker"
+)
+broker = SourceFileLoader("native_authentication_broker", str(BROKER_PATH)).load_module()
+
+
+class NativeAuthenticationProtocolTests(unittest.TestCase):
+    request_id = "2a8adad0-e2e3-43a0-882f-82f64d691c86"
+    challenge = "ab" * 32
+    guest_id = "ef" * 32
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.keys = tempfile.TemporaryDirectory(prefix="try-omarchy-auth-test-")
+        private_key = Path(cls.keys.name) / "private.pem"
+        generated = subprocess.run(
+            [
+                str(broker.OPENSSL),
+                "ecparam",
+                "-name",
+                "prime256v1",
+                "-genkey",
+                "-noout",
+                "-out",
+                str(private_key),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if generated.returncode:
+            raise RuntimeError(generated.stderr.decode(errors="replace"))
+        public_der = subprocess.run(
+            [
+                str(broker.OPENSSL),
+                "pkey",
+                "-in",
+                str(private_key),
+                "-pubout",
+                "-outform",
+                "DER",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout
+        if not public_der.startswith(broker.P256_SPKI_PREFIX):
+            raise RuntimeError("OpenSSL produced an unexpected P-256 public key")
+        cls.private_key = private_key
+        cls.public_key = public_der[len(broker.P256_SPKI_PREFIX) :]
+        if len(cls.public_key) != 65:
+            raise RuntimeError("OpenSSL produced an unexpected P-256 point")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.keys.cleanup()
+
+    def request(self, operation: str = "sudo") -> dict[str, object]:
+        if operation == "enroll":
+            user = requesting_user = tty = ""
+        else:
+            user = requesting_user = "test"
+            tty = "/dev/pts/4"
+        return {
+            "challenge": self.challenge,
+            "guestId": self.guest_id,
+            "operation": operation,
+            "requestId": self.request_id,
+            "requestingUser": requesting_user,
+            "service": "sudo",
+            "tty": tty,
+            "type": "authorize",
+            "user": user,
+            "version": 2,
+        }
+
+    def approved_response(
+        self,
+        request: dict[str, object],
+        *,
+        issued_at: int = 1_788_623_100,
+    ) -> dict[str, object]:
+        response = {
+            **request,
+            "type": "authorization-result",
+            "approved": True,
+            "issuedAt": issued_at,
+            "expiresAt": issued_at + broker.APPROVAL_LIFETIME_SECONDS,
+            "keyId": hashlib.sha256(self.public_key).hexdigest(),
+            "publicKey": base64.b64encode(self.public_key).decode("ascii"),
+            "signature": "",
+        }
+        signature = subprocess.run(
+            [
+                str(broker.OPENSSL),
+                "dgst",
+                "-sha256",
+                "-sign",
+                str(self.private_key),
+            ],
+            input=broker.authorization_payload(request, response),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        ).stdout
+        response["signature"] = base64.b64encode(signature).decode("ascii")
+        return response
+
+    def test_request_encoding_matches_the_host_schema(self) -> None:
+        request = self.request()
+        encoded = broker.encode_request(request)
+        self.assertEqual(
+            encoded,
+            json.dumps(request, separators=(",", ":"), sort_keys=True).encode("ascii")
+            + b"\n",
+        )
+
+    def test_enrollment_rejects_sudo_context(self) -> None:
+        request = self.request("enroll")
+        broker.validate_request(request)
+        request["user"] = "test"
+        with self.assertRaises(broker.AuthorizationError):
+            broker.validate_request(request)
+
+    def test_response_requires_the_original_request_identity(self) -> None:
+        request = self.request()
+        response = self.approved_response(request)
+        decoded = broker.decode_response(json.dumps(response).encode(), request)
+        self.assertTrue(decoded["approved"])
+        for field, value in (
+            ("requestId", "33333333-3333-4333-8333-333333333333"),
+            ("challenge", "cd" * 32),
+            ("tty", "/dev/pts/5"),
+            ("user", "root"),
+        ):
+            changed = dict(response)
+            changed[field] = value
+            with self.assertRaises(broker.AuthorizationError):
+                broker.decode_response(json.dumps(changed).encode(), request)
+
+    def test_real_ecdsa_signature_and_time_window_are_verified(self) -> None:
+        request = self.request()
+        response = self.approved_response(request)
+        decoded = broker.decode_response(json.dumps(response).encode(), request)
+        self.assertEqual(
+            broker.verify_approval(
+                request,
+                decoded,
+                pinned_public_key=self.public_key,
+                now=response["issuedAt"],
+            ),
+            self.public_key,
+        )
+
+        tampered = dict(decoded)
+        signature = bytearray(base64.b64decode(tampered["signature"]))
+        signature[-1] ^= 1
+        tampered["signature"] = base64.b64encode(signature).decode("ascii")
+        with self.assertRaises(broker.AuthorizationError):
+            broker.verify_approval(
+                request,
+                tampered,
+                pinned_public_key=self.public_key,
+                now=response["issuedAt"],
+            )
+        with self.assertRaises(broker.AuthorizationError):
+            broker.verify_approval(
+                request,
+                decoded,
+                pinned_public_key=self.public_key,
+                now=response["expiresAt"] + 1,
+            )
+
+    def test_enrollment_state_is_exact_atomic_and_mode_0600(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state" / "native-authentication.json"
+            broker.save_state(
+                self.public_key,
+                self.guest_id,
+                path,
+                enforce_root_owner=False,
+            )
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(
+                broker.load_state(path, enforce_root_owner=False),
+                (self.public_key, self.guest_id),
+            )
+            value = json.loads(path.read_text())
+            self.assertEqual(set(value), broker.STATE_FIELDS)
+
+    def test_fragmented_signed_round_trip(self) -> None:
+        request = self.request()
+        response = self.approved_response(request)
+        client, host = socket.socketpair()
+
+        def respond() -> None:
+            received = bytearray()
+            while not received.endswith(b"\n"):
+                received.extend(host.recv(7))
+            self.assertEqual(json.loads(received), request)
+            encoded = json.dumps(response, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+            for offset in range(0, len(encoded), 5):
+                host.sendall(encoded[offset : offset + 5])
+
+        worker = threading.Thread(target=respond)
+        worker.start()
+        try:
+            decoded = broker.exchange_on_descriptor(client.fileno(), request, timeout=2)
+            self.assertTrue(decoded["approved"])
+        finally:
+            worker.join(timeout=2)
+            client.close()
+            host.close()
+        self.assertFalse(worker.is_alive())
+
+    def test_named_virtio_port_accepts_only_the_kernel_device_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dev = Path(directory) / "dev"
+            named_ports = dev / "virtio-ports"
+            named_ports.mkdir(parents=True)
+            port = named_ports / "dev.tryomarchy.authentication"
+            port.symlink_to("../vport1p3")
+            self.assertEqual(
+                broker.authentication_device_path(port, enforce_root_owner=False),
+                dev / "vport1p3",
+            )
+            port.unlink()
+            for target in ("../../etc/shadow", "../vport1p3/extra", "/dev/vport1p3"):
+                port.symlink_to(target)
+                with self.assertRaises(broker.AuthorizationError):
+                    broker.authentication_device_path(port, enforce_root_owner=False)
+                port.unlink()
+
+    def test_pam_rejects_non_sudo_and_non_interactive_contexts(self) -> None:
+        base = {
+            "PAM_TYPE": "auth",
+            "PAM_SERVICE": "sudo",
+            "PAM_USER": "test",
+            "PAM_RUSER": "test",
+            "PAM_TTY": "/dev/pts/4",
+        }
+        with mock.patch.object(broker.os, "getuid", return_value=0), mock.patch.object(
+            broker.os, "geteuid", return_value=0
+        ):
+            with mock.patch.dict(broker.os.environ, {**base, "PAM_SERVICE": "login"}, clear=True):
+                self.assertFalse(broker.authenticate_pam())
+            with mock.patch.dict(broker.os.environ, {**base, "PAM_TTY": ""}, clear=True):
+                self.assertFalse(broker.authenticate_pam())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/guest/tests/test_native_authentication_bridge.py
+++ b/guest/tests/test_native_authentication_bridge.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import io
+from contextlib import redirect_stdout
 from importlib.machinery import SourceFileLoader
 import json
 from pathlib import Path
@@ -318,6 +320,31 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
                 self.assertFalse(broker.authenticate_pam())
             with mock.patch.dict(broker.os.environ, {**base, "PAM_TTY": ""}, clear=True):
                 self.assertFalse(broker.authenticate_pam())
+
+    def test_pam_explains_clock_rejection_and_keeps_success_quiet(self) -> None:
+        request = self.request()
+        response = self.approved_response(request)
+        env = {
+            "PAM_TYPE": "auth", "PAM_SERVICE": "sudo", "PAM_USER": "test",
+            "PAM_RUSER": "test", "PAM_TTY": "/dev/pts/4",
+        }
+        with mock.patch.object(broker.os, "getuid", return_value=0), \
+             mock.patch.object(broker.os, "geteuid", return_value=0), \
+             mock.patch.dict(broker.os.environ, env, clear=True), \
+             mock.patch.object(broker, "load_state", return_value=(self.public_key, self.guest_id)), \
+             mock.patch.object(broker, "make_request", return_value=request), \
+             mock.patch.object(broker, "exchange", return_value=response):
+            for offset in (-16, 0, 16):
+                with self.subTest(offset=offset), \
+                     mock.patch.object(broker.time, "time", return_value=response["issuedAt"] + offset), \
+                     redirect_stdout(io.StringIO()) as output:
+                    self.assertEqual(broker.authenticate_pam(), offset == 0)
+                    if offset == 0:
+                        self.assertEqual(output.getvalue(), "")
+                    else:
+                        self.assertIn("clocks are out of sync", output.getvalue())
+                        self.assertIn("Falling back to your guest password", output.getvalue())
+                        self.assertNotIn(response["signature"], output.getvalue())
 
 
 if __name__ == "__main__":

--- a/guest/tests/test_native_authentication_bridge.py
+++ b/guest/tests/test_native_authentication_bridge.py
@@ -287,6 +287,31 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
             host.close()
         self.assertFalse(worker.is_alive())
 
+    def test_late_response_does_not_poison_the_next_request(self) -> None:
+        request = self.request()
+        response = self.approved_response(request)
+        stale = {**response, "requestId": "33333333-3333-4333-8333-333333333333"}
+        client, host = socket.socketpair()
+        try:
+            host.sendall(json.dumps(stale).encode() + b"\n" + json.dumps(response).encode() + b"\n")
+            decoded = broker.exchange_on_descriptor(client.fileno(), request, timeout=0.2)
+            broker.verify_approval(request, decoded, pinned_public_key=self.public_key, now=response["issuedAt"])
+        finally:
+            client.close()
+            host.close()
+
+    def test_stale_responses_do_not_reset_the_request_deadline(self) -> None:
+        request = self.request()
+        stale = {**self.approved_response(request), "requestId": "33333333-3333-4333-8333-333333333333"}
+        client, host = socket.socketpair()
+        try:
+            host.sendall(json.dumps(stale).encode() + b"\n")
+            with self.assertRaises(TimeoutError):
+                broker.exchange_on_descriptor(client.fileno(), request, timeout=0.01)
+        finally:
+            client.close()
+            host.close()
+
     def test_named_virtio_port_accepts_only_the_kernel_device_symlink(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             dev = Path(directory) / "dev"

--- a/guest/tests/test_touch_id_command.py
+++ b/guest/tests/test_touch_id_command.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+
+COMMAND = Path(__file__).resolve().parents[1] / "native-overlay/usr/local/bin/try-omarchy-touch-id-test"
+
+
+class TouchIDCommandTests(unittest.TestCase):
+    def test_password_fallback_is_disabled_and_failure_is_propagated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            sudo = Path(directory) / "sudo"
+            sudo.write_text(
+                '#!/bin/sh\n'
+                '[ "$1" = -k ] && exit 0\n'
+                '[ "$1" = -A ] && [ "$2" = true ] && '
+                '[ "$SUDO_ASKPASS" = /bin/false ] || exit 99\n'
+                'exit "$CHECK_STATUS"\n'
+            )
+            sudo.chmod(0o755)
+            for status in (0, 1):
+                with self.subTest(status=status):
+                    result = subprocess.run(
+                        [str(COMMAND)],
+                        env={**os.environ, "PATH": directory, "CHECK_STATUS": str(status)},
+                        capture_output=True, text=True,
+                    )
+                    self.assertEqual(result.returncode, status)
+                    if status:
+                        self.assertIn("check failed", result.stderr)
+                        self.assertEqual(result.stdout, "")
+                    else:
+                        self.assertIn("without a guest password", result.stdout)

--- a/guest/tests/test_touch_id_installer.py
+++ b/guest/tests/test_touch_id_installer.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+GUEST = Path(__file__).resolve().parents[1]
+INSTALLER = GUEST / "scripts/install-touch-id-sudo.sh"
+PAM_LINE = "auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam"
+
+
+class TouchIDInstallerTests(unittest.TestCase):
+    def test_live_installer_migrates_existing_state_and_refreshes_the_menu(self) -> None:
+        source = INSTALLER.read_text(encoding="utf-8")
+        self.assertIn("native-authentication-broker migrate", source)
+        self.assertIn("/usr/bin/omarchy menu refresh", source)
+
+    def test_stages_dormant_components_without_changing_sudo_pam(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "root"
+            (root / "usr/bin").mkdir(parents=True)
+            (root / "usr/lib/security").mkdir(parents=True)
+            (root / "etc/pam.d").mkdir(parents=True)
+            (root / "usr/bin/python3").symlink_to(sys.executable)
+            openssl = root / "usr/bin/openssl"
+            shutil.copyfile("/usr/bin/openssl", openssl)
+            openssl.chmod(0o755)
+            (root / "usr/lib/security/pam_exec.so").write_bytes(b"fixture")
+            sudo_policy = root / "etc/pam.d/sudo"
+            original_policy = "#%PAM-1.0\nauth include system-auth\n"
+            sudo_policy.write_text(original_policy, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(INSTALLER),
+                    "--root",
+                    str(root),
+                    "--guest-dir",
+                    str(GUEST),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(sudo_policy.read_text(encoding="utf-8"), original_policy)
+            self.assertNotIn(PAM_LINE, sudo_policy.read_text(encoding="utf-8"))
+            for relative in (
+                "usr/local/bin/try-omarchy-touch-id",
+                "usr/local/bin/try-omarchy-touch-id-test",
+                "usr/local/lib/try-omarchy/native-authentication-broker",
+                "usr/local/sbin/try-omarchy-touch-id-control",
+                "usr/local/sbin/try-omarchy-touch-id-enroll",
+            ):
+                installed = root / relative
+                self.assertTrue(installed.is_file(), relative)
+                self.assertTrue(os.access(installed, os.X_OK), relative)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/guest/tests/test_touch_id_installer.py
+++ b/guest/tests/test_touch_id_installer.py
@@ -11,7 +11,7 @@ import unittest
 
 GUEST = Path(__file__).resolve().parents[1]
 INSTALLER = GUEST / "scripts/install-touch-id-sudo.sh"
-PAM_LINE = "auth\t\tsufficient\tpam_exec.so quiet seteuid /usr/local/lib/try-omarchy/native-authentication-broker pam"
+PAM_LINE = "auth\t\tsufficient\tpam_exec.so quiet seteuid stdout /usr/local/lib/try-omarchy/native-authentication-broker pam"
 
 
 class TouchIDInstallerTests(unittest.TestCase):

--- a/guest/tests/test_touch_id_menu_entry.py
+++ b/guest/tests/test_touch_id_menu_entry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import tempfile
+import unittest
+
+
+GUEST = Path(__file__).resolve().parents[1]
+SCRIPT = GUEST / "scripts/install-touch-id-menu-entry.py"
+SPEC = spec_from_file_location("install_touch_id_menu_entry", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+menu_installer = module_from_spec(SPEC)
+SPEC.loader.exec_module(menu_installer)
+
+
+class TouchIDMenuEntryTests(unittest.TestCase):
+    def test_preserves_existing_jsonc_and_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / ".config/omarchy/extensions/omarchy-menu.jsonc"
+            path.parent.mkdir(parents=True)
+            original = '{\n  // User comment.\n  "personal": {"label":"Personal"},\n}\n'
+            path.write_text(original, encoding="utf-8")
+
+            menu_installer.install(path)
+            first = path.read_text(encoding="utf-8")
+            menu_installer.install(path)
+
+            self.assertIn(menu_installer.ENTRY_ID, first)
+            self.assertIn("// User comment.", first)
+            self.assertIn('"personal": {"label":"Personal"}', first)
+            self.assertEqual(path.read_text(encoding="utf-8"), first)
+
+    def test_creates_a_missing_extension(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "extensions/omarchy-menu.jsonc"
+            menu_installer.install(path)
+            self.assertIn(menu_installer.ENTRY_ID, path.read_text(encoding="utf-8"))
+
+    def test_rejects_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            target = base / "target"
+            target.write_text("{}\n", encoding="utf-8")
+            path = base / "menu.jsonc"
+            path.symlink_to(target)
+            with self.assertRaises(SystemExit):
+                menu_installer.install(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/guest/tests/test_touch_id_menu_entry.py
+++ b/guest/tests/test_touch_id_menu_entry.py
@@ -15,6 +15,18 @@ SPEC.loader.exec_module(menu_installer)
 
 
 class TouchIDMenuEntryTests(unittest.TestCase):
+    def test_compact_objects_keep_the_entry_inside_the_object(self) -> None:
+        for original in ('{}\n', '{"personal": true}\n', '{"personal": true\n}\n'):
+            with self.subTest(original=original), tempfile.TemporaryDirectory() as directory:
+                path = Path(directory) / "menu.jsonc"
+                path.write_text(original)
+                menu_installer.install(path)
+                updated = path.read_text()
+                self.assertEqual(updated, '{\n' + menu_installer.ENTRY + original[1:])
+                self.assertTrue(updated.rstrip().endswith('}'))
+                menu_installer.install(path)
+                self.assertEqual(path.read_text(), updated)
+
     def test_preserves_existing_jsonc_and_is_idempotent(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / ".config/omarchy/extensions/omarchy-menu.jsonc"

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -506,6 +506,29 @@ def main() -> None:
         spec["runtime"]["clipboard"]["port"] == "dev.tryomarchy.clipboard",
         "clipboard contract names the virtio port",
     )
+    authentication = spec["runtime"]["authenticationExperiment"]
+    authentication_launcher = read(REPO / "macos/run-qemu-gpu.sh")
+    check(
+        authentication
+        == {
+            "approvalLifetimeSeconds": 15,
+            "authorizationScope": "sudo-authentication",
+            "device": "virtserialport",
+            "guestDeviceMode": "0600",
+            "guestIdentity": "root-private-random-256-bit",
+            "hostKey": "per-guest-secure-enclave-p256",
+            "pamService": "sudo",
+            "port": "dev.tryomarchy.authentication",
+            "protocolVersion": 2,
+            "requiresEnrollment": True,
+            "signature": "ecdsa-p256-sha256",
+        }
+        and "virtserialport,bus=omarchy-serial.0,nr=3" in authentication_launcher
+        and "name=dev.tryomarchy.authentication" in authentication_launcher
+        and "--bridge-native-authentication" in authentication_launcher
+        and "authentication_bridge_restarts < 5" in authentication_launcher,
+        "Touch ID sudo experiment has a signed, supervised virtio contract",
+    )
     camera = spec["runtime"]["camera"]
     check(
         camera
@@ -888,6 +911,52 @@ def main() -> None:
     check(
         'ATTR{name}=="dev.tryomarchy.clipboard"' in clipboard_rule and 'GROUP="users"' in clipboard_rule,
         "clipboard port is readable by the provisioned users group",
+    )
+    authentication_command = (
+        GUEST / "native-overlay/usr/local/bin/try-omarchy-touch-id-test"
+    )
+    check(
+        authentication_command.stat().st_mode & stat.S_IXUSR != 0
+        and "sudo -k" in read(authentication_command)
+        and "/var/lib/try-omarchy/native-authentication.json" not in read(authentication_command),
+        "Touch ID sudo test command is executable",
+    )
+    enrollment_command = (
+        GUEST / "native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll"
+    )
+    check(
+        enrollment_command.stat().st_mode & stat.S_IXUSR != 0,
+        "Touch ID enrollment command is executable",
+    )
+    authentication_broker = (
+        GUEST
+        / "native-overlay/usr/local/lib/try-omarchy/native-authentication-broker"
+    )
+    with tempfile.TemporaryDirectory() as temporary:
+        py_compile.compile(
+            str(authentication_broker),
+            cfile=str(Path(temporary) / "authentication.pyc"),
+            doraise=True,
+        )
+    installer = read(GUEST / "scripts/install-touch-id-sudo-prototype.sh")
+    check(
+        authentication_broker.stat().st_mode & stat.S_IXUSR != 0
+        and "pam_exec.so quiet seteuid" in installer
+        and "/usr/local/lib/try-omarchy/native-authentication-broker pam" in installer
+        and "sudo.try-omarchy-before-touch-id" in installer
+        and "install-touch-id-sudo-prototype.sh" in configure,
+        "sudo PAM uses the root broker with password fallback and a live-install backup",
+    )
+    authentication_rule = read(
+        GUEST
+        / "native-overlay/etc/udev/rules.d/93-omarchy-native-authentication.rules"
+    )
+    check(
+        'ATTR{name}=="dev.tryomarchy.authentication"' in authentication_rule
+        and 'OWNER="root"' in authentication_rule
+        and 'GROUP="root"' in authentication_rule
+        and 'MODE="0600"' in authentication_rule,
+        "Touch ID authorization port is root-only",
     )
     mac_share = GUEST / "native-overlay/usr/local/bin/omarchy-native-mac-share"
     check(mac_share.stat().st_mode & stat.S_IXUSR != 0, "native Mac share mounter is executable")

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -155,15 +155,16 @@ def main() -> None:
     verbatim_trees = authenticity["verbatimRuntimeTrees"]
     backported_trees = authenticity["backportedRuntimeTrees"]
     check(
-        not {"bin", "install", "shell"} & set(verbatim_trees)
-        and backported_trees == ["bin", "install", "shell"]
+        not {"bin", "config", "install", "shell"} & set(verbatim_trees)
+        and backported_trees == ["bin", "config", "install", "shell"]
         and not set(verbatim_trees) & set(backported_trees),
-        "patched bin, install, and shell trees are separated from verbatim upstream runtime trees",
+        "patched bin, config, install, and shell trees are separated from verbatim upstream runtime trees",
     )
     backports = authenticity["backports"]
     check(
         [backport.get("id") for backport in backports]
         == [
+            "touch-id-sudo-menu",
             "1password-arm64-installer",
             "vivaldi-arm64-browser",
             "notification-hover-close",
@@ -180,8 +181,10 @@ def main() -> None:
             f"backport patch digest matches: {backport['id']}",
         )
         check(
-            backport.get("reference", "").startswith("https://github.com/basecamp/omarchy/"),
-            f"backport has an upstream review reference: {backport['id']}",
+            backport.get("reference", "").startswith(
+                ("https://github.com/basecamp/omarchy/", "https://github.com/omacom/try-omarchy/")
+            ),
+            f"backport has a public review reference: {backport['id']}",
         )
         for target in backport["targets"]:
             check(
@@ -506,11 +509,12 @@ def main() -> None:
         spec["runtime"]["clipboard"]["port"] == "dev.tryomarchy.clipboard",
         "clipboard contract names the virtio port",
     )
-    authentication = spec["runtime"]["authenticationExperiment"]
+    authentication = spec["runtime"]["authentication"]
     authentication_launcher = read(REPO / "macos/run-qemu-gpu.sh")
     check(
         authentication
         == {
+            "activation": "explicit-menu-opt-in",
             "approvalLifetimeSeconds": 15,
             "authorizationScope": "sudo-authentication",
             "device": "virtserialport",
@@ -519,7 +523,7 @@ def main() -> None:
             "hostKey": "per-guest-secure-enclave-p256",
             "pamService": "sudo",
             "port": "dev.tryomarchy.authentication",
-            "protocolVersion": 2,
+            "protocolVersion": 3,
             "requiresEnrollment": True,
             "signature": "ecdsa-p256-sha256",
         }
@@ -527,7 +531,7 @@ def main() -> None:
         and "name=dev.tryomarchy.authentication" in authentication_launcher
         and "--bridge-native-authentication" in authentication_launcher
         and "authentication_bridge_restarts < 5" in authentication_launcher,
-        "Touch ID sudo experiment has a signed, supervised virtio contract",
+        "Touch ID sudo has a signed, supervised virtio contract",
     )
     camera = spec["runtime"]["camera"]
     check(
@@ -924,9 +928,15 @@ def main() -> None:
     enrollment_command = (
         GUEST / "native-overlay/usr/local/sbin/try-omarchy-touch-id-enroll"
     )
+    menu_command = GUEST / "native-overlay/usr/local/bin/try-omarchy-touch-id"
+    control_command = (
+        GUEST / "native-overlay/usr/local/sbin/try-omarchy-touch-id-control"
+    )
     check(
-        enrollment_command.stat().st_mode & stat.S_IXUSR != 0,
-        "Touch ID enrollment command is executable",
+        enrollment_command.stat().st_mode & stat.S_IXUSR != 0
+        and menu_command.stat().st_mode & stat.S_IXUSR != 0
+        and control_command.stat().st_mode & stat.S_IXUSR != 0,
+        "Touch ID menu, enrollment, and root control commands are executable",
     )
     authentication_broker = (
         GUEST
@@ -938,14 +948,29 @@ def main() -> None:
             cfile=str(Path(temporary) / "authentication.pyc"),
             doraise=True,
         )
-    installer = read(GUEST / "scripts/install-touch-id-sudo-prototype.sh")
+    installer = read(GUEST / "scripts/install-touch-id-sudo.sh")
+    control = read(control_command)
+    menu = read(menu_command)
     check(
         authentication_broker.stat().st_mode & stat.S_IXUSR != 0
-        and "pam_exec.so quiet seteuid" in installer
-        and "/usr/local/lib/try-omarchy/native-authentication-broker pam" in installer
-        and "sudo.try-omarchy-before-touch-id" in installer
-        and "install-touch-id-sudo-prototype.sh" in configure,
-        "sudo PAM uses the root broker with password fallback and a live-install backup",
+        and "/etc/pam.d/sudo" not in installer
+        and "pam_exec.so quiet seteuid" in control
+        and control.index('"$broker" enroll') < control.index("rewrite_policy enable")
+        and control.index("rewrite_policy disable") < control.index('"$broker" disable')
+        and "native-authentication-broker migrate" in installer
+        and "/usr/bin/omarchy menu refresh" in installer
+        and "sudo -k" in menu
+        and "omarchy menu refresh" in menu
+        and "gum choose" in menu
+        and "install-touch-id-sudo.sh" in configure,
+        "Touch ID stays dormant until transactional menu enrollment enables sudo PAM",
+    )
+    touch_id_menu_patch = read(GUEST / "patches/omarchy/touch-id-sudo-menu.patch")
+    check(
+        '"setup.security.touch-id"' in touch_id_menu_patch
+        and '"checked":"/usr/local/bin/try-omarchy-touch-id status --quiet"' in touch_id_menu_patch
+        and "omarchy-launch-floating-terminal-with-presentation /usr/local/bin/try-omarchy-touch-id" in touch_id_menu_patch,
+        "Omarchy Setup > Security exposes one stateful Touch ID sudo control",
     )
     authentication_rule = read(
         GUEST

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -837,6 +837,7 @@ def main() -> None:
     check("factory" in finalizer and "aarch64" in finalizer, "finalizer enforces the native factory contract")
     check("systemd-growfs-root.service" in finalizer, "factory disk grows on first boot")
     check("systemctl enable omarchy-native-mac-share.service" in finalizer, "shared Mac folder mounts at boot")
+    check("systemctl enable systemd-timesyncd.service" in finalizer, "guest time synchronization starts at boot")
     check(
         'expected_ttfx=$(read_spec' in finalizer
         and "/usr/bin/ttfx --version" in finalizer
@@ -954,7 +955,7 @@ def main() -> None:
     check(
         authentication_broker.stat().st_mode & stat.S_IXUSR != 0
         and "/etc/pam.d/sudo" not in installer
-        and "pam_exec.so quiet seteuid" in control
+        and "pam_exec.so quiet seteuid stdout" in control
         and control.index('"$broker" enroll') < control.index("rewrite_policy enable")
         and control.index("rewrite_policy disable") < control.index('"$broker" disable')
         and "native-authentication-broker migrate" in installer

--- a/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
@@ -6,11 +6,14 @@ import LocalAuthentication
 import Security
 
 enum NativeAuthenticationOperation: String, Equatable {
+    case disable
     case enroll
     case sudo
 
     var localizedReason: String {
         switch self {
+        case .disable:
+            "Disable Touch ID for sudo in this Try Omarchy guest"
         case .enroll:
             "Pair this Try Omarchy guest for Touch ID sudo testing"
         case .sudo:
@@ -21,7 +24,7 @@ enum NativeAuthenticationOperation: String, Equatable {
 
 struct NativeAuthenticationRequest: Equatable {
     static let maximumLineBytes = 4096
-    static let protocolVersion = 2
+    static let protocolVersion = 3
 
     let operation: NativeAuthenticationOperation
     let guestID: String
@@ -58,9 +61,9 @@ struct NativeAuthenticationRequest: Equatable {
         }
 
         switch operation {
-        case .enroll:
+        case .disable, .enroll:
             guard user.isEmpty, requestingUser.isEmpty, tty.isEmpty else {
-                throw HelperError.io("guest sent an invalid enrollment request")
+                throw HelperError.io("guest sent an invalid authentication control request")
             }
         case .sudo:
             guard isAccountName(user),
@@ -84,7 +87,7 @@ struct NativeAuthenticationRequest: Equatable {
 
     func signaturePayload(issuedAt: Int64, expiresAt: Int64, keyID: String) -> Data {
         let fields = [
-            "try-omarchy-native-authentication-v2",
+            "try-omarchy-native-authentication-v3",
             guestID,
             operation.rawValue,
             requestID,
@@ -138,7 +141,20 @@ struct NativeAuthenticationApproval: Equatable {
 
 struct NativeAuthenticationResponse: Equatable {
     let request: NativeAuthenticationRequest
+    let approved: Bool
     let approval: NativeAuthenticationApproval?
+
+    init(request: NativeAuthenticationRequest, approval: NativeAuthenticationApproval?) {
+        self.request = request
+        self.approved = approval != nil
+        self.approval = approval
+    }
+
+    init(disabledRequest request: NativeAuthenticationRequest) {
+        self.request = request
+        self.approved = true
+        self.approval = nil
+    }
 
     func encode() throws -> Data {
         let object: [String: Any] = [
@@ -152,7 +168,7 @@ struct NativeAuthenticationResponse: Equatable {
             "requestingUser": request.requestingUser,
             "service": request.service,
             "tty": request.tty,
-            "approved": approval != nil,
+            "approved": approved,
             "issuedAt": approval?.issuedAt ?? 0,
             "expiresAt": approval?.expiresAt ?? 0,
             "keyId": approval?.keyID ?? "",
@@ -167,6 +183,7 @@ struct NativeAuthenticationResponse: Equatable {
 
 protocol HostAuthorizationSigning: AnyObject {
     func authorize(_ request: NativeAuthenticationRequest) throws -> NativeAuthenticationApproval?
+    func disable(guestID: String) throws
     func cancel()
 }
 
@@ -194,6 +211,9 @@ final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @uncheck
         }
         let keyURL = keyURL(for: request.guestID)
         let keyAlreadyExists = try keyExists(at: keyURL)
+        if request.operation == .disable {
+            throw HelperError.io("disable request reached the signing path")
+        }
         if request.operation == .sudo && !keyAlreadyExists {
             fputs("[authentication-bridge] Touch ID sudo is not enrolled for this Mac.\n", stderr)
             return nil
@@ -238,6 +258,14 @@ final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @uncheck
             publicKey: publicKeyData,
             signature: signature
         )
+    }
+
+    func disable(guestID: String) throws {
+        let keyURL = keyURL(for: guestID)
+        guard try keyExists(at: keyURL) else { return }
+        guard Darwin.unlink(keyURL.path) == 0 else {
+            throw HelperError.io("cannot remove Secure Enclave key representation")
+        }
     }
 
     func cancel() {
@@ -484,6 +512,26 @@ final class NativeAuthenticationBridge {
 
     private func handle(_ data: Data) throws {
         let request = try NativeAuthenticationRequest.decode(data)
+        if request.operation == .disable {
+            var disabled = false
+            if processAlive(), focusProbe() {
+                do {
+                    try signer.disable(guestID: request.guestID)
+                    disabled = true
+                } catch {
+                    fputs("[authentication-bridge] \(error.localizedDescription)\n", stderr)
+                }
+            }
+            let response = disabled
+                ? NativeAuthenticationResponse(disabledRequest: request)
+                : NativeAuthenticationResponse(request: request, approval: nil)
+            try NativeBridgeSocket.writeAll(
+                response.encode(),
+                to: descriptor,
+                label: "authentication"
+            )
+            return
+        }
         var approval: NativeAuthenticationApproval?
         if processAlive(), focusProbe() {
             do {

--- a/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
@@ -1,0 +1,505 @@
+import AppKit
+import CryptoKit
+import Darwin
+import Foundation
+import LocalAuthentication
+import Security
+
+enum NativeAuthenticationOperation: String, Equatable {
+    case enroll
+    case sudo
+
+    var localizedReason: String {
+        switch self {
+        case .enroll:
+            "Pair this Try Omarchy guest for Touch ID sudo testing"
+        case .sudo:
+            "Approve sudo in the focused Try Omarchy guest"
+        }
+    }
+}
+
+struct NativeAuthenticationRequest: Equatable {
+    static let maximumLineBytes = 4096
+    static let protocolVersion = 2
+
+    let operation: NativeAuthenticationOperation
+    let guestID: String
+    let requestID: String
+    let challenge: String
+    let user: String
+    let requestingUser: String
+    let service: String
+    let tty: String
+
+    static func decode(_ data: Data) throws -> Self {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              object.keys.sorted() == [
+                  "challenge", "guestId", "operation", "requestId", "requestingUser",
+                  "service", "tty", "type", "user", "version",
+              ],
+              object["type"] as? String == "authorize",
+              object["version"] as? Int == protocolVersion,
+              let operationValue = object["operation"] as? String,
+              let operation = NativeAuthenticationOperation(rawValue: operationValue),
+              let guestID = object["guestId"] as? String,
+              isLowercaseHex(guestID, bytes: 32),
+              let requestID = object["requestId"] as? String,
+              let identifier = UUID(uuidString: requestID),
+              identifier.uuidString.lowercased() == requestID,
+              let challenge = object["challenge"] as? String,
+              isLowercaseHex(challenge, bytes: 32),
+              let user = object["user"] as? String,
+              let requestingUser = object["requestingUser"] as? String,
+              let service = object["service"] as? String,
+              service == "sudo",
+              let tty = object["tty"] as? String else {
+            throw HelperError.io("guest sent an invalid authentication request")
+        }
+
+        switch operation {
+        case .enroll:
+            guard user.isEmpty, requestingUser.isEmpty, tty.isEmpty else {
+                throw HelperError.io("guest sent an invalid enrollment request")
+            }
+        case .sudo:
+            guard isAccountName(user),
+                  isAccountName(requestingUser),
+                  isInteractiveTTY(tty) else {
+                throw HelperError.io("guest sent invalid sudo authentication context")
+            }
+        }
+
+        return Self(
+            operation: operation,
+            guestID: guestID,
+            requestID: requestID,
+            challenge: challenge,
+            user: user,
+            requestingUser: requestingUser,
+            service: service,
+            tty: tty
+        )
+    }
+
+    func signaturePayload(issuedAt: Int64, expiresAt: Int64, keyID: String) -> Data {
+        let fields = [
+            "try-omarchy-native-authentication-v2",
+            guestID,
+            operation.rawValue,
+            requestID,
+            challenge,
+            user,
+            requestingUser,
+            service,
+            tty,
+            String(issuedAt),
+            String(expiresAt),
+            keyID,
+        ]
+        return Data(fields.joined(separator: "\0").utf8)
+    }
+
+    private static func isLowercaseHex(_ value: String, bytes: Int) -> Bool {
+        value.utf8.count == bytes * 2
+            && value.utf8.allSatisfy { (48...57).contains($0) || (97...102).contains($0) }
+    }
+
+    private static func isAccountName(_ value: String) -> Bool {
+        let bytes = Array(value.utf8)
+        guard (1...32).contains(bytes.count),
+              let first = bytes.first,
+              first == 95 || (97...122).contains(first) else { return false }
+        return bytes.dropFirst().allSatisfy {
+            $0 == 45 || $0 == 95 || (48...57).contains($0) || (97...122).contains($0)
+        }
+    }
+
+    private static func isInteractiveTTY(_ value: String) -> Bool {
+        let suffix: Substring
+        if value.hasPrefix("/dev/pts/") {
+            suffix = value.dropFirst("/dev/pts/".count)
+        } else if value.hasPrefix("/dev/tty") {
+            suffix = value.dropFirst("/dev/tty".count)
+        } else {
+            return false
+        }
+        return !suffix.isEmpty && suffix.utf8.allSatisfy { (48...57).contains($0) }
+    }
+}
+
+struct NativeAuthenticationApproval: Equatable {
+    let issuedAt: Int64
+    let expiresAt: Int64
+    let keyID: String
+    let publicKey: Data
+    let signature: Data
+}
+
+struct NativeAuthenticationResponse: Equatable {
+    let request: NativeAuthenticationRequest
+    let approval: NativeAuthenticationApproval?
+
+    func encode() throws -> Data {
+        let object: [String: Any] = [
+            "type": "authorization-result",
+            "version": NativeAuthenticationRequest.protocolVersion,
+            "operation": request.operation.rawValue,
+            "guestId": request.guestID,
+            "requestId": request.requestID,
+            "challenge": request.challenge,
+            "user": request.user,
+            "requestingUser": request.requestingUser,
+            "service": request.service,
+            "tty": request.tty,
+            "approved": approval != nil,
+            "issuedAt": approval?.issuedAt ?? 0,
+            "expiresAt": approval?.expiresAt ?? 0,
+            "keyId": approval?.keyID ?? "",
+            "publicKey": approval?.publicKey.base64EncodedString() ?? "",
+            "signature": approval?.signature.base64EncodedString() ?? "",
+        ]
+        var data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        data.append(0x0A)
+        return data
+    }
+}
+
+protocol HostAuthorizationSigning: AnyObject {
+    func authorize(_ request: NativeAuthenticationRequest) throws -> NativeAuthenticationApproval?
+    func cancel()
+}
+
+final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @unchecked Sendable {
+    static let approvalLifetimeSeconds: Int64 = 15
+
+    private let lock = NSLock()
+    private let keyDirectory: URL
+    private var activeContext: LAContext?
+
+    init(keyDirectory: URL? = nil) {
+        self.keyDirectory = keyDirectory
+            ?? FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            )[0]
+            .appendingPathComponent("Try Omarchy", isDirectory: true)
+            .appendingPathComponent("Native Authentication Keys", isDirectory: true)
+    }
+
+    func authorize(_ request: NativeAuthenticationRequest) throws -> NativeAuthenticationApproval? {
+        guard SecureEnclave.isAvailable else {
+            fputs("[authentication-bridge] The Secure Enclave is unavailable.\n", stderr)
+            return nil
+        }
+        let keyURL = keyURL(for: request.guestID)
+        let keyAlreadyExists = try keyExists(at: keyURL)
+        if request.operation == .sudo && !keyAlreadyExists {
+            fputs("[authentication-bridge] Touch ID sudo is not enrolled for this Mac.\n", stderr)
+            return nil
+        }
+
+        guard let context = authenticate(reason: request.operation.localizedReason) else {
+            return nil
+        }
+        defer { clear(context) }
+
+        let privateKey: SecureEnclave.P256.Signing.PrivateKey
+        if request.operation == .enroll && !keyAlreadyExists {
+            privateKey = try createPrivateKey(authenticationContext: context)
+            try saveKeyRepresentation(privateKey.dataRepresentation, to: keyURL)
+        } else {
+            privateKey = try loadPrivateKey(
+                from: keyURL,
+                authenticationContext: context
+            )
+        }
+        let publicKeyData = privateKey.publicKey.x963Representation
+        guard publicKeyData.count == 65,
+              publicKeyData.first == 0x04 else {
+            throw HelperError.io("cannot export Secure Enclave P-256 public key")
+        }
+        let keyID = SHA256.hash(data: publicKeyData)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let issuedAt = Int64(Date().timeIntervalSince1970)
+        let expiresAt = issuedAt + Self.approvalLifetimeSeconds
+        let payload = request.signaturePayload(
+            issuedAt: issuedAt,
+            expiresAt: expiresAt,
+            keyID: keyID
+        )
+
+        let signature = try privateKey.signature(for: payload).derRepresentation
+        return NativeAuthenticationApproval(
+            issuedAt: issuedAt,
+            expiresAt: expiresAt,
+            keyID: keyID,
+            publicKey: publicKeyData,
+            signature: signature
+        )
+    }
+
+    func cancel() {
+        lock.lock()
+        let context = activeContext
+        activeContext = nil
+        lock.unlock()
+        context?.invalidate()
+    }
+
+    private func authenticate(reason: String) -> LAContext? {
+        let context = LAContext()
+        context.localizedCancelTitle = "Return to Omarchy"
+        context.localizedFallbackTitle = ""
+        context.touchIDAuthenticationAllowableReuseDuration = 0
+
+        var availabilityError: NSError?
+        guard context.canEvaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            error: &availabilityError
+        ) else {
+            let detail = availabilityError?.localizedDescription ?? "Touch ID is unavailable"
+            fputs("[authentication-bridge] \(detail)\n", stderr)
+            return nil
+        }
+
+        lock.lock()
+        activeContext = context
+        lock.unlock()
+
+        let completion = DispatchSemaphore(value: 0)
+        let resultLock = NSLock()
+        var approved = false
+        context.evaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            localizedReason: reason
+        ) { success, _ in
+            resultLock.lock()
+            approved = success
+            resultLock.unlock()
+            completion.signal()
+        }
+        completion.wait()
+        resultLock.lock()
+        let result = approved
+        resultLock.unlock()
+        if !result {
+            clear(context)
+            return nil
+        }
+        return context
+    }
+
+    private func clear(_ context: LAContext) {
+        lock.lock()
+        if activeContext === context {
+            activeContext = nil
+        }
+        lock.unlock()
+    }
+
+    private func keyURL(for guestID: String) -> URL {
+        keyDirectory.appendingPathComponent("\(guestID).key", isDirectory: false)
+    }
+
+    private func keyExists(at url: URL) throws -> Bool {
+        var information = stat()
+        if lstat(url.path, &information) == 0 {
+            guard (information.st_mode & S_IFMT) == S_IFREG,
+                  information.st_uid == getuid(),
+                  (information.st_mode & 0o777) == 0o600 else {
+                throw HelperError.io("Secure Enclave key representation is unsafe")
+            }
+            return true
+        }
+        if errno == ENOENT { return false }
+        throw HelperError.io("cannot inspect Secure Enclave key representation")
+    }
+
+    private func createPrivateKey(
+        authenticationContext: LAContext
+    ) throws -> SecureEnclave.P256.Signing.PrivateKey {
+        var accessError: Unmanaged<CFError>?
+        guard let accessControl = SecAccessControlCreateWithFlags(
+            kCFAllocatorDefault,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            [.privateKeyUsage, .biometryCurrentSet],
+            &accessError
+        ) else {
+            throw HelperError.io(
+                "cannot create Secure Enclave access control: \(errorDescription(accessError))"
+            )
+        }
+        return try SecureEnclave.P256.Signing.PrivateKey(
+            compactRepresentable: false,
+            accessControl: accessControl,
+            authenticationContext: authenticationContext
+        )
+    }
+
+    private func saveKeyRepresentation(_ representation: Data, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: keyDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: keyDirectory.path
+        )
+        var directoryInfo = stat()
+        guard lstat(keyDirectory.path, &directoryInfo) == 0,
+              (directoryInfo.st_mode & S_IFMT) == S_IFDIR,
+              directoryInfo.st_uid == getuid(),
+              (directoryInfo.st_mode & 0o777) == 0o700 else {
+            throw HelperError.io("Secure Enclave key directory is unsafe")
+        }
+
+        let descriptor = Darwin.open(
+            url.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw HelperError.io("cannot create Secure Enclave key representation")
+        }
+        var completed = false
+        defer {
+            Darwin.close(descriptor)
+            if !completed {
+                Darwin.unlink(url.path)
+            }
+        }
+        try NativeBridgeSocket.writeAll(
+            representation,
+            to: descriptor,
+            label: "Secure Enclave key representation"
+        )
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw HelperError.io("cannot sync Secure Enclave key representation")
+        }
+        completed = true
+    }
+
+    private func loadPrivateKey(
+        from url: URL,
+        authenticationContext: LAContext
+    ) throws -> SecureEnclave.P256.Signing.PrivateKey {
+        guard try keyExists(at: url) else {
+            throw HelperError.io("Secure Enclave key representation is missing")
+        }
+        let representation = try Data(contentsOf: url, options: .uncached)
+        guard representation.count <= 4096 else {
+            throw HelperError.io("Secure Enclave key representation is too large")
+        }
+        return try SecureEnclave.P256.Signing.PrivateKey(
+            dataRepresentation: representation,
+            authenticationContext: authenticationContext
+        )
+    }
+
+    private func errorDescription(_ error: Unmanaged<CFError>?) -> String {
+        error?.takeRetainedValue().localizedDescription
+            ?? "unknown Security framework error"
+    }
+}
+
+final class NativeAuthenticationBridge {
+    typealias FocusProbe = () -> Bool
+    typealias ProcessAlive = () -> Bool
+
+    private let descriptor: Int32
+    private let signer: HostAuthorizationSigning
+    private let focusProbe: FocusProbe
+    private let processAlive: ProcessAlive
+    private let stopLock = NSLock()
+    private var stopped = false
+
+    init(
+        targetPID: pid_t,
+        socketPath: String,
+        signer: HostAuthorizationSigning = SecureEnclaveAuthorizationSigner(),
+        focusProbe: FocusProbe? = nil,
+        processAlive: ProcessAlive? = nil
+    ) throws {
+        guard let processIdentity = KernelProcessIdentity.capture(processIdentifier: targetPID),
+              processIdentity.isQEMUSystemProcess else {
+            throw HelperError.io("native authentication bridge target is not a QEMU system process")
+        }
+        descriptor = try NativeBridgeSocket.connectSecure(
+            path: socketPath,
+            label: "authentication bridge"
+        )
+        self.signer = signer
+        self.focusProbe = focusProbe ?? {
+            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == targetPID,
+                  let application = NSRunningApplication(processIdentifier: targetPID) else {
+                return false
+            }
+            return application.isActive && !application.isTerminated
+        }
+        self.processAlive = processAlive ?? { processIdentity.isStillRunning }
+    }
+
+    deinit {
+        stop()
+    }
+
+    func run() throws {
+        var line = Data()
+        while true {
+            var byte: UInt8 = 0
+            let count = Darwin.read(descriptor, &byte, 1)
+            if count == 1 {
+                if byte == 0x0A {
+                    try handle(line)
+                    line.removeAll(keepingCapacity: true)
+                } else if byte != 0x0D {
+                    guard line.count < NativeAuthenticationRequest.maximumLineBytes else {
+                        throw HelperError.io("guest authentication request exceeds 4 KiB")
+                    }
+                    line.append(byte)
+                }
+            } else if count == 0 {
+                return
+            } else if errno != EINTR {
+                throw HelperError.io("cannot read the guest authentication channel")
+            }
+        }
+    }
+
+    func stop() {
+        stopLock.lock()
+        guard !stopped else {
+            stopLock.unlock()
+            return
+        }
+        stopped = true
+        stopLock.unlock()
+        signer.cancel()
+        Darwin.shutdown(descriptor, SHUT_RDWR)
+        Darwin.close(descriptor)
+    }
+
+    private func handle(_ data: Data) throws {
+        let request = try NativeAuthenticationRequest.decode(data)
+        var approval: NativeAuthenticationApproval?
+        if processAlive(), focusProbe() {
+            do {
+                let candidate = try signer.authorize(request)
+                if processAlive(), focusProbe() {
+                    approval = candidate
+                }
+            } catch {
+                fputs("[authentication-bridge] \(error.localizedDescription)\n", stderr)
+            }
+        }
+        let response = NativeAuthenticationResponse(request: request, approval: approval)
+        try NativeBridgeSocket.writeAll(
+            response.encode(),
+            to: descriptor,
+            label: "authentication"
+        )
+    }
+}

--- a/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
@@ -187,6 +187,31 @@ protocol HostAuthorizationSigning: AnyObject {
     func cancel()
 }
 
+enum NativeAuthenticationPrompt {
+    static func approve(
+        timeout: TimeInterval = 55,
+        evaluate: (@escaping (Bool) -> Void) -> Void,
+        cancel: () -> Void
+    ) -> Bool {
+        let completion = DispatchSemaphore(value: 0)
+        let lock = NSLock()
+        var approved = false
+        evaluate { success in
+            lock.lock()
+            approved = success
+            lock.unlock()
+            completion.signal()
+        }
+        guard completion.wait(timeout: .now() + timeout) == .success else {
+            cancel()
+            return false
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        return approved
+    }
+}
+
 final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @unchecked Sendable {
     static let approvalLifetimeSeconds: Int64 = 15
 
@@ -296,22 +321,15 @@ final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @uncheck
         activeContext = context
         lock.unlock()
 
-        let completion = DispatchSemaphore(value: 0)
-        let resultLock = NSLock()
-        var approved = false
-        context.evaluatePolicy(
-            .deviceOwnerAuthenticationWithBiometrics,
-            localizedReason: reason
-        ) { success, _ in
-            resultLock.lock()
-            approved = success
-            resultLock.unlock()
-            completion.signal()
-        }
-        completion.wait()
-        resultLock.lock()
-        let result = approved
-        resultLock.unlock()
+        let result = NativeAuthenticationPrompt.approve(
+            evaluate: { completion in
+                context.evaluatePolicy(
+                    .deviceOwnerAuthenticationWithBiometrics,
+                    localizedReason: reason
+                ) { success, _ in completion(success) }
+            },
+            cancel: { context.invalidate() }
+        )
         if !result {
             clear(context)
             return nil

--- a/macos/Sources/OmarchyVMHelper/main.swift
+++ b/macos/Sources/OmarchyVMHelper/main.swift
@@ -5,7 +5,7 @@ import Foundation
 private var terminationSignalSources: [DispatchSourceSignal] = []
 
 private func usage() -> Never {
-    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY | --bridge-native-camera QEMU_PID SOCKET | --bridge-native-clipboard QEMU_PID SOCKET\n", stderr)
+    fputs("Usage: omarchy-vm-helper --run-qemu [--ephemeral | --reset-storage | --reset-storage-only] [GUEST_DIR] | --bridge-command-super QEMU_PID QMP_SOCKET | --bridge-native-audio QEMU_PID SOCKET ROUTE_DIRECTORY | --bridge-native-authentication QEMU_PID SOCKET | --bridge-native-camera QEMU_PID SOCKET | --bridge-native-clipboard QEMU_PID SOCKET\n", stderr)
     exit(64)
 }
 
@@ -64,6 +64,29 @@ do {
             terminationSignalSources.append(source)
         }
         fputs("[clipboard-bridge] The Mac clipboard is shared with Omarchy.\n", stderr)
+        try bridge.run()
+        exit(0)
+    }
+
+    if arguments.first == "--bridge-native-authentication" {
+        guard arguments.count == 3,
+              let processIdentifier = Int32(arguments[1]),
+              processIdentifier > 1 else { usage() }
+        let bridge = try NativeAuthenticationBridge(
+            targetPID: processIdentifier,
+            socketPath: arguments[2]
+        )
+        for signalNumber in [SIGINT, SIGTERM] {
+            Darwin.signal(signalNumber, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(
+                signal: signalNumber,
+                queue: .global(qos: .userInitiated)
+            )
+            source.setEventHandler { bridge.stop() }
+            source.resume()
+            terminationSignalSources.append(source)
+        }
+        fputs("[authentication-bridge] Signed Touch ID sudo authentication is available inside Omarchy.\n", stderr)
         try bridge.run()
         exit(0)
     }

--- a/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import OmarchyVMHelper
+
+@Suite("Native authentication bridge")
+struct NativeAuthenticationBridgeTests {
+    private let requestID = "2a8adad0-e2e3-43a0-882f-82f64d691c86"
+    private let challenge = String(repeating: "ab", count: 32)
+    private let guestID = String(repeating: "ef", count: 32)
+
+    @Test("sudo requests use a strict versioned context")
+    func sudoRequestSchema() throws {
+        let line = Data(
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/4","type":"authorize","user":"test","version":2}"#.utf8
+        )
+        #expect(
+            try NativeAuthenticationRequest.decode(line)
+                == NativeAuthenticationRequest(
+                    operation: .sudo,
+                    guestID: guestID,
+                    requestID: requestID,
+                    challenge: challenge,
+                    user: "test",
+                    requestingUser: "test",
+                    service: "sudo",
+                    tty: "/dev/pts/4"
+                )
+        )
+    }
+
+    @Test("enrollment cannot smuggle sudo context")
+    func enrollmentSchema() throws {
+        let valid = Data(
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"","service":"sudo","tty":"","type":"authorize","user":"","version":2}"#.utf8
+        )
+        #expect(try NativeAuthenticationRequest.decode(valid).operation == .enroll)
+
+        let invalid = Data(
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"","type":"authorize","user":"test","version":2}"#.utf8
+        )
+        #expect(throws: HelperError.self) {
+            try NativeAuthenticationRequest.decode(invalid)
+        }
+    }
+
+    @Test("malformed or extensible authorization requests are rejected")
+    func invalidRequests() {
+        for line in [
+            "not json",
+            #"{"challenge":"short","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"\#(challenge)","guestId":"short","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"not-a-uuid","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"login","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"unknown","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"\#(challenge)","extra":true,"guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+        ] {
+            #expect(throws: HelperError.self) {
+                try NativeAuthenticationRequest.decode(Data(line.utf8))
+            }
+        }
+    }
+
+    @Test("signature payload binds every sudo context field")
+    func signaturePayload() {
+        let request = NativeAuthenticationRequest(
+            operation: .sudo,
+            guestID: guestID,
+            requestID: requestID,
+            challenge: challenge,
+            user: "root",
+            requestingUser: "test",
+            service: "sudo",
+            tty: "/dev/pts/7"
+        )
+        #expect(
+            request.signaturePayload(
+                issuedAt: 1_788_623_100,
+                expiresAt: 1_788_623_115,
+                keyID: String(repeating: "cd", count: 32)
+            )
+                == Data(
+                    [
+                        "try-omarchy-native-authentication-v2",
+                        guestID,
+                        "sudo",
+                        requestID,
+                        challenge,
+                        "root",
+                        "test",
+                        "sudo",
+                        "/dev/pts/7",
+                        "1788623100",
+                        "1788623115",
+                        String(repeating: "cd", count: 32),
+                    ].joined(separator: "\0").utf8
+                )
+        )
+    }
+
+    @Test("approved responses carry signed material and denials carry none")
+    func responseSchema() throws {
+        let request = NativeAuthenticationRequest(
+            operation: .sudo,
+            guestID: guestID,
+            requestID: requestID,
+            challenge: challenge,
+            user: "test",
+            requestingUser: "test",
+            service: "sudo",
+            tty: "/dev/pts/2"
+        )
+        let publicKey = Data([0x04] + Array(repeating: UInt8(0x11), count: 64))
+        let signature = Data([0x30, 0x02, 0x01, 0x01])
+        let encoded = try NativeAuthenticationResponse(
+            request: request,
+            approval: NativeAuthenticationApproval(
+                issuedAt: 1_788_623_100,
+                expiresAt: 1_788_623_115,
+                keyID: String(repeating: "cd", count: 32),
+                publicKey: publicKey,
+                signature: signature
+            )
+        ).encode()
+        let object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        #expect(object.keys.sorted() == [
+            "approved", "challenge", "expiresAt", "guestId", "issuedAt", "keyId",
+            "operation", "publicKey", "requestId", "requestingUser", "service",
+            "signature", "tty", "type", "user", "version",
+        ])
+        #expect(object["approved"] as? Bool == true)
+        #expect(object["publicKey"] as? String == publicKey.base64EncodedString())
+        #expect(object["signature"] as? String == signature.base64EncodedString())
+        #expect(encoded.last == 0x0A)
+
+        let denied = try NativeAuthenticationResponse(request: request, approval: nil).encode()
+        let deniedObject = try #require(
+            JSONSerialization.jsonObject(with: denied) as? [String: Any]
+        )
+        #expect(deniedObject["approved"] as? Bool == false)
+        #expect(deniedObject["issuedAt"] as? Int == 0)
+        #expect(deniedObject["keyId"] as? String == "")
+    }
+
+    @Test("prompt text is fixed by operation and approvals are short-lived")
+    func promptPolicy() {
+        #expect(NativeAuthenticationOperation.enroll.localizedReason.contains("Pair"))
+        #expect(NativeAuthenticationOperation.sudo.localizedReason.contains("sudo"))
+        #expect(SecureEnclaveAuthorizationSigner.approvalLifetimeSeconds == 15)
+    }
+}

--- a/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
@@ -11,7 +11,7 @@ struct NativeAuthenticationBridgeTests {
     @Test("sudo requests use a strict versioned context")
     func sudoRequestSchema() throws {
         let line = Data(
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/4","type":"authorize","user":"test","version":2}"#.utf8
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/4","type":"authorize","user":"test","version":3}"#.utf8
         )
         #expect(
             try NativeAuthenticationRequest.decode(line)
@@ -31,12 +31,12 @@ struct NativeAuthenticationBridgeTests {
     @Test("enrollment cannot smuggle sudo context")
     func enrollmentSchema() throws {
         let valid = Data(
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"","service":"sudo","tty":"","type":"authorize","user":"","version":2}"#.utf8
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"","service":"sudo","tty":"","type":"authorize","user":"","version":3}"#.utf8
         )
         #expect(try NativeAuthenticationRequest.decode(valid).operation == .enroll)
 
         let invalid = Data(
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"","type":"authorize","user":"test","version":2}"#.utf8
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"enroll","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"","type":"authorize","user":"test","version":3}"#.utf8
         )
         #expect(throws: HelperError.self) {
             try NativeAuthenticationRequest.decode(invalid)
@@ -47,12 +47,12 @@ struct NativeAuthenticationBridgeTests {
     func invalidRequests() {
         for line in [
             "not json",
-            #"{"challenge":"short","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
-            #"{"challenge":"\#(challenge)","guestId":"short","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"not-a-uuid","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"login","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
-            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"unknown","type":"authorize","user":"test","version":2}"#,
-            #"{"challenge":"\#(challenge)","extra":true,"guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":2}"#,
+            #"{"challenge":"short","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":3}"#,
+            #"{"challenge":"\#(challenge)","guestId":"short","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":3}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"not-a-uuid","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":3}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"login","tty":"/dev/pts/1","type":"authorize","user":"test","version":3}"#,
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"unknown","type":"authorize","user":"test","version":3}"#,
+            #"{"challenge":"\#(challenge)","extra":true,"guestId":"\#(guestID)","operation":"sudo","requestId":"\#(requestID)","requestingUser":"test","service":"sudo","tty":"/dev/pts/1","type":"authorize","user":"test","version":3}"#,
         ] {
             #expect(throws: HelperError.self) {
                 try NativeAuthenticationRequest.decode(Data(line.utf8))
@@ -80,7 +80,7 @@ struct NativeAuthenticationBridgeTests {
             )
                 == Data(
                     [
-                        "try-omarchy-native-authentication-v2",
+                        "try-omarchy-native-authentication-v3",
                         guestID,
                         "sudo",
                         requestID,
@@ -141,12 +141,48 @@ struct NativeAuthenticationBridgeTests {
         #expect(deniedObject["approved"] as? Bool == false)
         #expect(deniedObject["issuedAt"] as? Int == 0)
         #expect(deniedObject["keyId"] as? String == "")
+
+        let disable = NativeAuthenticationRequest(
+            operation: .disable,
+            guestID: guestID,
+            requestID: requestID,
+            challenge: challenge,
+            user: "",
+            requestingUser: "",
+            service: "sudo",
+            tty: ""
+        )
+        let disabled = try NativeAuthenticationResponse(disabledRequest: disable).encode()
+        let disabledObject = try #require(
+            JSONSerialization.jsonObject(with: disabled) as? [String: Any]
+        )
+        #expect(disabledObject["approved"] as? Bool == true)
+        #expect(disabledObject["issuedAt"] as? Int == 0)
+        #expect(disabledObject["keyId"] as? String == "")
     }
 
     @Test("prompt text is fixed by operation and approvals are short-lived")
     func promptPolicy() {
         #expect(NativeAuthenticationOperation.enroll.localizedReason.contains("Pair"))
+        #expect(NativeAuthenticationOperation.disable.localizedReason.contains("Disable"))
         #expect(NativeAuthenticationOperation.sudo.localizedReason.contains("sudo"))
         #expect(SecureEnclaveAuthorizationSigner.approvalLifetimeSeconds == 15)
+    }
+
+    @Test("disable removes only the requested safe key representation")
+    func disableKey() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let key = directory.appendingPathComponent("\(guestID).key")
+        try Data([0x01, 0x02]).write(to: key)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: key.path)
+        let signer = SecureEnclaveAuthorizationSigner(keyDirectory: directory)
+
+        try signer.disable(guestID: guestID)
+        #expect(!FileManager.default.fileExists(atPath: key.path))
+        try signer.disable(guestID: guestID)
     }
 }

--- a/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
@@ -8,6 +8,25 @@ struct NativeAuthenticationBridgeTests {
     private let challenge = String(repeating: "ab", count: 32)
     private let guestID = String(repeating: "ef", count: 32)
 
+    @Test("an abandoned prompt is canceled and late approval cannot approve the next prompt")
+    func promptTimeout() {
+        var lateCompletion: ((Bool) -> Void)?
+        var canceled = false
+        #expect(!NativeAuthenticationPrompt.approve(
+            timeout: 0.01,
+            evaluate: { lateCompletion = $0 },
+            cancel: { canceled = true }
+        ))
+        #expect(canceled)
+        lateCompletion?(true)
+        #expect(!NativeAuthenticationPrompt.approve(
+            evaluate: { $0(false) }, cancel: {}
+        ))
+        #expect(NativeAuthenticationPrompt.approve(
+            evaluate: { $0(true) }, cancel: {}
+        ))
+    }
+
     @Test("sudo requests use a strict versioned context")
     func sudoRequestSchema() throws {
         let line = Data(

--- a/macos/Tests/run-qemu-ssh-contract.test.sh
+++ b/macos/Tests/run-qemu-ssh-contract.test.sh
@@ -295,6 +295,100 @@ printf 'factory\n' >"$guest/rootfs.ext4"
 launcher="$resources/scripts/run-qemu-gpu.sh"
 persistent_root="$test_root/persistent"
 
+# Exercise the repo-local development path, where release-time launch.plist is
+# absent and the launcher validates build-spec.json directly.
+development_guest="$resources/development-guest"
+mkdir -p "$development_guest"
+/bin/cp "$macos_dir/../guest/spec.json" "$development_guest/build-spec.json"
+DEVELOPMENT_GUEST="$development_guest" /usr/bin/python3 <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+guest = Path(os.environ["DEVELOPMENT_GUEST"])
+spec = json.loads(guest.joinpath("build-spec.json").read_text())
+files = {
+    "LICENSE.omarchy": b"MIT\n",
+    "initramfs-linux.img": b"070701",
+    "packages.lock.txt": b"fixture\n",
+    "provenance.json": b"{}\n",
+    "rootfs.ext4.zst": b"\x28\xb5\x2f\xfd",
+}
+kernel = bytearray(60)
+kernel[56:60] = b"ARM\x64"
+files["vmlinuz-linux"] = bytes(kernel)
+for name, data in files.items():
+    guest.joinpath(name).write_bytes(data)
+
+metadata = {
+    "LICENSE.omarchy": ("guest-license", "text/plain"),
+    "build-spec.json": ("guest-metadata", "application/json"),
+    "initramfs-linux.img": ("guest-initramfs", "application/vnd.linux.initramfs"),
+    "packages.lock.txt": ("guest-metadata", "text/plain"),
+    "provenance.json": ("guest-metadata", "application/json"),
+    "rootfs.ext4": ("guest-rootfs", "application/vnd.omarchy.ext4"),
+    "rootfs.ext4.zst": ("guest-rootfs-compressed", "application/zstd"),
+    "vmlinuz-linux": ("guest-kernel", "application/vnd.linux.kernel"),
+}
+records = []
+checksums = {}
+for name, (role, media_type) in metadata.items():
+    if name == "rootfs.ext4":
+        size = spec["image"]["sizeMiB"] * 1024 * 1024
+        digest = "0" * 64
+    else:
+        data = guest.joinpath(name).read_bytes()
+        size = len(data)
+        digest = hashlib.sha256(data).hexdigest()
+    records.append(
+        {
+            "bytes": size,
+            "mediaType": media_type,
+            "path": name,
+            "role": role,
+            "sha256": digest,
+        }
+    )
+    checksums[name] = digest
+
+manifest = {
+    "artifacts": records,
+    "build": {},
+    "guest": {
+        "architecture": "aarch64",
+        "display": spec["guest"]["virtualDisplay"],
+        "distribution": "Arch Linux",
+        "kernelCommandLine": spec["runtime"]["kernelCommandLine"],
+        "profile": "factory",
+        "username": None,
+    },
+    "kind": "try-omarchy-guest-artifacts",
+    "normalizedUpstreamTree": {},
+    "schemaVersion": 1,
+    "upstream": {},
+}
+manifest_data = (json.dumps(manifest, separators=(",", ":")) + "\n").encode()
+guest.joinpath("guest-manifest.json").write_bytes(manifest_data)
+checksums["guest-manifest.json"] = hashlib.sha256(manifest_data).hexdigest()
+guest.joinpath("SHA256SUMS").write_text(
+    "".join(f"{checksums[name]}  {name}\n" for name in sorted(checksums)),
+    encoding="ascii",
+)
+PY
+
+development_stderr="$test_root/development-validation.stderr"
+if ! development_validation=$(env \
+  PATH="$shim_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+  OMARCHY_QEMU_GPU_INSPECT_ONLY=1 \
+  "$launcher" "$development_guest" 2>"$development_stderr"); then
+  /bin/cat "$development_stderr" >&2 || true
+  fail 'generated build spec failed repo-local development validation'
+fi
+assert_contains "$development_validation" \
+  'root=/dev/vda rw rootwait console=tty0 console=hvc0'
+
 run_scenario() {
   local scenario=$1
   local expected_status=$2

--- a/macos/Tests/run-qemu-ssh-contract.test.sh
+++ b/macos/Tests/run-qemu-ssh-contract.test.sh
@@ -54,6 +54,7 @@ cat >"$contents/MacOS/omarchy-vm-helper" <<'SH'
 #!/bin/bash
 set -euo pipefail
 if [[ ${1:-} == --bridge-native-audio \
+   || ${1:-} == --bridge-native-authentication \
    || ${1:-} == --bridge-native-clipboard \
    || ${1:-} == --bridge-native-camera ]]; then
   while kill -0 "$2" 2>/dev/null; do
@@ -333,6 +334,10 @@ assert_not_contains "$disabled_qemu" hostfwd
 assert_not_contains "$disabled_qemu" tryomarchy.ssh_access
 assert_contains "$disabled_qemu" \
   'cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=on,full-grab=on,immersive=on,swap-opt-cmd=off'
+assert_contains "$disabled_qemu" \
+  'socket,id=omarchy-authentication-bridge,path='
+assert_contains "$disabled_qemu" \
+  'virtserialport,bus=omarchy-serial.0,nr=3,chardev=omarchy-authentication-bridge,name=dev.tryomarchy.authentication'
 assert_contains "$(<"$test_root/disabled/storage.log")" select-existing
 assert_contains "$(<"$test_root/disabled/storage.log")" create
 

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -912,6 +912,7 @@ owner_marker=""
 owner_token=""
 qemu_pid=""
 audio_bridge_pid=""
+authentication_bridge_pid=""
 camera_bridge_pid=""
 clipboard_bridge_pid=""
 
@@ -943,6 +944,9 @@ cleanup() {
   fi
   if [[ $audio_bridge_pid =~ ^[0-9]+$ ]]; then
     terminate_child "$audio_bridge_pid" 20
+  fi
+  if [[ $authentication_bridge_pid =~ ^[0-9]+$ ]]; then
+    terminate_child "$authentication_bridge_pid" 20
   fi
   if [[ $camera_bridge_pid =~ ^[0-9]+$ ]]; then
     terminate_child "$camera_bridge_pid" 20
@@ -1198,6 +1202,7 @@ chmod 600 "$owner_marker"
 # for cleanup, but expose the runtime sockets through that standardized alias.
 qmp_socket="/tmp/${work_dir##*/}/qmp.sock"
 audio_bridge_socket="/tmp/${work_dir##*/}/audio.sock"
+authentication_bridge_socket="/tmp/${work_dir##*/}/authentication.sock"
 camera_bridge_socket="/tmp/${work_dir##*/}/camera.sock"
 clipboard_bridge_socket="/tmp/${work_dir##*/}/clipboard.sock"
 audio_route_dir="/tmp/${work_dir##*/}/audio-routes"
@@ -1339,6 +1344,8 @@ qemu_args=(
   -device 'virtserialport,bus=omarchy-serial.0,nr=1,chardev=omarchy-audio-bridge,name=dev.tryomarchy.audio'
   -chardev "socket,id=omarchy-clipboard-bridge,path=$clipboard_bridge_socket,server=on,wait=off"
   -device 'virtserialport,bus=omarchy-serial.0,nr=2,chardev=omarchy-clipboard-bridge,name=dev.tryomarchy.clipboard'
+  -chardev "socket,id=omarchy-authentication-bridge,path=$authentication_bridge_socket,server=on,wait=off"
+  -device 'virtserialport,bus=omarchy-serial.0,nr=3,chardev=omarchy-authentication-bridge,name=dev.tryomarchy.authentication'
   -chardev "socket,id=omarchy-camera-bridge,path=$camera_bridge_socket,server=on,wait=off"
   -device 'virtserialport,bus=omarchy-serial.0,nr=4,chardev=omarchy-camera-bridge,name=dev.tryomarchy.camera'
 )
@@ -1373,6 +1380,8 @@ if [[ ${OMARCHY_QEMU_GPU_DRY_RUN:-0} == 1 ]]; then
     "$native_bridge" "$audio_bridge_socket" "$audio_route_dir" >&2
   printf '\n[qemu-gpu] clipboard bridge command: %q --bridge-native-clipboard QEMU_PID %q' \
     "$native_bridge" "$clipboard_bridge_socket" >&2
+  printf '\n[qemu-gpu] authentication bridge command: %q --bridge-native-authentication QEMU_PID %q' \
+    "$native_bridge" "$authentication_bridge_socket" >&2
   printf '\n[qemu-gpu] camera bridge command: %q --bridge-native-camera QEMU_PID %q' \
     "$native_bridge" "$camera_bridge_socket" >&2
   if [[ -n $shared_folder ]]; then
@@ -1404,7 +1413,7 @@ printf '%s\n' "$qemu_pid" >"$work_dir/.qemu.pid"
 chmod 600 "$work_dir/.qemu.pid"
 
 for ((attempt = 0; attempt < 100; attempt++)); do
-  if [[ -S $qmp_socket && -S $audio_bridge_socket && -S $camera_bridge_socket && -S $clipboard_bridge_socket ]]; then
+  if [[ -S $qmp_socket && -S $audio_bridge_socket && -S $authentication_bridge_socket && -S $camera_bridge_socket && -S $clipboard_bridge_socket ]]; then
     break
   fi
   kill -0 "$qemu_pid" 2>/dev/null || fail "QEMU exited before creating its private QMP socket"
@@ -1412,6 +1421,7 @@ for ((attempt = 0; attempt < 100; attempt++)); do
 done
 [[ -S $qmp_socket ]] || fail "QEMU did not create its private QMP socket"
 [[ -S $audio_bridge_socket ]] || fail "QEMU did not create its private audio bridge socket"
+[[ -S $authentication_bridge_socket ]] || fail "QEMU did not create its private authentication bridge socket"
 [[ -S $camera_bridge_socket ]] || fail "QEMU did not create its private camera bridge socket"
 [[ -S $clipboard_bridge_socket ]] || fail "QEMU did not create its private clipboard bridge socket"
 echo "[qemu-gpu] Ready. QMP: $qmp_socket" >&2
@@ -1429,6 +1439,14 @@ start_clipboard_bridge() {
 }
 start_clipboard_bridge
 clipboard_bridge_restarts=0
+
+start_authentication_bridge() {
+  "$native_bridge" --bridge-native-authentication \
+    "$qemu_pid" "$authentication_bridge_socket" 9>&- &
+  authentication_bridge_pid=$!
+}
+start_authentication_bridge
+authentication_bridge_restarts=0
 
 start_camera_bridge() {
   "$native_bridge" --bridge-native-camera \
@@ -1476,6 +1494,27 @@ while true; do
       fi
     fi
   fi
+  # Touch ID sudo remains optional to VM availability: signed-response failure
+  # falls back to the guest password. Reconnect a transiently failed helper.
+  if [[ $authentication_bridge_pid =~ ^[0-9]+$ ]]; then
+    authentication_bridge_state=$(ps -p "$authentication_bridge_pid" -o state= 2>/dev/null || true)
+    if [[ -z $authentication_bridge_state || $authentication_bridge_state == *Z* ]]; then
+      if wait "$authentication_bridge_pid"; then
+        authentication_bridge_status=0
+      else
+        authentication_bridge_status=$?
+      fi
+      authentication_bridge_pid=""
+      if (( authentication_bridge_restarts < 5 )); then
+        authentication_bridge_restarts=$((authentication_bridge_restarts + 1))
+        echo "[qemu-gpu] authentication bridge exited (status $authentication_bridge_status); restarting ($authentication_bridge_restarts/5)" >&2
+        sleep 1
+        start_authentication_bridge
+      else
+        echo "[qemu-gpu] Touch ID sudo is unavailable for the rest of this session; password authentication remains available" >&2
+      fi
+    fi
+  fi
   # Camera sharing is optional. A failed capture backend must not stop the VM;
   # reconnect it so a transient device change can recover in this session.
   if [[ $camera_bridge_pid =~ ^[0-9]+$ ]]; then
@@ -1519,6 +1558,10 @@ else
   wait "$audio_bridge_pid" 2>/dev/null || true
 fi
 audio_bridge_pid=""
+if [[ $authentication_bridge_pid =~ ^[0-9]+$ ]]; then
+  terminate_child "$authentication_bridge_pid" 20
+fi
+authentication_bridge_pid=""
 if [[ $clipboard_bridge_pid =~ ^[0-9]+$ ]]; then
   terminate_child "$clipboard_bridge_pid" 20
 fi

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -361,7 +361,7 @@ runtime = exact_keys(
     spec.get("runtime"),
     {
         "audio",
-        "authenticationExperiment",
+        "authentication",
         "camera",
         "clipboard",
         "compressedDisk",
@@ -405,6 +405,7 @@ clipboard = {
     "formats": ["text/plain;charset=utf-8", "image/png"],
 }
 authentication = {
+    "activation": "explicit-menu-opt-in",
     "approvalLifetimeSeconds": 15,
     "authorizationScope": "sudo-authentication",
     "device": "virtserialport",
@@ -413,7 +414,7 @@ authentication = {
     "hostKey": "per-guest-secure-enclave-p256",
     "pamService": "sudo",
     "port": "dev.tryomarchy.authentication",
-    "protocolVersion": 2,
+    "protocolVersion": 3,
     "requiresEnrollment": True,
     "signature": "ecdsa-p256-sha256",
 }
@@ -493,7 +494,7 @@ if (
     or runtime.get("camera") != camera
     or runtime.get("storage") != storage
     or runtime.get("clipboard") != clipboard
-    or runtime.get("authenticationExperiment") != authentication
+    or runtime.get("authentication") != authentication
     or runtime.get("sharedFolder") != shared_folder
     or runtime.get("devices") != expected_devices
     or runtime.get("minimumMemoryMiB") != 2048

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -361,6 +361,7 @@ runtime = exact_keys(
     spec.get("runtime"),
     {
         "audio",
+        "authenticationExperiment",
         "camera",
         "clipboard",
         "compressedDisk",
@@ -402,6 +403,19 @@ clipboard = {
     "device": "virtserialport",
     "port": "dev.tryomarchy.clipboard",
     "formats": ["text/plain;charset=utf-8", "image/png"],
+}
+authentication = {
+    "approvalLifetimeSeconds": 15,
+    "authorizationScope": "sudo-authentication",
+    "device": "virtserialport",
+    "guestDeviceMode": "0600",
+    "guestIdentity": "root-private-random-256-bit",
+    "hostKey": "per-guest-secure-enclave-p256",
+    "pamService": "sudo",
+    "port": "dev.tryomarchy.authentication",
+    "protocolVersion": 2,
+    "requiresEnrollment": True,
+    "signature": "ecdsa-p256-sha256",
 }
 shared_folder = {
     "device": "virtio-9p-pci",
@@ -479,6 +493,7 @@ if (
     or runtime.get("camera") != camera
     or runtime.get("storage") != storage
     or runtime.get("clipboard") != clipboard
+    or runtime.get("authenticationExperiment") != authentication
     or runtime.get("sharedFolder") != shared_folder
     or runtime.get("devices") != expected_devices
     or runtime.get("minimumMemoryMiB") != 2048


### PR DESCRIPTION
## Summary

- add an opt-in Touch ID authentication bridge for guest `sudo`
- add a stateful **Setup → Security → Touch ID for sudo** control with enable, test, re-pair, and disable actions
- keep the integration dormant until the user authenticates with the guest sudo password and approves enrollment with Touch ID
- preserve normal guest-password authentication as fallback and display the reason before requesting the password
- enable guest time synchronization at boot so clock drift does not invalidate otherwise valid signed approvals

This implements the separate guest-sudo feature. It does not attempt to expose Apple Passwords/Keychain data or replace guest login and screen-unlock authentication.

## Security model

- the guest authentication device and enrollment state are root-only
- each approval uses a fresh request ID and 256-bit challenge
- the Secure Enclave P-256 signature binds the operation, guest identity, PAM user, requesting user, service, TTY, key identity, and 15-second validity window
- the guest pins the enrolled public key and verifies every signature with OpenSSL
- macOS prompts with `deviceOwnerAuthenticationWithBiometrics`, biometric-set binding, no password fallback, and zero reuse duration
- the host prompts only while the matching QEMU process is alive and focused
- enabling writes the PAM rule only after enrollment succeeds; disabling removes the PAM rule before deleting enrollment state
- existing recognized PAM rules migrate to enable user-visible fallback explanations without re-enrollment; approval validity checks remain unchanged

## Validation

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make test` passed, including guest unit and contract tests, 210 Swift tests in 47 suites, macOS compatibility/runtime relocation, and QEMU forwarding, power, SSH, and persistent-storage tests
- the release host helper builds successfully; new regression coverage checks compact menu insertion, command failure propagation, refusal of password fallback, host prompt cancellation, late callbacks, and late-response recovery
- regression coverage verifies that a real signed approval is rejected with a clock explanation when guest time is outside the allowed window, while successful authentication stays quiet
- checked message delivery through the running guest's actual PAM library: the explanation reaches the conversation and failed authentication remains rejected
- live guest validation: time synchronization corrected approximately 16 seconds of drift; Mac and guest clocks then matched, and the user confirmed Touch ID sudo authentication without a guest password
- verified enable, disable, re-enable, and persistence across shutdown/power-on during the original implementation
- the original security review covered commit `c523029`; it is not presented as a security review of the subsequent time-sync and diagnostic changes
- clean factory-image rebuild attempted: guest package resolution stopped with `could not satisfy dependencies` before reaching the changed configuration scripts. For live testing, cached guest artifacts were refreshed and the app rebuilt; signature and macOS compatibility checks passed. This does not establish a successful clean factory build.

### Deliberate manual failure-path testing

Tests were performed interactively with real Mac Touch ID and the persistent guest. Each authentication test cleared sudo's cached credentials.

- **Normal approval:** with guest time synchronized, fingerprint approval completed `sudo true` with exit status 0 and no guest password.
- **Explicit cancellation:** canceling Touch ID displayed the fallback explanation; entering the correct guest password then completed ordinary sudo with exit status 0.
- **Focus loss:** switching to another Mac application while the prompt was open, then successfully scanning a finger, resulted in rejected approval and a guest-password prompt. The dialog remained visible and repeatedly returned to the foreground; automatic cancellation on focus loss is not claimed.
- **Timeout on `dc06bcf`:** two unanswered attempts both closed the Touch ID dialog and reported failed authentication without accepting password fallback. The first was timed at exactly 55 seconds; the second was not timed. No numeric exit status was captured for these timeout attempts.
- **Recovery after timeout on `dc06bcf`:** two subsequent interactive test runs completed without a guest password, each reporting exit status 0, with no mismatched-request errors.

Normal approval, explicit cancellation, and focus-loss checks were performed before the final timeout/test-command update. Timeout and recovery were repeated after installing the `dc06bcf` Mac helper and guest scripts in the enrolled VM. Earlier runs against the old installation reproduced the stale-response failure and are not counted as validation of the fix.

Remaining UX limitation: host timeout still appears as “Touch ID was not approved”; the shared broker message mentions password fallback even though the dedicated test deliberately refuses it.

## Operational boundaries

- supported scope is guest `sudo` only
- moving or resetting the VM, changing Macs or macOS accounts, or changing the enrolled biometric set may require re-pairing
- the Try Omarchy window must be focused when Touch ID is requested
- new factory images enable `systemd-timesyncd`; existing guests with drift can enable it with `sudo systemctl enable --now systemd-timesyncd.service` and verify synchronization with `timedatectl`
- unanswered Mac prompts are canceled after 55 seconds; the guest discards late responses without extending its 65-second deadline
- the test and enable/re-pair checks refuse password fallback and propagate failure; passwordless sudo policies are explicitly distinguished from evidence of Touch ID use

#133 remains separate: this PR does not implement Apple Keychain unlock.
