### PR TITLE
[fix] Force software GL for Alacritty on VirGL

### DIFF
--- a/guest/native-overlay/usr/local/bin/alacritty
+++ b/guest/native-overlay/usr/local/bin/alacritty
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Alacritty's OpenGL path paints an empty transparent surface on Try Omarchy's
+# VirGL guest. Force Mesa llvmpipe so Install → Terminal → Alacritty is usable.
+# Prefer the pacman binary so this PATH shim never recurses on itself.
+
+real=/usr/bin/alacritty
+if [[ ! -x $real ]]; then
+  echo "alacritty is not installed" >&2
+  exit 127
+fi
+
+cmdline_file=${OMARCHY_ALACRITTY_CMDLINE:-/proc/cmdline}
+if [[ -r $cmdline_file ]]; then
+  read -r -a kernel_options <"$cmdline_file" || true
+  for kernel_option in "${kernel_options[@]}"; do
+    if [[ $kernel_option == omarchy.qemu_virgl=1 ]]; then
+      export LIBGL_ALWAYS_SOFTWARE=1
+      break
+    fi
+  done
+fi
+
+exec "$real" "$@"

--- a/guest/scripts/configure-rootfs.sh
+++ b/guest/scripts/configure-rootfs.sh
@@ -73,6 +73,7 @@ chmod 0755 \
   "$root/usr/bin/omarchy-audio-input-set-default" \
   "$root/usr/bin/omarchy-screensaver" \
   "$root/usr/bin/omarchy-theme-bg-switcher" \
+  "$root/usr/local/bin/alacritty" \
   "$root/usr/local/bin/omarchy-native-audio-bridge" \
   "$root/usr/local/bin/omarchy-native-camera-bridge" \
   "$root/usr/local/bin/omarchy-native-clipboard-bridge" \

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -1069,6 +1069,17 @@ def main() -> None:
         "native background picker override is executable",
     )
     check(cursor_restore.stat().st_mode & stat.S_IXUSR != 0, "native cursor restore helper is executable")
+    alacritty_wrapper = GUEST / "native-overlay/usr/local/bin/alacritty"
+    alacritty_wrapper_text = read(alacritty_wrapper)
+    check(alacritty_wrapper.stat().st_mode & stat.S_IXUSR != 0, "Alacritty VirGL wrapper is executable")
+    check(
+        'real=/usr/bin/alacritty' in alacritty_wrapper_text
+        and "export LIBGL_ALWAYS_SOFTWARE=1" in alacritty_wrapper_text
+        and "omarchy.qemu_virgl=1" in alacritty_wrapper_text
+        and 'exec "$real" "$@"' in alacritty_wrapper_text
+        and '"$root/usr/local/bin/alacritty"' in configure,
+        "Alacritty VirGL wrapper forces software GL onto the pacman binary",
+    )
     check(
         "/usr/local/bin/omarchy-native-cursor-restore 2>/dev/null || true"
         in read(screensaver_override),
@@ -1183,6 +1194,7 @@ HOTPLUG=1
         screensaver_override,
         background_switcher_override,
         cursor_restore,
+        alacritty_wrapper,
         display_sync,
         mac_share,
         *GUEST.glob("*.sh"),


### PR DESCRIPTION
## Summary
- Fixes https://github.com/omacom/try-omarchy/issues/148: Alacritty installs cleanly on aarch64, but the default VirGL/OpenGL path paints an empty transparent window (wallpaper shows through; no text).
- Confirmed locally that `LIBGL_ALWAYS_SOFTWARE=1 alacritty` renders normally.
- Add a `/usr/local/bin/alacritty` PATH wrapper that execs `/usr/bin/alacritty` with `LIBGL_ALWAYS_SOFTWARE=1` when `omarchy.qemu_virgl=1` is on the guest cmdline (same idea as the 1Password ARM installer software-GL shim).

## Test plan
- [x] `python3 guest/tests/verify.py`
- [x] Manual: `LIBGL_ALWAYS_SOFTWARE=1 alacritty` shows text (reporter/dev repro)
- [ ] After image with this fix: Install → Terminal → Alacritty (or `alacritty` from foot) shows a usable terminal without manually exporting `LIBGL_ALWAYS_SOFTWARE`
- [ ] CI green

Fixes #148.
