### PR TITLE
Forward Cocoa pinches through a dedicated virtio touchpad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ doctor:
 	@printf 'Toolchain ready: %s (%s)\n' "$$(sw_vers -productVersion)" "$$(uname -m)"
 
 test:
+	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/macos/Tests/test-cocoa-pinch.py"
+	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/macos/Tests/test-virtio-pinch.py"
 	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/tests/test-build-cache.py"
 	@PYTHONDONTWRITEBYTECODE=1 python3 "$(ROOT)/tests/test-pack-app-icon.py"
 	@$(ROOT)/guest/test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,12 @@ starts at EL2 and Linux exposes `/dev/kvm`; on older chips the launcher keeps
 the existing platform-GIC/EL1 configuration. The pinned QEMU 11.1.1 runtime
 contains the upstream HVF vGIC and nested-virtualization implementation.
 
+Trackpad magnification uses a dedicated indirect virtio touchpad alongside the
+ordinary pointer tablet. The Cocoa bridge reconstructs two contacts from each
+pinch and releases them on cancellation or focus loss; the guest disables
+tapping for this gesture-only device. See [pinch zoom](pinch-zoom.md) for the
+input contract, existing-guest setup, and integration validation.
+
 The macOS helper opens an authenticated connection to QEMU's private,
 single-client machine protocol socket before host sleep and retains that control
 session through wake. Before macOS sleeps it synchronously pauses the guest

--- a/docs/pinch-zoom.md
+++ b/docs/pinch-zoom.md
@@ -1,0 +1,87 @@
+# Trackpad pinch zoom
+
+The Cocoa runtime forwards macOS magnification gestures through a dedicated
+`virtio-pinch-pci` device named **QEMU Virtio Pinch Touchpad**. Linux can recognize
+this as an indirect touchpad and deliver pinch gestures to Wayland applications
+such as Chromium and Firefox. The bridge does not send zoom keyboard shortcuts.
+
+The existing Virtio Tablet continues to handle pointer movement, clicks, and
+scrolling. The new device subscribes only to QEMU multitouch events and does not
+replace the existing multitouch touchscreen device.
+
+## Guest configuration
+
+New factory users load `/usr/share/try-omarchy/pinch-input.lua` from their
+`~/.config/hypr/input.lua`. This disables tapping and disable-while-typing for
+the gesture device. Its synthetic contacts must not become tap clicks or be
+suppressed after keyboard input.
+
+App updates retain existing persistent guest disks. Before testing a rebuilt
+runtime with an existing guest, add this to `~/.config/hypr/input.lua`:
+
+```lua
+hl.device({
+  name = "qemu-virtio-pinch-touchpad",
+  tap_to_click = false,
+  disable_while_typing = false,
+})
+```
+
+Save, then run `hyprctl reload` and `hyprctl configerrors`. A factory reset is
+not needed. A later reset of the user's Hyprland configuration may require
+restoring this override.
+
+## Input behavior
+
+Cocoa provides relative magnification, not raw finger positions. The bridge
+reconstructs two symmetric contacts on a 100 mm virtual sensor, with a fixed
+center so the gesture does not intentionally pan the pointer. Contact spacing
+accumulates continuously, bounded to 0.125–3.5 times the initial spacing per
+gesture to stay within the advertised sensor. Lift and pinch again to continue
+beyond those bounds. libinput still applies its normal gesture recognition.
+
+Only gestures in the focused guest view are accepted. Ending a gesture,
+cancelling it, leaving the view, or losing window focus releases both contacts.
+Updates after cancellation are ignored until the next begin. Non-finite and
+invalid magnification values cancel the active contacts.
+
+VM state changes clear the local gesture. Resuming also emits a release frame,
+because QEMU drops normal input while stopped and a release during that time
+may not have reached the guest.
+
+This adds magnification only. Rotation, raw trackpad passthrough, and
+three/four-finger gestures are outside this change. Applications must support
+pinch gestures; this does not add zoom behavior to every Linux application.
+
+## Validation
+
+`make test` compiles and exercises the exact geometry and lifecycle header from
+the runtime patch, and checks the builder's patch checksum. The runtime build
+applies the patch after the existing patches without changing the upstream pin.
+
+An optional Linux guest-ABI test uses a patched x86_64 QEMU built with TCG/qtest:
+
+```sh
+QEMU_PINCH_TEST_BINARY=/absolute/path/to/qemu-system-x86_64 \
+  python3 macos/Tests/test-virtio-pinch.py
+```
+
+It creates an isolated VM with no disk and an inert ROM, reads the actual PCI
+device configuration, negotiates a virtqueue, and checks contact/release events
+and routing of ordinary buttons. It does not inject host input or run a guest OS.
+
+Before marking the feature ready to merge, complete on Apple Silicon macOS:
+
+1. Run `make test` and `make runtime`, then build/run the app.
+2. Check `hyprctl devices` and `libinput list-devices` for the new touchpad and
+   its gesture capability. Confirm tapping is disabled for that device.
+3. Check `libinput debug-events` for pinch begin/update/end events, then verify
+   continuous zoom in native Wayland Chromium and Firefox at the pointer.
+4. Test short pinches, inward/outward gestures, repeated gestures, focus loss,
+   leaving the guest view, and windowed/fullscreen operation. Short or cancelled
+   pinches must not click; ordinary scrolling, clicking, and modifiers must work.
+5. Test an existing persistent guest with the override above and a new factory
+   guest. Verify cancellation around VM suspend/resume and guest reboot.
+
+The Linux ABI and model tests do not validate AppKit event delivery or
+libinput's live gesture recognition. Those remain macOS integration checks.

--- a/guest/native-overlay/usr/share/try-omarchy/pinch-input.lua
+++ b/guest/native-overlay/usr/share/try-omarchy/pinch-input.lua
@@ -1,0 +1,7 @@
+-- This device carries reconstructed pinch contacts, not physical fingers.
+-- Keep taps and keyboard palm rejection from changing those gestures.
+hl.device({
+  name = "qemu-virtio-pinch-touchpad",
+  tap_to_click = false,
+  disable_while_typing = false,
+})

--- a/guest/scripts/materialize-omarchy.sh
+++ b/guest/scripts/materialize-omarchy.sh
@@ -144,6 +144,13 @@ done < <(find "$source_dir/bin" -maxdepth 1 -type f | sort)
 # Seed new users exactly like omarchy-settings does.
 rm -rf "$root/etc/skel/.config"
 copy_tree "$source_dir/config" "$root/etc/skel/.config"
+# The host pinch device must not turn short gestures into tap clicks. Keep this
+# in the user's input overrides so upstream runtime trees stay untouched.
+cat >> "$root/etc/skel/.config/hypr/input.lua" <<'EOF'
+
+-- Try Omarchy's host pinch device carries gestures only.
+dofile("/usr/share/try-omarchy/pinch-input.lua")
+EOF
 install_file 0644 "$source_dir/default/bashrc" "$root/etc/skel/.bashrc"
 mkdir -p "$root/etc/skel/.local/share/applications"
 copy_contents "$source_dir/applications" "$root/etc/skel/.local/share/applications"

