### PR TITLE
[feat] Add safe growth for existing VM disks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ test:
 	@$(ROOT)/macos/Tests/run-qemu-ssh-contract.test.sh
 	@$(ROOT)/macos/Tests/qemu-power-actions.test.sh
 	@$(ROOT)/macos/Tests/qemu-persistent-storage.test.sh
+	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/macos/Tests/resize-vm-disk.test.py"
 
 guest:
 	@OMARCHY_FORCE_BUILD="$(FORCE)" "$(BUILD_CACHE)" \

--- a/README.md
+++ b/README.md
@@ -285,6 +285,47 @@ all of that app's factory-image changes to an existing VM, and an in-guest
 update should not be assumed to reproduce them. A confirmed reset is the
 deliberate, destructive way to start again from the newest bundled factory.
 
+### Growing an existing VM disk
+
+To add capacity without resetting the VM, shut down Omarchy and run the
+maintenance command from a source checkout on the Mac:
+
+```sh
+# Preview a new total capacity of 32 GiB.
+macos/resize-vm-disk.sh --size-gib 32
+
+# Retain a verified backup, then enlarge the stopped disk.
+macos/resize-vm-disk.sh --size-gib 32 --apply
+```
+
+Run as the macOS user who owns the VM, without `sudo`. The command requires
+Python 3 and an APFS volume, but does not require building the app. It uses the
+same workspace lock as the launcher and refuses an active VM, shrinking,
+unrecognized metadata, or a missing/invalid paired boot kit. An equal size is
+a no-op. Whole-number targets up to 8192 GiB are accepted.
+
+The default state directory is
+`~/Library/Application Support/Try Omarchy/VM/v1`. For a custom VM location,
+pass `--state-root "/path/to/selected-folder/VM/v1"`, using the directory that
+contains `.omarchy-qemu-storage` and `disks/current`. The command does not read
+the app's saved location preference or select legacy development workspaces.
+
+The backup is an APFS clone in a private sibling directory named
+`v1.resize-backup.XXXXXX`; the command prints its exact path. It retains the
+original disk, disk metadata, and paired boot files and verifies the disk's
+checksum before resizing; reading both full disk images can take several
+minutes. Keep it until the resized VM is working. To roll back, shut down the
+VM and restore its original disk from this backup; any
+writes made after the backup would be lost, so preserve the newer disk first.
+Never shrink the enlarged disk to undo the operation.
+
+The host must have free space for the requested increase plus 1 GiB of
+headroom. Growth is sparse, not a reservation of host capacity, and retained
+clones consume additional space as their contents diverge. On the next normal
+boot, the guest's enabled `systemd-growfs-root.service` grows ext4 to fill the
+disk. Verify inside Omarchy with `lsblk` and `df -h /`. No app rebuild, guest
+reinstall, or change to the factory image is needed.
+
 ### Choosing where the VM lives
 
 **Change…** on the start menu's **VM Location** row moves the VM to any folder

