### PR TITLE
Replace themartiano paths with omacom

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ port. The `dtc` mirror should be reverted once kernel.org returns.
 
 ## Quick start
 
-1. Open [Releases](https://github.com/themartiano/try-omarchy/releases) and download the latest signed and notarized `.dmg`.
+1. Open [Releases](https://github.com/omacom/try-omarchy/releases) and download the latest signed and notarized `.dmg`.
 2. Open the DMG and drag **Try Omarchy** to **Applications**.
 3. Launch **Try Omarchy** from Applications.
 
@@ -441,7 +441,7 @@ The architecture and trust boundaries are documented in [`docs/architecture.md`]
 
 Try Omarchy is pre-1.0 and under active development. Omarchy and bundled dependencies retain their own licenses; see [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
-Report ordinary bugs through [GitHub Issues](https://github.com/themartiano/try-omarchy/issues). Report suspected vulnerabilities using the private process in [`SECURITY.md`](SECURITY.md), not a public issue.
+Report ordinary bugs through [GitHub Issues](https://github.com/omacom/try-omarchy/issues). Report suspected vulnerabilities using the private process in [`SECURITY.md`](SECURITY.md), not a public issue.
 
 Try Omarchy's original code is licensed under the [MIT License](LICENSE).
 

--- a/guest/scripts/register-patched-hyprland.sh
+++ b/guest/scripts/register-patched-hyprland.sh
@@ -206,7 +206,7 @@ build_packages_json=${metadata[21]}
 [[ $glaze_url == "https://github.com/stephenberry/glaze/archive/refs/tags/v$glaze_version.tar.gz" ]] ||
   fail "Glaze URL does not match the pinned release"
 [[ $license == BSD-3-Clause ]] || fail "unexpected Hyprland license: $license"
-[[ $issue == https://github.com/themartiano/try-omarchy/issues/5 ]] || fail "unexpected Hyprland issue URL"
+[[ $issue == https://github.com/omacom/try-omarchy/issues/5 ]] || fail "unexpected Hyprland issue URL"
 [[ $source_date_epoch =~ ^[0-9]+$ && $source_date_epoch -gt 0 ]] || fail "invalid source date epoch"
 for digest in "$sha256" "$upstream_package_sha256" "$patch_sha256" "$glaze_sha256" "$glaze_license_sha256" "$binary_sha256"; do
   [[ $digest =~ ^[0-9a-f]{64}$ ]] || fail "invalid Hyprland content digest"

--- a/guest/spec.json
+++ b/guest/spec.json
@@ -54,7 +54,7 @@
       "glazeLicenseSha256": "5d49e66411a0807a7c8d6b911b9a26b59e940c71aebe561a3ad8b0b80ac4b7b6",
       "binarySha256": "c668b05275f2d5cbff66fdb8f4ea4cbbfb7d5a7f9e682f358f3fbcff8494c68a",
       "license": "BSD-3-Clause",
-      "issue": "https://github.com/themartiano/try-omarchy/issues/5",
+      "issue": "https://github.com/omacom/try-omarchy/issues/5",
       "buildPackages": {
         "base-devel": "1-2",
         "binutils": "2.46+r70+g155188ea10a7-1",

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -375,7 +375,7 @@ def main() -> None:
             "glazeLicenseSha256": "5d49e66411a0807a7c8d6b911b9a26b59e940c71aebe561a3ad8b0b80ac4b7b6",
             "binarySha256": "c668b05275f2d5cbff66fdb8f4ea4cbbfb7d5a7f9e682f358f3fbcff8494c68a",
             "license": "BSD-3-Clause",
-            "issue": "https://github.com/themartiano/try-omarchy/issues/5",
+            "issue": "https://github.com/omacom/try-omarchy/issues/5",
             "buildPackages": {
                 "base-devel": "1-2",
                 "binutils": "2.46+r70+g155188ea10a7-1",

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -570,7 +570,7 @@ exact_keys(
 hyprland_identity = hashlib.sha256(
     json.dumps(hyprland, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
 ).hexdigest()
-if hyprland_identity != "f3855f9bc084ee047657484400f413bb37d0797d71c64b9d9c2e459bdbc67bf5":
+if hyprland_identity != "edd58c17fc115b375d8e8b9b5eb7eb78008e89c05867b3ed2f2834287badcae8":
     fail("factory Hyprland component is not the reviewed rounded-border build")
 mise = exact_keys(
     supply_chain.get("mise"),


### PR DESCRIPTION
The repo moved to the omacom org in v0.3.0, but some references still point at themartiano/try-omarchy. Old paths redirect, so nothing is broken, but they should name the current owner.
