### PR TITLE
Fix memory contract test after pinch device support

### DIFF
--- a/macos/Tests/qemu-memory-contract.test.sh
+++ b/macos/Tests/qemu-memory-contract.test.sh
@@ -79,7 +79,7 @@ case " $* " in
     for device in \
       hda-micro intel-hda virtconsole virtserialport virtio-balloon-pci \
       virtio-9p-pci virtio-blk-pci virtio-gpu-gl-pci virtio-keyboard-pci \
-      virtio-net-pci virtio-rng-pci virtio-serial-pci virtio-tablet-pci; do
+      virtio-net-pci virtio-pinch-pci virtio-rng-pci virtio-serial-pci virtio-tablet-pci; do
       printf 'name "%s"\n' "$device"
     done
     ;;


### PR DESCRIPTION
The memory contract test's fake QEMU omitted `virtio-pinch-pci`, which the launcher requires after #158. This caused `make test` to stop before exercising the memory scenarios with “staged QEMU does not provide virtio-pinch-pci”.

Add the device to the fake QEMU's advertised capabilities so the existing memory scenarios can run. No production behavior changes.

Validation: full `make test` passed on macOS, including the previously failing memory contract test. The optional staged-QEMU lock-inheritance check was skipped because a staged runtime binary was absent.