--- a/macos/Tests/resize-vm-disk.test.py
+++ b/macos/Tests/resize-vm-disk.test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+NATIVE = Path(__file__).resolve().parents[1]
+SCRIPT = NATIVE / "resize-vm-disk.sh"
+GIB = 1024**3
+
+
+class ResizeDiskTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="omarchy-resize-test.")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.state = self.root / "VM with spaces"
+        self.source = self.root / "source.ext4"
+        self.payload = b"existing guest data" + bytes(4096)
+        self.source.write_bytes(self.payload)
+        self.kernel = self.root / "kernel"
+        self.kernel.write_bytes(bytes(56) + b"ARMd" + bytes(4))
+        self.initramfs = self.root / "initramfs"
+        self.initramfs.write_bytes(b"070701fixture")
+        self.identity = hashlib.sha256(b"bundle").hexdigest()
+        self.environment = dict(os.environ, OMARCHY_QEMU_GPU_STATE_ROOT=str(self.state),
+                                OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK="0")
+        self.environment.pop("OMARCHY_QEMU_GPU_TEST_FREE_BYTES", None)
+        self.environment.pop("OMARCHY_QEMU_GPU_TEST_FS_TYPE", None)
+        result = subprocess.run([
+            "bash", "-eu", "-c",
+            'source "$1"; qemu_persistent_storage_select persistent "$2" "$3" "$4" "$5" "" "$5" "$6" "$7" "root=/dev/vda rw rootwait console=tty0 console=hvc0"',
+            "fixture", str(NATIVE / "qemu-persistent-storage.sh"), self.identity,
+            str(self.source), hashlib.sha256(self.payload).hexdigest(), str(len(self.payload)),
+            str(self.kernel), str(self.initramfs),
+        ], env=self.environment, capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.disk = self.state / "disks/current/rootfs.ext4"
+        self.metadata = self.disk.with_name("metadata.json")
+
+    def run_resize(self, *args, environment=None):
+        return subprocess.run([str(SCRIPT), "--state-root", str(self.state), *args],
+                              env=environment or self.environment, text=True, capture_output=True)
+
+    def backups(self):
+        return list(self.root.glob("VM with spaces.resize-backup.*"))
+
+    def assert_rejected(self, result):
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.disk.read_bytes(), self.payload)
+        self.assertEqual(self.backups(), [])
+
+    def test_preview_preserves_disk_and_creates_no_backup(self):
+        result = self.run_resize("--size-gib", "1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Preview only", result.stdout)
+        self.assertEqual(self.disk.read_bytes(), self.payload)
+        self.assertEqual(self.backups(), [])
+
+    def test_growth_retains_verified_backup_and_is_idempotent(self):
+        metadata = self.metadata.read_bytes()
+        result = self.run_resize("--size-gib", "1", "--apply")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.disk.stat().st_size, GIB)
+        self.assertEqual(self.disk.stat().st_mode & 0o777, 0o600)
+        with self.disk.open("rb") as disk:
+            self.assertEqual(disk.read(len(self.payload)), self.payload)
+            disk.seek(GIB - 4096)
+            self.assertEqual(disk.read(), bytes(4096))
+        self.assertLess(self.disk.stat().st_blocks * 512, GIB)
+        self.assertEqual(self.metadata.read_bytes(), metadata)
+        backup, = self.backups()
+        self.assertEqual(backup.stat().st_mode & 0o777, 0o700)
+        self.assertEqual((backup / "rootfs.ext4").read_bytes(), self.payload)
+        self.assertEqual((backup / "metadata.json").read_bytes(), metadata)
+        self.assertEqual((backup / "boot" / self.identity / "kernel").read_bytes(), self.kernel.read_bytes())
+        self.assertIn(hashlib.sha256(self.payload).hexdigest(), (backup / "resize.txt").read_text())
+        result = self.run_resize("--size-gib", "1", "--apply")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("nothing changed", result.stdout)
+        self.assertEqual(self.backups(), [backup])
+        # The real launcher accepts a grown disk without rewriting its identity.
+        result = subprocess.run(["bash", "-eu", "-c",
+            'source "$1"; _qps_require_compatible_workspace "$2" "$3"',
+            "verify", str(NATIVE / "qemu-persistent-storage.sh"), str(self.disk.parent), self.identity],
+            env=self.environment, capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_shrinking(self):
+        with self.disk.open("r+b") as disk:
+            disk.truncate(2 * GIB)
+        result = self.run_resize("--size-gib", "1", "--apply")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("shrinking", result.stderr)
+        self.assertEqual(self.disk.stat().st_size, 2 * GIB)
+        self.assertEqual(self.backups(), [])
+
+    def test_rejects_invalid_and_overflowing_sizes(self):
+        for value in ("0", "-1", "1.5", "01", "8193", "99999999999999999999999", "1G"):
+            with self.subTest(value=value):
+                self.assert_rejected(self.run_resize("--size-gib", value, "--apply"))
+
+    def test_rejects_lock_held_by_launcher(self):
+        import fcntl
+        with (self.state / "locks/current.lock").open("r+b") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+
+    def test_rejects_symlinked_disk(self):
+        self.disk.rename(self.root / "original.ext4")
+        self.disk.symlink_to(self.root / "original.ext4")
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+
+    def test_rejects_hardlinked_disk(self):
+        os.link(self.disk, self.root / "alias.ext4")
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+
+    def test_rejects_corrupt_marker_and_preserves_it(self):
+        marker = self.state / ".omarchy-qemu-storage"
+        marker.write_text("unrecognized\n")
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+        self.assertEqual(marker.read_text(), "unrecognized\n")
+
+    def test_rejects_corrupt_boot_kit(self):
+        (self.state / "boot" / self.identity / "kernel").write_bytes(bytes(64))
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+
+    def test_rejects_insufficient_space_and_unsupported_filesystem(self):
+        for overrides in ({"OMARCHY_QEMU_GPU_TEST_FREE_BYTES": "1"},
+                          {"OMARCHY_QEMU_GPU_TEST_FS_TYPE": "exfat"}):
+            with self.subTest(overrides=overrides):
+                self.assert_rejected(self.run_resize("--size-gib", "1", "--apply",
+                    environment=dict(self.environment, **overrides)))
+
+    def test_rejects_insecure_disk_permissions(self):
+        self.disk.chmod(0o644)
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+
+    def test_rejects_legacy_and_unrecognized_metadata(self):
+        original = self.metadata.read_text()
+        for content in (original.replace('"schemaVersion":2', '"schemaVersion":1'), "{}\n"):
+            with self.subTest(content=content):
+                self.metadata.write_text(content)
+                self.assert_rejected(self.run_resize("--size-gib", "1", "--apply"))
+                self.assertEqual(self.metadata.read_text(), content)
+
+    def test_rejects_development_multi_disk_mode(self):
+        self.assert_rejected(self.run_resize("--size-gib", "1", "--apply",
+            environment=dict(self.environment, OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK="1")))
+
+    def test_missing_state_is_not_initialized(self):
+        missing = self.root / "missing"
+        result = self.run_resize("--state-root", str(missing), "--size-gib", "1", "--apply")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(missing.exists())
+        self.assertEqual(self.backups(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/resize-vm-disk.sh
+++ b/macos/resize-vm-disk.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: macos/resize-vm-disk.sh --size-gib N [--state-root DIR] [--apply]
+
+Preview growing an existing, stopped VM to N GiB (whole number, at most 8192).
+Add --apply to retain a verified APFS clone backup and enlarge the disk.
+The root filesystem grows automatically on the next normal guest boot.
+
+DIR is the VM state directory containing .omarchy-qemu-storage and disks/current.
+Default: ~/Library/Application Support/Try Omarchy/VM/v1
+Custom VM locations require --state-root; saved app preferences are not read.
+EOF
+}
+
+fail() {
+  printf 'resize-vm-disk: %s\n' "$*" >&2
+  exit 1
+}
+
+size_gib=''
+state_root="${HOME:?}/Library/Application Support/Try Omarchy/VM/v1"
+apply=0
+while (($#)); do
+  case "$1" in
+    --size-gib)
+      (($# >= 2)) && [[ -z $size_gib ]] || { usage >&2; exit 64; }
+      size_gib=$2
+      shift 2
+      ;;
+    --state-root)
+      (($# >= 2)) || { usage >&2; exit 64; }
+      state_root=$2
+      shift 2
+      ;;
+    --apply) apply=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 64 ;;
+  esac
+done
+[[ $size_gib =~ ^[1-9][0-9]{0,3}$ ]] || fail '--size-gib must be a whole number from 1 to 8192'
+(( size_gib <= 8192 )) || fail '--size-gib cannot exceed 8192'
+[[ $(uname -s) == Darwin ]] || fail 'macOS is required'
+(( EUID != 0 )) || fail 'run as the macOS user who owns the VM, without sudo'
+command -v python3 >/dev/null || fail 'python3 is required'
+[[ ${OMARCHY_QEMU_GPU_DEVELOPMENT_MULTI_DISK:-0} == 0 ]] || fail 'development multi-disk workspaces are not supported'
+
+script_dir=$(cd "$(dirname "$0")" && pwd -P)
+# shellcheck source=qemu-persistent-storage.sh
+source "$script_dir/qemu-persistent-storage.sh"
+
+# Unlike the launch path, a maintenance command must never initialize storage.
+_qps_assert_safe_root_path "$state_root"
+_qps_assert_private_directory "$state_root" 'existing state root'
+state_root=$(cd "$state_root" && pwd -P)
+_qps_assert_safe_root_path "$state_root"
+_qps_assert_volume_supported "$state_root"
+_qps_validate_root_marker "$state_root/.omarchy-qemu-storage"
+for child in disks boot locks; do
+  _qps_assert_private_directory "$state_root/$child" "state $child directory"
+done
+QEMU_PERSISTENT_STORAGE_LOCKS_ROOT="$state_root/locks"
+_qps_assert_private_regular_file "$state_root/locks/current.lock" 'existing workspace lock'
+_qps_acquire_lock current
+trap 'qemu_persistent_storage_release_lock' EXIT
+
+workspace="$state_root/disks/current"
+_qps_validate_recorded_workspace "$workspace"
+[[ $QPS_METADATA_SCHEMA == "$QEMU_PERSISTENT_STORAGE_SCHEMA" ]] || fail 'launch and shut down this VM with the current app before resizing'
+boot_kit="$state_root/boot/$QPS_METADATA_IDENTITY"
+_qps_validate_boot_kit_directory "$boot_kit" "$QPS_METADATA_IDENTITY"
+disk="$workspace/rootfs.ext4"
+current_bytes=$QPS_RECORDED_EXISTING_BYTES
+target_bytes=$((size_gib * 1024 * 1024 * 1024))
+(( target_bytes >= current_bytes )) || fail 'shrinking a VM disk is not supported'
+if (( target_bytes == current_bytes )); then
+  printf 'VM disk is already %s GiB; nothing changed.\n' "$size_gib"
+  exit 0
+fi
+[[ $(/usr/bin/stat -f '%l' "$disk") == 1 ]] || fail 'root disk must not have hard links'
+disk_identity=$(_qps_file_identity "$disk")
+_qps_assert_free_space "$state_root" "$((target_bytes - current_bytes + QEMU_PERSISTENT_STORAGE_HEADROOM_BYTES))"
+printf 'VM disk: %s\nCurrent bytes: %s\nTarget: %s GiB (%s bytes)\n' \
+  "$disk" "$current_bytes" "$size_gib" "$target_bytes"
+if (( ! apply )); then
+  printf 'Preview only. Re-run with --apply after shutting down the VM.\nBackup will be retained beside %s.\n' "$state_root"
+  exit 0
+fi
+
+umask 077
+backup=$(mktemp -d "${state_root}.resize-backup.XXXXXX")
+printf 'Retaining backup: %s\n' "$backup"
+# Require cloning on this APFS volume; do not silently fall back to a full copy.
+/bin/cp -c "$disk" "$backup/rootfs.ext4"
+/bin/cp -p "$workspace/metadata.json" "$backup/metadata.json"
+mkdir "$backup/boot"
+/bin/cp -cR "$boot_kit" "$backup/boot/$QPS_METADATA_IDENTITY"
+_qps_assert_private_regular_file "$backup/rootfs.ext4" 'backup root disk'
+[[ $(_qps_size "$backup/rootfs.ext4") == "$current_bytes" ]] || fail 'backup disk has the wrong size'
+original_sha=$(_qps_sha256 "$disk")
+[[ $original_sha == "$(_qps_sha256 "$backup/rootfs.ext4")" ]] || fail 'backup disk checksum mismatch; original disk unchanged'
+/usr/bin/cmp -s "$workspace/metadata.json" "$backup/metadata.json" || fail 'backup metadata mismatch'
+_qps_validate_boot_kit_directory "$backup/boot/$QPS_METADATA_IDENTITY" "$QPS_METADATA_IDENTITY"
+printf 'originalBytes=%s\ntargetBytes=%s\noriginalSha256=%s\n' \
+  "$current_bytes" "$target_bytes" "$original_sha" >"$backup/resize.txt"
+_qps_fsync "$backup"
+
+# Keep the descriptor bound to the validated inode and recheck its size before
+# extending it. Never let a changed path or a concurrent growth become a shrink.
+python3 - "$disk" "$current_bytes" "$target_bytes" "$disk_identity" <<'PY'
+import os
+import stat
+import sys
+
+path, old, new, identity = sys.argv[1:]
+old, new = int(old), int(new)
+fd = os.open(path, os.O_RDWR | os.O_NOFOLLOW | os.O_NONBLOCK)
+try:
+    info = os.fstat(fd)
+    if (not stat.S_ISREG(info.st_mode) or info.st_nlink != 1
+            or info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600
+            or f"{info.st_dev}:{info.st_ino}" != identity
+            or info.st_size != old or new <= old):
+        raise SystemExit("resize-vm-disk: disk changed during backup; refusing to resize")
+    os.ftruncate(fd, new)
+    os.fsync(fd)
+    if os.fstat(fd).st_size != new:
+        raise SystemExit("resize-vm-disk: disk size verification failed; backup retained")
+finally:
+    os.close(fd)
+PY
+printf 'VM disk enlarged to %s GiB. Backup: %s\n' "$size_gib" "$backup"
+printf 'Launch normally, then verify inside Omarchy with: lsblk; df -h /\n'


### PR DESCRIPTION
## Summary

Existing VM disks default to 24 GiB, and choosing a larger factory-image capacity does not enlarge an existing installation. Add a source-checkout maintenance command that grows a stopped VM without resetting its data:

```sh
macos/resize-vm-disk.sh --size-gib 32          # preview
macos/resize-vm-disk.sh --size-gib 32 --apply  # back up and grow
```

The command reuses the launcher's workspace lock, metadata checks, and paired-boot validation. It requires APFS, checks host headroom, retains checksum-verified disk and boot backups, and extends only the validated disk inode. It refuses active VMs, shrinking, unsafe paths, and unrecognized storage. Equal-size requests are no-ops. The existing guest boot service expands ext4 on the next launch.

Custom locations use an explicit `--state-root`; this command does not read the app's location preference or support legacy development workspaces. It needs Python 3 but no app rebuild. The README covers capacity limits, backup retention, and recovery.

Related to #104 and #132. Complements draft #141, which configures capacity for new/reset VMs and explicitly excludes resizing existing disks. This provides a command-line maintenance path that a future UI can build on.

## Validation

- Full `make test` with the Xcode developer directory selected, including 14 new resize tests.
- `bash -n` and `git diff --check`.
- Ran the command on an isolated APFS clone of an existing 24 GiB guest: verified backup, growth to 32 GiB, successful boot with the original paired kernel, automatic ext4 growth, and clean shutdown.
- A second resize was rejected while real QEMU held the workspace lock.
- Read-only `e2fsck -fn` passed after shutdown; filesystem metadata reports 8,388,608 blocks of 4,096 bytes (32 GiB).

No factory-image inputs or native app code changed. The isolated boot used an existing built runtime; this change does not require a new factory build.