--- a/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/QEMUGPULauncherTests.swift
@@ -127,12 +127,9 @@ struct QEMUStandardErrorDrainTests {
     @Test("drains a bounded tail without waiting for EOF and restores descriptor flags")
     func boundedNonblockingDrain() throws {
         let pipe = Pipe()
-        var writerClosed = false
         defer {
             pipe.fileHandleForReading.closeFile()
-            if !writerClosed {
-                pipe.fileHandleForWriting.closeFile()
-            }
+            pipe.fileHandleForWriting.closeFile()
         }
 
         let payload = Data("trailing QEMU diagnostic".utf8)
@@ -156,11 +153,26 @@ struct QEMUStandardErrorDrainTests {
         #expect(second.data == Data(payload.dropFirst(8)))
         #expect(!second.reachedEnd)
         #expect(Darwin.fcntl(descriptor, F_GETFL) == originalFlags)
+    }
 
-        pipe.fileHandleForWriting.closeFile()
-        writerClosed = true
+    @Test("reports EOF on a shut-down stream and restores descriptor flags")
+    func drainAtEndOfStream() throws {
+        var descriptors: [Int32] = [-1, -1]
+        try #require(socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0)
+        let reader = FileHandle(fileDescriptor: descriptors[0], closeOnDealloc: true)
+        defer {
+            reader.closeFile()
+            Darwin.close(descriptors[1])
+        }
+        let descriptor = reader.fileDescriptor
+        let originalFlags = Darwin.fcntl(descriptor, F_GETFL)
+        #expect(originalFlags >= 0)
+
+        // Parallel process tests can inherit a pipe writer and delay EOF after
+        // close. Socket shutdown ends the stream even with inherited copies.
+        try #require(Darwin.shutdown(descriptors[1], SHUT_WR) == 0)
         let end = QEMUGPUProcessSupervisor.drainAvailableStandardError(
-            from: pipe.fileHandleForReading,
+            from: reader,
             maximumBytes: 1_024
         )
         #expect(end.data.isEmpty)

--- a/macos/Tests/run-qemu-ssh-contract.test.sh
+++ b/macos/Tests/run-qemu-ssh-contract.test.sh
@@ -83,7 +83,7 @@ case " $* " in
     for device in \
       hda-micro intel-hda virtconsole virtserialport virtio-balloon-pci \
       virtio-9p-pci virtio-blk-pci virtio-gpu-gl-pci virtio-keyboard-pci \
-      virtio-net-pci virtio-rng-pci virtio-serial-pci virtio-tablet-pci; do
+      virtio-net-pci virtio-rng-pci virtio-serial-pci virtio-tablet-pci virtio-pinch-pci; do
       printf 'name "%s"\n' "$device"
     done
     ;;

--- a/macos/Tests/test-cocoa-pinch.py
+++ b/macos/Tests/test-cocoa-pinch.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Compile and exercise the geometry shipped in the QEMU patch, without AppKit."""
+
+import hashlib
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCH = ROOT / "macos/patches/qemu-cocoa-pinch-zoom.patch"
+
+
+def added_file(path):
+    section = PATCH.read_text().split(f"diff --git a/{path} b/{path}\n", 1)[1]
+    section = section.split("\ndiff --git ", 1)[0]
+    return "".join(line[1:] + "\n" for line in section.splitlines()
+                   if line.startswith("+") and not line.startswith("+++"))
+
+
+class CocoaPinchTests(unittest.TestCase):
+    def test_geometry_and_lifecycle(self):
+        with tempfile.TemporaryDirectory() as directory:
+            work = Path(directory)
+            (work / "cocoa-pinch.h").write_text(added_file("include/ui/cocoa-pinch.h"))
+            (work / "test.c").write_text(r'''
+#include <assert.h>
+#include <float.h>
+#include "cocoa-pinch.h"
+
+static CocoaPinchFrame frames[16];
+static unsigned count;
+
+static void record(void *opaque, const CocoaPinchFrame *frame)
+{
+    assert(opaque == frames);
+    assert(count < 16);
+    frames[count++] = *frame;
+}
+
+static void check_bounds(const CocoaPinch *pinch)
+{
+    int left = cocoa_pinch_x(pinch, 0);
+    int right = cocoa_pinch_x(pinch, 1);
+    assert(left >= 0 && right <= COCOA_PINCH_AXIS_MAX);
+    assert(left < right);
+    assert(left + right == 2 * COCOA_PINCH_CENTER);
+}
+
+int main(void)
+{
+    CocoaPinch pinch = {0};
+    assert(!cocoa_pinch_update(&pinch, 0.5));
+    assert(!cocoa_pinch_end(&pinch));
+
+    cocoa_pinch_begin(&pinch);
+    assert(pinch.active && pinch.scale == 1.0);
+    int original = cocoa_pinch_x(&pinch, 1) - cocoa_pinch_x(&pinch, 0);
+    assert(cocoa_pinch_update(&pinch, 0.5));
+    int expanded = cocoa_pinch_x(&pinch, 1) - cocoa_pinch_x(&pinch, 0);
+    assert(expanded == original * 3 / 2);
+    assert(cocoa_pinch_update(&pinch, -1.0 / 3.0));
+    assert(fabs(pinch.scale - 1.0) < 1e-12);
+    check_bounds(&pinch);
+
+    /* Small events accumulate continuously instead of becoming key presses. */
+    for (int i = 0; i < 100; i++) {
+        assert(cocoa_pinch_update(&pinch, 0.001));
+        check_bounds(&pinch);
+    }
+    assert(fabs(pinch.scale - pow(1.001, 100)) < 1e-12);
+
+    /* Extreme finite input saturates; non-finite/invalid deltas are rejected. */
+    assert(cocoa_pinch_update(&pinch, DBL_MAX));
+    check_bounds(&pinch);
+    assert(cocoa_pinch_update(&pinch, DBL_MAX));
+    check_bounds(&pinch);
+    for (int i = 0; i < 100; i++) {
+        assert(cocoa_pinch_update(&pinch, -0.9));
+        check_bounds(&pinch);
+    }
+    double before = pinch.scale;
+    assert(!cocoa_pinch_update(&pinch, NAN));
+    assert(!cocoa_pinch_update(&pinch, INFINITY));
+    assert(!cocoa_pinch_update(&pinch, -INFINITY));
+    assert(!cocoa_pinch_update(&pinch, -1.0));
+    assert(!cocoa_pinch_update(&pinch, -2.0));
+    assert(pinch.scale == before);
+
+    /* End/cancel/focus loss emit one release, and orphaned updates stay idle. */
+    assert(cocoa_pinch_end(&pinch));
+    assert(!cocoa_pinch_end(&pinch));
+    assert(!cocoa_pinch_update(&pinch, 0.1));
+    cocoa_pinch_begin(&pinch);
+    assert(pinch.scale == 1.0);
+    assert(cocoa_pinch_end(&pinch));
+
+    /* Exercise the same lifecycle dispatch used by the Cocoa event handler. */
+    assert(cocoa_pinch_event(&pinch, 0, true, 0.5, record, frames));
+    assert(count == 0);  /* orphaned update */
+    assert(!cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, false, 0.1,
+                             record, frames));
+    assert(count == 0);  /* background window */
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    assert(count == 1 && frames[0].down);
+    cocoa_pinch_event(&pinch, 0, true, 0.5, record, frames);
+    assert(count == 2 && frames[1].down);
+    assert(frames[1].x[1] > frames[0].x[1]);
+    cocoa_pinch_event(&pinch, COCOA_PINCH_END, true, 0, record, frames);
+    assert(count == 3 && !frames[2].down);
+    cocoa_pinch_event(&pinch, COCOA_PINCH_END, true, 0, record, frames);
+    assert(count == 3);
+
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    assert(frames[3].x[1] == frames[0].x[1]);
+    cocoa_pinch_cancel(&pinch, record, frames);  /* windowDidResignKey */
+    assert(count == 5 && !frames[4].down);
+    cocoa_pinch_event(&pinch, 0, true, 0.5, record, frames);
+    assert(count == 5);  /* focus return does not resume old contacts */
+
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    cocoa_pinch_event(&pinch, COCOA_PINCH_CANCEL, true, 0.5, record, frames);
+    assert(count == 7 && !frames[6].down);
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, NAN, record, frames);
+    assert(count == 7);  /* invalid begin never creates contacts */
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    cocoa_pinch_event(&pinch, 0, true, NAN, record, frames);
+    assert(count == 9 && !frames[8].down);  /* invalid update releases */
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    cocoa_pinch_event(&pinch, 0, false, 0, record, frames);
+    assert(count == 11 && !frames[10].down);  /* pointer leaves guest */
+    cocoa_pinch_event(&pinch, COCOA_PINCH_BEGIN, true, 0, record, frames);
+    cocoa_pinch_vm_state(&pinch, false, record, frames);
+    assert(count == 12 && !pinch.active);  /* no input while stopped */
+    cocoa_pinch_cancel(&pinch, record, frames);  /* focus loss while stopped */
+    cocoa_pinch_vm_state(&pinch, true, record, frames);
+    assert(count == 13 && !frames[12].down);  /* clear guest slots on resume */
+    cocoa_pinch_event(&pinch, 0, true, 0.2, record, frames);
+    assert(count == 13);
+    return 0;
+}
+''')
+            compiler = shlex.split(os.environ.get("CC", "cc"))
+            subprocess.run(compiler + ["-std=c11", "-Wall", "-Wextra", "-Werror",
+                           str(work / "test.c"), "-lm", "-o", str(work / "test")],
+                           check=True)
+            subprocess.run([str(work / "test")], check=True)
+
+    def test_builder_verifies_exact_patch(self):
+        builder = (ROOT / "macos/build-qemu-gpu-runtime.sh").read_text()
+        expected = re.search(r"^pinch_patch_sha256=([a-f0-9]{64})$", builder, re.M)
+        self.assertIsNotNone(expected)
+        self.assertEqual(hashlib.sha256(PATCH.read_bytes()).hexdigest(), expected[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/Tests/test-virtio-pinch.py
+++ b/macos/Tests/test-virtio-pinch.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Optional guest-ABI test against a patched x86_64 QEMU built on Linux.
+
+QEMU_PINCH_TEST_BINARY=/path/to/qemu-system-x86_64 python3 this-file.py
+Uses qtest, with no guest disk, host input injection, or hardware acceleration.
+"""
+
+import json
+import os
+from pathlib import Path
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+BINARY = os.environ.get("QEMU_PINCH_TEST_BINARY")
+
+
+@unittest.skipUnless(BINARY, "set QEMU_PINCH_TEST_BINARY to run the guest ABI test")
+class VirtioPinchTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        work = Path(self.directory.name)
+        self.log = open(work / "qemu.log", "w+")
+        self.addCleanup(self.log.close)
+        # qtest does not execute guest instructions; provide an inert ROM.
+        (work / "bios").write_bytes(bytes(65536))
+        self.process = subprocess.Popen([
+            BINARY, "-machine", "q35", "-accel", "qtest", "-m", "64M",
+            "-nodefaults", "-display", "none", "-S", "-bios", str(work / "bios"),
+            "-device", "virtio-tablet-pci,addr=03.0,romfile=",
+            "-device", "virtio-pinch-pci,addr=04.0,romfile=",
+            "-qtest", f"unix:{work}/qtest,server=on,wait=off",
+            "-qmp", f"unix:{work}/qmp,server=on,wait=off",
+        ], stdout=self.log, stderr=self.log)
+        self.addCleanup(self.stop)
+        self.qtest = self.connect(work / "qtest")
+        self.qmp = self.connect(work / "qmp")
+        json.loads(self.qmp.readline())
+        self.command("qmp_capabilities")
+        self.bar = 0x10000000
+        cap = self.pci_read(0x34) & 0xff
+        self.caps = {}
+        seen = set()
+        while cap:
+            self.assertNotIn(cap, seen)
+            seen.add(cap)
+            header = self.pci_read(cap)
+            if header & 0xff == 9 and header >> 24 in (1, 2, 3, 4):
+                kind = header >> 24
+                bar = self.pci_read(cap + 4) & 0xff
+                self.assertEqual(bar, 4)
+                self.caps[kind] = self.bar + self.pci_read(cap + 8)
+            cap = (header >> 8) & 0xff
+        self.pci_write(0x20, self.bar)  # BAR4 (64 bit)
+        self.pci_write(0x24, 0)
+        self.pci_write(0x04, 6)  # memory + bus master
+        self.assertIn(1, self.caps)
+        self.assertIn(4, self.caps)
+
+    def stop(self):
+        if self.process.poll() not in (None, 0):
+            self.log.seek(0)
+            print(self.log.read(), file=sys.stderr)
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=5)
+
+    def connect(self, path):
+        sock = socket.socket(socket.AF_UNIX)
+        self.addCleanup(sock.close)
+        sock.settimeout(5)
+        deadline = time.monotonic() + 5
+        while True:
+            try:
+                sock.connect(str(path))
+                break
+            except (FileNotFoundError, ConnectionRefusedError):
+                if self.process.poll() is not None or time.monotonic() > deadline:
+                    self.log.seek(0)
+                    self.fail(self.log.read())
+                time.sleep(0.01)
+        stream = sock.makefile("rwb", buffering=0)
+        self.addCleanup(stream.close)
+        return stream
+
+    def qt(self, line):
+        self.qtest.write((line + "\n").encode())
+        while True:
+            reply = self.qtest.readline().decode().strip()
+            if not reply.startswith("IRQ"):
+                self.assertTrue(reply.startswith("OK"), reply)
+                return reply[2:].strip()
+
+    def command(self, name, arguments=None):
+        self.qmp.write((json.dumps({"execute": name, "arguments": arguments or {}})
+                        + "\n").encode())
+        while True:
+            reply = json.loads(self.qmp.readline())
+            if "event" not in reply:
+                self.assertNotIn("error", reply)
+                return reply.get("return")
+
+    def pci_read(self, offset):
+        self.qt(f"outl 0xcf8 {0x80002000 + offset:#x}")
+        return int(self.qt("inl 0xcfc"), 0)
+
+    def pci_write(self, offset, value):
+        self.qt(f"outl 0xcf8 {0x80002000 + offset:#x}")
+        self.qt(f"outl 0xcfc {value:#x}")
+
+    def write(self, address, data):
+        self.qt(f"write {address:#x} {len(data):#x} 0x{data.hex()}")
+
+    def read(self, address, length):
+        return bytes.fromhex(self.qt(f"read {address:#x} {length:#x}")[2:])
+
+    def config(self, select, subselect=0):
+        address = self.caps[4]
+        self.qt(f"writeb {address:#x} {select}")
+        self.qt(f"writeb {address + 1:#x} {subselect}")
+        size = int(self.qt(f"readb {address + 2:#x}"), 0)
+        return self.read(address + 8, size) if size else b""
+
+    def test_touchpad_capabilities_and_contact_frames(self):
+        self.assertEqual(self.config(1).rstrip(b"\0"), b"QEMU Virtio Pinch Touchpad")
+        self.assertEqual(int.from_bytes(self.config(0x10), "little"), 1)  # POINTER
+        keys = int.from_bytes(self.config(0x11, 1), "little")
+        for key in (0x110, 0x145, 0x14a, 0x14d):  # LEFT, FINGER, TOUCH, DOUBLETAP
+            self.assertTrue(keys & (1 << key))
+        axes = int.from_bytes(self.config(0x11, 3), "little")
+        for axis in (0, 1, 0x2f, 0x35, 0x36, 0x39):
+            self.assertTrue(axes & (1 << axis))
+        for axis in (0, 1, 0x35, 0x36):
+            self.assertEqual(struct.unpack("<5I", self.config(0x12, axis)),
+                             (0, 32767, 0, 0, 327))
+
+        common = self.caps[1]
+        self.qt(f"writeb {common + 20:#x} 3")
+        self.qt(f"writel {common + 8:#x} 1")
+        self.qt(f"writel {common + 12:#x} 1")  # VIRTIO_F_VERSION_1
+        self.qt(f"writeb {common + 20:#x} 11")
+        self.assertEqual(int(self.qt(f"readb {common + 20:#x}"), 0), 11)
+        self.qt(f"writew {common + 22:#x} 0")
+        self.qt(f"writew {common + 24:#x} 64")
+        desc, avail, used, buffers = 0x100000, 0x101000, 0x102000, 0x103000
+        self.write(desc, b"".join(struct.pack("<QIHH", buffers + i * 8, 8, 2, 0)
+                                  for i in range(64)))
+        self.write(avail, struct.pack("<66H", 0, 64, *range(64)))
+        for offset, address in ((32, desc), (40, avail), (48, used)):
+            self.qt(f"writeq {common + offset:#x} {address:#x}")
+        self.qt(f"writew {common + 28:#x} 1")
+        self.qt(f"writeb {common + 20:#x} 15")
+        self.command("cont")
+
+        def contact(kind, slot, tracking, axis="x", value=0):
+            return {"type": "mtt", "data": {"type": kind, "slot": slot,
+                    "tracking-id": tracking, "axis": axis, "value": value}}
+
+        def frame(radius):
+            events = []
+            for slot in range(2):
+                events += [contact("update", slot, slot),
+                           contact("data", slot, slot, "x", 16384 + (2 * slot - 1) * radius),
+                           contact("data", slot, slot, "y", 16384)]
+            return events
+
+        self.command("input-send-event", {"events": frame(4096)})
+        self.command("input-send-event", {"events": frame(6144)})
+        self.command("input-send-event", {"events": [contact("end", 0, -1),
+                                                       contact("end", 1, -1)]})
+        count = struct.unpack("<H", self.read(used + 2, 2))[0]
+        self.assertEqual(count, 33)  # two motion frames (13 each), release (7)
+        events = [struct.unpack("<HHi", self.read(buffers + i * 8, 8))
+                  for i in range(count)]
+        self.assertEqual(events[:2], [(1, 0x14a, 1), (1, 0x14d, 1)])
+        self.assertEqual(events[-7:], [(1, 0x14a, 0), (1, 0x14d, 0),
+                         (3, 0x2f, 0), (3, 0x39, -1), (3, 0x2f, 1),
+                         (3, 0x39, -1), (0, 0, 0)])
+        # Normal mouse buttons must still route to the tablet, not this device.
+        self.command("input-send-event", {"events": [
+            {"type": "btn", "data": {"button": "left", "down": True}},
+            {"type": "btn", "data": {"button": "left", "down": False}},
+        ]})
+        self.assertEqual(struct.unpack("<H", self.read(used + 2, 2))[0], count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -7,7 +7,7 @@ usage() {
 Usage: macos/build-qemu-gpu-runtime.sh [--archive-dir DIR]
 
 Build the pinned QEMU/VirGL source stack with Try Omarchy's Cocoa identity,
-dynamic-display, immersive-mode, and pause-ownership patches, then relocate,
+dynamic-display, immersive-mode, pause-ownership, and pinch-zoom patches, then relocate,
 sign, validate, and
 atomically stage it at:
   macos/.build/qemu-gpu-runtime
@@ -49,6 +49,7 @@ display_patch="$native_dir/patches/qemu-cocoa-dynamic-display.patch"
 immersive_patch="$native_dir/patches/qemu-cocoa-immersive-mode.patch"
 full_grab_patch="$native_dir/patches/qemu-cocoa-full-grab-focus.patch"
 pause_ownership_patch="$native_dir/patches/qemu-cocoa-pause-ownership.patch"
+pinch_patch="$native_dir/patches/qemu-cocoa-pinch-zoom.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
 shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 strchrnul_patch="$native_dir/patches/qemu-darwin-strchrnul-compat.patch"
@@ -68,6 +69,7 @@ display_patch_sha256=1ce59350b6b8e6842bc0c9ca34c97f54cb75e85e2d7b35e5b483858654c
 immersive_patch_sha256=2462463932f7db0d659f754f7f9c182884564dbcd7d4b8e523f1b57f0bd9fe5b
 full_grab_patch_sha256=d94aaa7b8b8b97eb25a5ace2b3a1268985e1b16e4e6201847b926b8ee709dbfb
 pause_ownership_patch_sha256=1a5729b36eb3e437395d41883a10c3c652df71d289d5df84d95aebd49c78a8f0
+pinch_patch_sha256=37acb8895dddd35fc66812d0c49ec5fc697f9127e9e12ed2e60d17999bf32aee
 audio_device_patch_sha256=03aca71c26163c337338cc3b2013c35430690fc0e8b66c5ce92a42f59a9b3334
 shared_folder_patch_sha256=41247692501655393ae3a40f56915472ab29b6e89c5173e33db1f62cca56632f
 strchrnul_patch_sha256=ec1048dd0e8ebe53bf7e8a3bca9bf2f5f4336cd607d4cd077437470e9a32094a
@@ -153,6 +155,8 @@ macos_major=$(sw_vers -productVersion | awk -F. '{ print $1 }')
   die "missing Cocoa full-grab patch: $full_grab_patch"
 [[ -f $pause_ownership_patch && ! -L $pause_ownership_patch ]] || \
   die "missing Cocoa pause-ownership patch: $pause_ownership_patch"
+[[ -f $pinch_patch && ! -L $pinch_patch ]] || \
+  die "missing Cocoa pinch-zoom patch: $pinch_patch"
 [[ -f $audio_device_patch && ! -L $audio_device_patch ]] || \
   die "missing SDL audio-device patch: $audio_device_patch"
 [[ -f $texture_patch && ! -L $texture_patch ]] || \
@@ -337,6 +341,8 @@ verify_file_sha "Try Omarchy Cocoa full-grab patch" \
   "$full_grab_patch" "$full_grab_patch_sha256"
 verify_file_sha "Try Omarchy Cocoa pause-ownership patch" \
   "$pause_ownership_patch" "$pause_ownership_patch_sha256"
+verify_file_sha "Try Omarchy Cocoa pinch-zoom patch" \
+  "$pinch_patch" "$pinch_patch_sha256"
 verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
 verify_file_sha "Try Omarchy 9p shared-folder patch" \
@@ -344,7 +350,7 @@ verify_file_sha "Try Omarchy 9p shared-folder patch" \
 verify_file_sha "Try Omarchy Darwin strchrnul compatibility patch" \
   "$strchrnul_patch" "$strchrnul_patch_sha256"
 
-log "Applying the exact render, identity, display, immersive, pause-ownership, audio, folder, and Darwin compatibility patches"
+log "Applying the exact render, identity, display, immersive, pause-ownership, audio, folder, Darwin compatibility, and pinch patches"
 patch -d "$source_dir" -p1 -f -i "$texture_patch"
 patch -d "$source_dir" -p1 -f -i "$gpu_fix_patch"
 patch -d "$source_dir" -p1 -f -i "$identity_patch"
@@ -355,6 +361,7 @@ patch -d "$source_dir" -p1 -f -i "$pause_ownership_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
 patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 patch -d "$source_dir" -p1 -f -i "$strchrnul_patch"
+patch -d "$source_dir" -p1 -f -i "$pinch_patch"
 
 virgl_root="$dependency_root/virglrenderer/$virgl_version"
 angle_root="$dependency_root/angle/$angle_version"

--- a/macos/patches/qemu-cocoa-pinch-zoom.patch
+++ b/macos/patches/qemu-cocoa-pinch-zoom.patch
@@ -1,0 +1,484 @@
+From: Try Omarchy contributors
+Subject: [PATCH] cocoa: forward magnification through a dedicated virtio touchpad
+
+Applies after the existing Try Omarchy QEMU patches. Preserve the tablet and
+multitouch touchscreen; the new pinch device accepts only multitouch events.
+The Cocoa bridge reconstructs two symmetric contacts from magnification and
+releases them on cancellation or loss of keyboard focus. Guest configuration
+disables tapping for this gesture-only device.
+
+diff --git a/include/ui/cocoa-pinch.h b/include/ui/cocoa-pinch.h
+new file mode 100644
+--- /dev/null
++++ b/include/ui/cocoa-pinch.h
+@@ -0,0 +1,127 @@
++/*
++ * Cocoa pinch geometry, independent of AppKit for deterministic testing.
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++#ifndef QEMU_COCOA_PINCH_H
++#define QEMU_COCOA_PINCH_H
++
++#include <stdbool.h>
++#include <math.h>
++
++typedef struct CocoaPinch {
++    bool active;
++    double scale;
++} CocoaPinch;
++
++enum {
++    COCOA_PINCH_CENTER = 16384,
++    COCOA_PINCH_RADIUS = 4096,
++    COCOA_PINCH_AXIS_MAX = 32767,
++};
++
++static inline void cocoa_pinch_begin(CocoaPinch *pinch)
++{
++    pinch->active = true;
++    pinch->scale = 1.0;
++}
++
++static inline bool cocoa_pinch_end(CocoaPinch *pinch)
++{
++    bool active = pinch->active;
++    pinch->active = false;
++    pinch->scale = 1.0;
++    return active;
++}
++
++/* NSEvent.magnification is the relative change since the previous event. */
++static inline bool cocoa_pinch_update(CocoaPinch *pinch, double delta)
++{
++    if (!pinch->active || !isfinite(delta) || delta <= -1.0) {
++        return false;
++    }
++    double scale = pinch->scale * (1.0 + delta);
++    pinch->scale = fmin(3.5, fmax(0.125, scale));
++    return true;
++}
++
++static inline int cocoa_pinch_x(const CocoaPinch *pinch, int slot)
++{
++    int radius = (int)lround(COCOA_PINCH_RADIUS * pinch->scale);
++    return COCOA_PINCH_CENTER + (slot == 0 ? -radius : radius);
++}
++
++typedef struct CocoaPinchFrame {
++    bool down;
++    int x[2];
++} CocoaPinchFrame;
++
++typedef void (*CocoaPinchEmit)(void *opaque, const CocoaPinchFrame *frame);
++
++enum {
++    COCOA_PINCH_BEGIN = 1,
++    COCOA_PINCH_END = 2,
++    COCOA_PINCH_CANCEL = 4,
++};
++
++static inline void cocoa_pinch_emit(const CocoaPinch *pinch,
++                                    CocoaPinchEmit emit, void *opaque)
++{
++    CocoaPinchFrame frame = {
++        .down = pinch->active,
++        .x = { cocoa_pinch_x(pinch, 0), cocoa_pinch_x(pinch, 1) },
++    };
++    emit(opaque, &frame);
++}
++
++static inline void cocoa_pinch_cancel(CocoaPinch *pinch,
++                                      CocoaPinchEmit emit, void *opaque)
++{
++    if (cocoa_pinch_end(pinch)) {
++        cocoa_pinch_emit(pinch, emit, opaque);
++    }
++}
++
++/* Input is dropped while QEMU is paused. Clear stale guest slots on resume,
++ * even if focus loss already cleared the local state during the pause. */
++static inline void cocoa_pinch_vm_state(CocoaPinch *pinch, bool running,
++                                        CocoaPinchEmit emit, void *opaque)
++{
++    cocoa_pinch_end(pinch);
++    if (running) {
++        cocoa_pinch_emit(pinch, emit, opaque);
++    }
++}
++
++/* Only a new begin can re-establish contacts after cancellation/focus loss. */
++static inline bool cocoa_pinch_event(CocoaPinch *pinch, unsigned phase,
++                                     bool eligible, double delta,
++                                     CocoaPinchEmit emit, void *opaque)
++{
++    if (!eligible) {
++        cocoa_pinch_cancel(pinch, emit, opaque);
++        return false;
++    }
++    if (phase & COCOA_PINCH_CANCEL) {
++        cocoa_pinch_cancel(pinch, emit, opaque);
++        return true;
++    }
++    if (!isfinite(delta) || delta <= -1.0) {
++        cocoa_pinch_cancel(pinch, emit, opaque);
++        return true;
++    }
++    if (phase & COCOA_PINCH_BEGIN) {
++        cocoa_pinch_cancel(pinch, emit, opaque);
++        cocoa_pinch_begin(pinch);
++        cocoa_pinch_emit(pinch, emit, opaque);
++    }
++    if (pinch->active && delta != 0.0) {
++        cocoa_pinch_update(pinch, delta);
++        cocoa_pinch_emit(pinch, emit, opaque);
++    }
++    if (phase & COCOA_PINCH_END) {
++        cocoa_pinch_cancel(pinch, emit, opaque);
++    }
++    return true;
++}
++
++#endif
+diff --git a/include/hw/virtio/virtio-input.h b/include/hw/virtio/virtio-input.h
+--- a/include/hw/virtio/virtio-input.h
++++ b/include/hw/virtio/virtio-input.h
+@@ -31,6 +31,7 @@
+ #define TYPE_VIRTIO_MOUSE      "virtio-mouse-device"
+ #define TYPE_VIRTIO_TABLET     "virtio-tablet-device"
+ #define TYPE_VIRTIO_MULTITOUCH "virtio-multitouch-device"
++#define TYPE_VIRTIO_PINCH      "virtio-pinch-device"
+ 
+ OBJECT_DECLARE_SIMPLE_TYPE(VirtIOInputHID, VIRTIO_INPUT_HID)
+ #define VIRTIO_INPUT_HID_GET_PARENT_CLASS(obj) \
+diff --git a/hw/input/virtio-input-hid.c b/hw/input/virtio-input-hid.c
+--- a/hw/input/virtio-input-hid.c
++++ b/hw/input/virtio-input-hid.c
+@@ -529,6 +529,132 @@
+     .instance_init = virtio_multitouch_init,
+ };
+ 
++/*
++ * A dedicated two-contact, indirect device for Cocoa magnification. It does
++ * not subscribe to BTN/ABS/REL events: the existing tablet retains all normal
++ * pointer input. Slot zero carries the two-contact lifecycle; slot one is
++ * always its symmetric partner. There is no persistent backend contact state,
++ * so virtio reset/migration uses the existing input device machinery.
++ */
++static void virtio_pinch_send(VirtIOInput *vinput, int type, int code, int value)
++{
++    virtio_input_event event = {
++        .type = cpu_to_le16(type),
++        .code = cpu_to_le16(code),
++        .value = cpu_to_le32(value),
++    };
++    virtio_input_send(vinput, &event);
++}
++
++static void virtio_pinch_event(DeviceState *dev, QemuConsole *src,
++                               QemuInputEvent *evt)
++{
++    VirtIOInput *vinput = VIRTIO_INPUT(dev);
++    InputMultiTouchEvent *mtt = &evt->mtt;
++
++    if (evt->type != INPUT_EVENT_KIND_MTT || mtt->slot < 0 || mtt->slot > 1) {
++        return;
++    }
++    if (mtt->slot == 0) {
++        if (mtt->type != INPUT_MULTI_TOUCH_TYPE_DATA) {
++            /* BTN_TOUCH must precede the axes within the frame. */
++            bool down = mtt->tracking_id >= 0;
++            virtio_pinch_send(vinput, EV_KEY, BTN_TOUCH, down);
++            virtio_pinch_send(vinput, EV_KEY, BTN_TOOL_DOUBLETAP, down);
++        } else if (mtt->axis == INPUT_AXIS_X || mtt->axis == INPUT_AXIS_Y) {
++            virtio_pinch_send(vinput, EV_ABS, axismap_abs[mtt->axis],
++                              mtt->value);
++        }
++    }
++    virtio_input_handle_event(dev, src, evt);
++}
++
++static const QemuInputHandler virtio_pinch_handler = {
++    .name = "QEMU Virtio Pinch Touchpad",
++    .mask = INPUT_EVENT_MASK_MTT,
++    .event = virtio_pinch_event,
++    .sync = virtio_input_handle_sync,
++};
++
++static void virtio_pinch_init(Object *obj)
++{
++    VirtIOInputHID *vhid = VIRTIO_INPUT_HID(obj);
++    VirtIOInput *vinput = VIRTIO_INPUT(obj);
++    const unsigned short keys[] = {
++        BTN_LEFT, BTN_TOUCH, BTN_TOOL_FINGER, BTN_TOOL_DOUBLETAP,
++    };
++    /* ABS_X and INPUT_PROP_POINTER are zero: the bitmap helper skips zero. */
++    const unsigned short axes[] = {
++        ABS_Y, ABS_MT_SLOT, ABS_MT_TRACKING_ID,
++        ABS_MT_POSITION_X, ABS_MT_POSITION_Y,
++    };
++    const unsigned short position_axes[] = {
++        ABS_X, ABS_Y, ABS_MT_POSITION_X, ABS_MT_POSITION_Y,
++    };
++    virtio_input_config config = {
++        .select = VIRTIO_INPUT_CFG_ID_NAME,
++        .size = sizeof("QEMU Virtio Pinch Touchpad"),
++        .u.string = "QEMU Virtio Pinch Touchpad",
++    };
++
++    virtio_input_config empty = {0};
++
++    vhid->handler = &virtio_pinch_handler;
++    virtio_input_init_config(vinput, &empty);
++    virtio_input_add_config(vinput, &config);
++    memset(&config, 0, sizeof(config));
++    config.select = VIRTIO_INPUT_CFG_ID_DEVIDS;
++    config.size = sizeof(struct virtio_input_devids);
++    config.u.ids.bustype = const_le16(BUS_VIRTUAL);
++    config.u.ids.vendor = const_le16(0x0627);
++    config.u.ids.product = const_le16(0x0004);
++    config.u.ids.version = const_le16(1);
++    virtio_input_add_config(vinput, &config);
++
++    virtio_input_extend_config(vinput, keys, ARRAY_SIZE(keys),
++                               VIRTIO_INPUT_CFG_EV_BITS, EV_KEY);
++    memset(&config, 0, sizeof(config));
++    config.select = VIRTIO_INPUT_CFG_EV_BITS;
++    config.subsel = EV_ABS;
++    config.size = 1;
++    config.u.bitmap[0] = 1 << ABS_X;
++    /* Include ABS_X explicitly as the generic bitmap helper skips zero. */
++    for (int i = 0; i < ARRAY_SIZE(axes); i++) {
++        config.u.bitmap[axes[i] / 8] |= 1 << (axes[i] % 8);
++        config.size = MAX(config.size, axes[i] / 8 + 1);
++    }
++    virtio_input_add_config(vinput, &config);
++    memset(&config, 0, sizeof(config));
++    config.select = VIRTIO_INPUT_CFG_PROP_BITS;
++    config.size = 1;
++    config.u.bitmap[0] = 1 << INPUT_PROP_POINTER;
++    virtio_input_add_config(vinput, &config);
++
++    memset(&config, 0, sizeof(config));
++    config.select = VIRTIO_INPUT_CFG_ABS_INFO;
++    config.size = sizeof(virtio_input_absinfo);
++    config.subsel = ABS_MT_SLOT;
++    config.u.abs.max = const_le32(1);
++    virtio_input_add_config(vinput, &config);
++    config.subsel = ABS_MT_TRACKING_ID;
++    config.u.abs.max = const_le32(65535);
++    virtio_input_add_config(vinput, &config);
++    /* A 100 mm square sensor, with explicit resolution for libinput. */
++    config.u.abs.max = const_le32(INPUT_EVENT_ABS_MAX);
++    config.u.abs.res = const_le32(327);
++    for (int i = 0; i < ARRAY_SIZE(position_axes); i++) {
++        config.subsel = position_axes[i];
++        virtio_input_add_config(vinput, &config);
++    }
++}
++
++static const TypeInfo virtio_pinch_info = {
++    .name = TYPE_VIRTIO_PINCH,
++    .parent = TYPE_VIRTIO_INPUT_HID,
++    .instance_size = sizeof(VirtIOInputHID),
++    .instance_init = virtio_pinch_init,
++};
++
+ /* ----------------------------------------------------------------- */
+ 
+ static void virtio_register_types(void)
+@@ -538,6 +664,7 @@
+     type_register_static(&virtio_mouse_info);
+     type_register_static(&virtio_tablet_info);
+     type_register_static(&virtio_multitouch_info);
++    type_register_static(&virtio_pinch_info);
+ }
+ 
+ type_init(virtio_register_types)
+diff --git a/hw/virtio/virtio-input-pci.c b/hw/virtio/virtio-input-pci.c
+--- a/hw/virtio/virtio-input-pci.c
++++ b/hw/virtio/virtio-input-pci.c
+@@ -30,6 +30,7 @@
+ #define TYPE_VIRTIO_MOUSE_PCI      "virtio-mouse-pci"
+ #define TYPE_VIRTIO_TABLET_PCI     "virtio-tablet-pci"
+ #define TYPE_VIRTIO_MULTITOUCH_PCI "virtio-multitouch-pci"
++#define TYPE_VIRTIO_PINCH_PCI     "virtio-pinch-pci"
+ OBJECT_DECLARE_SIMPLE_TYPE(VirtIOInputHIDPCI, VIRTIO_INPUT_HID_PCI)
+ 
+ struct VirtIOInputHIDPCI {
+@@ -111,6 +112,14 @@
+                                 TYPE_VIRTIO_MULTITOUCH);
+ }
+ 
++static void virtio_pinch_initfn(Object *obj)
++{
++    VirtIOInputHIDPCI *dev = VIRTIO_INPUT_HID_PCI(obj);
++
++    virtio_instance_init_common(obj, &dev->vdev, sizeof(dev->vdev),
++                                TYPE_VIRTIO_PINCH);
++}
++
+ static const TypeInfo virtio_input_pci_info = {
+     .name          = TYPE_VIRTIO_INPUT_PCI,
+     .parent        = TYPE_VIRTIO_PCI,
+@@ -156,6 +165,13 @@
+     .instance_init = virtio_multitouch_initfn,
+ };
+ 
++static const VirtioPCIDeviceTypeInfo virtio_pinch_pci_info = {
++    .generic_name  = TYPE_VIRTIO_PINCH_PCI,
++    .parent        = TYPE_VIRTIO_INPUT_HID_PCI,
++    .instance_size = sizeof(VirtIOInputHIDPCI),
++    .instance_init = virtio_pinch_initfn,
++};
++
+ static void virtio_pci_input_register(void)
+ {
+     /* Base types: */
+@@ -167,6 +183,7 @@
+     virtio_pci_types_register(&virtio_mouse_pci_info);
+     virtio_pci_types_register(&virtio_tablet_pci_info);
+     virtio_pci_types_register(&virtio_multitouch_pci_info);
++    virtio_pci_types_register(&virtio_pinch_pci_info);
+ }
+ 
+ type_init(virtio_pci_input_register)
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -37,6 +37,7 @@
+ #include "ui/clipboard.h"
+ #include "ui/console.h"
+ #include "ui/input.h"
++#include "ui/cocoa-pinch.h"
+ #include "ui/kbd-state.h"
+ #include "system/system.h"
+ #include "system/runstate.h"
+@@ -344,6 +345,7 @@
+     int mouseX;
+     int mouseY;
+     bool mouseOn;
++    CocoaPinch pinch;
+ }
+ - (void) grabMouse;
+ - (void) ungrabMouse;
+@@ -355,9 +357,20 @@
+ - (BOOL) isMouseGrabbed;
+ - (BOOL) isKeyboardCaptured;
+ - (void) raiseAllKeys;
++- (void) endPinchLocked;
++- (void) resetPinchLocked:(bool)running;
++- (bool) handlePinchLocked:(NSEvent *)event;
+ @end
+ 
+ QemuCocoaView *cocoaView;
++static VMChangeStateEntry *pinch_vm_change;
++
++/* VM state callbacks hold the BQL; this method only touches input state. */
++static void cocoa_pinch_vm_change(void *opaque, bool running, RunState state)
++{
++    [cocoaView resetPinchLocked:running];
++}
++
+ 
+ static CGEventRef handleTapEvent(CGEventTapProxy proxy, CGEventType type, CGEventRef cgEvent, void *userInfo)
+ {
+@@ -370,6 +383,24 @@
+     COCOA_DEBUG("Global events tap: qemu did not handle the event, letting it through...\n");
+ 
+     return cgEvent;
++}
++
++/* Called under the same BQL as normal Cocoa input. */
++static void cocoa_pinch_send_frame(void *opaque, const CocoaPinchFrame *frame)
++{
++    for (int slot = 0; slot < 2; slot++) {
++        qemu_input_queue_mtt(dcl.con,
++                            frame->down ? INPUT_MULTI_TOUCH_TYPE_UPDATE :
++                                          INPUT_MULTI_TOUCH_TYPE_END,
++                            slot, frame->down ? slot : -1);
++        if (frame->down) {
++            qemu_input_queue_mtt_abs(dcl.con, INPUT_AXIS_X, frame->x[slot], 0,
++                                    COCOA_PINCH_AXIS_MAX, slot, slot);
++            qemu_input_queue_mtt_abs(dcl.con, INPUT_AXIS_Y, COCOA_PINCH_CENTER, 0,
++                                    COCOA_PINCH_AXIS_MAX, slot, slot);
++        }
++    }
++    qemu_input_event_sync();
+ }
+ 
+ @implementation QemuCocoaView
+@@ -899,6 +930,40 @@
+         QemuTextConsole *con = QEMU_TEXT_CONSOLE(dcl.con);
+         qemu_text_console_put_keysym(con, keysym);
+     }
++}
++
++- (void) resetPinchLocked:(bool)running
++{
++    cocoa_pinch_vm_state(&pinch, running, cocoa_pinch_send_frame, NULL);
++}
++
++- (void) endPinchLocked
++{
++    cocoa_pinch_cancel(&pinch, cocoa_pinch_send_frame, NULL);
++}
++
++- (bool) handlePinchLocked:(NSEvent *)event
++{
++    NSEventPhase phase = [event phase];
++    NSPoint point = [self convertPoint:[event locationInWindow] fromView:nil];
++    unsigned action = 0;
++    bool eligible = [event window] == [self window] &&
++                    [[self window] isKeyWindow] &&
++                    NSPointInRect(point, [self bounds]) &&
++                    qemu_console_is_graphic(dcl.con) &&
++                    runstate_is_running();
++
++    if (phase & NSEventPhaseBegan) {
++        action |= COCOA_PINCH_BEGIN;
++    }
++    if (phase & NSEventPhaseEnded) {
++        action |= COCOA_PINCH_END;
++    }
++    if (phase & NSEventPhaseCancelled) {
++        action |= COCOA_PINCH_CANCEL;
++    }
++    return cocoa_pinch_event(&pinch, action, eligible, [event magnification],
++                            cocoa_pinch_send_frame, NULL);
+ }
+ 
+ - (bool) handleEvent:(NSEvent *)event
+@@ -1110,6 +1175,8 @@
+                 qkbd_state_key_event(kbd, keycode, false);
+             }
+             return true;
++        case NSEventTypeMagnify:
++            return [self handlePinchLocked:event];
+         case NSEventTypeScrollWheel:
+             /*
+              * Send wheel events to the guest regardless of window focus.
+@@ -1320,6 +1387,7 @@
+ - (void) raiseAllKeys
+ {
+     with_bql(^{
++        [self endPinchLocked];
+         qkbd_state_lift_all_keys(kbd);
+     });
+ }
+@@ -2667,6 +2735,8 @@
+     qemu_add_mouse_mode_change_notifier(&mouse_mode_change_notifier);
+     [cocoaView notifyMouseModeChange];
+     [cocoaView updateUIInfo];
++    pinch_vm_change = qemu_add_vm_change_state_handler(cocoa_pinch_vm_change,
++                                                       NULL);
+ 
+     qemu_event_init(&cbevent, false);
+     cbowner = [[QemuCocoaPasteboardTypeOwner alloc] init];
+@@ -2689,6 +2759,7 @@
+ 
+     qemu_console_unregister_listener(&dcl);
+     g_clear_pointer(&kbd, qkbd_state_free);
++    qemu_del_vm_change_state_handler(pinch_vm_change);
+     qemu_remove_mouse_mode_change_notifier(&mouse_mode_change_notifier);
+     qemu_clipboard_peer_unregister(&cbpeer);
+     g_clear_pointer(&cbinfo, qemu_clipboard_info_unref);

--- a/macos/prepare-qemu-gpu-runtime.sh
+++ b/macos/prepare-qemu-gpu-runtime.sh
@@ -415,7 +415,8 @@ verify_runtime_tree() {
     'name "intel-hda"' \
     'name "hda-micro"' \
     'name "virtio-net-pci"' \
-    'name "virtio-9p-pci"'; do
+    'name "virtio-9p-pci"' \
+    'name "virtio-pinch-pci"'; do
     [[ $device_help == *"$device"* ]] || die "relocated QEMU is missing device $device"
   done
 

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -151,7 +151,8 @@ for device in \
   virtio-net-pci \
   virtio-rng-pci \
   virtio-serial-pci \
-  virtio-tablet-pci; do
+  virtio-tablet-pci \
+  virtio-pinch-pci; do
   require_qemu_device "$device"
 done
 for marker in guest_owner_uid guest_owner_gid; do
@@ -1417,6 +1418,7 @@ qemu_args=(
   -display "cocoa,gl=es,show-cursor=on,zoom-to-fit=on,full-screen=$cocoa_full_screen,full-grab=on,immersive=$cocoa_immersive,swap-opt-cmd=off"
   -device 'virtio-keyboard-pci,romfile='
   -device 'virtio-tablet-pci,romfile='
+  -device 'virtio-pinch-pci,romfile='
   -object 'rng-random,id=omarchy-rng,filename=/dev/urandom'
   -device 'virtio-rng-pci,rng=omarchy-rng'
   -device virtio-balloon-pci


### PR DESCRIPTION
Native Wayland Chromium receives no pinch input in Try Omarchy because the guest only sees the pointer tablet and the Cocoa runtime does not handle magnification. This adds a dedicated indirect virtio touchpad and translates Cocoa magnification into two continuously spaced contacts for the guest's libinput/Wayland gesture path.

Closes #157.

The existing tablet retains pointer movement, clicks, and scrolling. The new device subscribes only to multitouch events; the existing touchscreen device is unchanged. The bridge releases contacts on end, cancellation, focus loss, and VM resume, rejects orphaned/invalid updates, and bounds coordinates to the advertised sensor. New factory users get a device-specific override disabling tapping and disable-while-typing. Existing persistent guests need the small input override documented in `docs/pinch-zoom.md`.

The runtime patch is checksummed and applies after the existing patches against the unchanged QEMU pin. This reconstructs pinch contacts from magnification; it does not forward raw finger positions, rotation, or other trackpad gestures.

Validation completed on Linux:

- Final patch applies with zero fuzz after the existing series and reproduces the tested sources exactly.
- Patched QEMU builds successfully for x86_64 with TCG/qtest.
- Compiled production gesture-model tests pass, including bounds, invalid values, cancellation, focus loss, repeated gestures, and stop/resume cleanup.
- Qtest reads the actual PCI touchpad capabilities, negotiates a virtqueue, checks two-contact motion/release frames, and verifies ordinary buttons do not reach the gesture device.
- Guest contract verification and shell syntax checks pass.

**Draft: native runtime and interactive gesture integration are not validated.** `make test` passes the new tests but stops at the same three pre-existing boot-export test failures seen on the clean baseline: their stat mock assumes macOS. `make runtime` cannot run here because `ditto` is unavailable. The native runtime build, live libinput recognition, and interactive Chromium/Firefox gesture tests remain required before merge; the checklist is in `docs/pinch-zoom.md`.

Rebased onto upstream `main` at `768d03d`. The stderr drain test retains its bounded pipe-read and descriptor-flag checks; EOF is tested separately using socket shutdown so inherited writer descriptors from parallel subprocess tests cannot delay EOF.

macOS CI: the full `make test` suite passed on commit `59cda5f`, including Swift and the subsequent shell suites. [Successful CI run](https://github.com/omacom/try-omarchy/actions/runs/34305278274).
