### PR TITLE
Resync guest display after Hyprland config reloads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,3 +264,19 @@ installer uses the declared sources and authenticates downloaded vendor
 artifacts against an explicit signing identity. Invoking an optional installer
 is the user's
 decision to cross that post-build boundary.
+
+### Guest display synchronization
+
+QEMU publishes the Cocoa window's current backing-pixel dimensions through
+Virtio GPU EDID. The guest's `omarchy-native-display-sync` helper applies those
+live timings at startup and on DRM hotplug events. The Hyprland monitor fragment
+also invokes the helper with `--once` after `config.reloaded`: a configuration
+reload can restore a cached preferred mode without emitting a hotplug event,
+leaving the rendered desktop and absolute pointer coordinates out of sync.
+
+Both paths reread Omarchy's numeric `omarchy_monitor_scale` setting from
+`~/.config/hypr/monitors.lua` (under `$XDG_CONFIG_HOME` when set). An automatic or
+absent setting uses the live EDID's pixel density. If a resized display cannot
+represent the requested zoom exactly, the helper selects the nearest supported
+scale with integral logical dimensions. Explicit per-output monitor rules still
+take precedence over the helper's catch-all rule.

--- a/guest/fragments/hypr-monitors-arm-qemu.append.lua
+++ b/guest/fragments/hypr-monitors-arm-qemu.append.lua
@@ -32,5 +32,10 @@ end
 if omarchy_kernel_option_enabled("omarchy.qemu_virgl=1") then
   hl.config({ cursor = { invisible = true } })
   o.exec_on_start("/usr/local/bin/omarchy-native-display-sync")
+  -- A config reload restores the cached preferred mode without a DRM hotplug.
+  -- Apply the live EDID after the reload has completed, using the same helper.
+  hl.on("config.reloaded", function()
+    hl.exec_cmd("/usr/local/bin/omarchy-native-display-sync --once")
+  end)
 end
 -- END OMARCHY ARM QEMU VIRGL PROFILE

--- a/guest/native-overlay/usr/local/bin/omarchy-native-display-sync
+++ b/guest/native-overlay/usr/local/bin/omarchy-native-display-sync
@@ -3,10 +3,12 @@
 set -euo pipefail
 
 drm_root=${OMARCHY_DISPLAY_SYNC_DRM_ROOT:-/sys/class/drm}
+monitor_config=${OMARCHY_DISPLAY_SYNC_MONITOR_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/hypr/monitors.lua}
 
 preferred_mode_from_edid() {
-  python3 - "$1" <<'PY'
+  python3 - "$1" "$monitor_config" <<'PY'
 import pathlib
+import re
 import sys
 from math import hypot
 
@@ -70,15 +72,30 @@ def scale_for_mode(
     physical_width_mm: int,
     physical_height_mm: int,
 ) -> str:
-    if physical_width_mm <= 0 or physical_height_mm <= 0:
-        return "auto"
+    # Omarchy's scaling controls write a numeric local in monitors.lua. Read it
+    # on each resync so a running hotplug watcher also sees later zoom changes.
+    # Auto/missing settings retain the live EDID's density-based scale.
+    requested = None
+    try:
+        config = pathlib.Path(sys.argv[2]).read_text()
+        match = re.search(
+            r"^\s*local\s+omarchy_monitor_scale\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*(?:--[^\n]*)?$",
+            config,
+            re.MULTILINE,
+        )
+        if match and 0.25 <= float(match.group(1)) <= 4:
+            requested = float(match.group(1))
+    except OSError:
+        pass
 
-    diagonal_inches = hypot(physical_width_mm, physical_height_mm) / 25.4
-    if diagonal_inches <= 0:
-        return "auto"
-
-    ppi = hypot(width, height) / diagonal_inches
-    requested = 2.0 if ppi > 200 else 1.5 if ppi > 140 else 1.0
+    if requested is None:
+        if physical_width_mm <= 0 or physical_height_mm <= 0:
+            return "auto"
+        diagonal_inches = hypot(physical_width_mm, physical_height_mm) / 25.4
+        if diagonal_inches <= 0:
+            return "auto"
+        ppi = hypot(width, height) / diagonal_inches
+        requested = 2.0 if ppi > 200 else 1.5 if ppi > 140 else 1.0
 
     # Hyprland requires the scaled logical dimensions to land on whole pixels.
     # It searches scale values in 1/120 increments around the requested value;
@@ -304,6 +321,13 @@ reload_on_display_change() {
     apply_preferred_modes
   fi
 }
+
+# Config reloads can restore Aquamarine's cached preferred mode without a
+# DRM hotplug event. Re-read the live EDID once, without starting a watcher.
+if [[ ${1:-} == --once ]]; then
+  apply_preferred_modes
+  exit 0
+fi
 
 if [[ ${1:-} == --from-stdin ]]; then
   reload_on_display_change

--- a/guest/tests/verify.py
+++ b/guest/tests/verify.py
@@ -1326,7 +1326,9 @@ def main() -> None:
         'o.exec_on_start("/usr/local/bin/omarchy-native-display-sync")'
         in monitor_fragment
         and 'omarchy_kernel_option_enabled("omarchy.qemu_virgl=1")' in monitor_fragment
-        and "cursor = { invisible = true }" in monitor_fragment,
+        and "cursor = { invisible = true }" in monitor_fragment
+        and 'hl.on("config.reloaded", function()' in monitor_fragment
+        and 'hl.exec_cmd("/usr/local/bin/omarchy-native-display-sync --once")' in monitor_fragment,
         "ARM VirGL profile starts display sync and uses the host-composited cursor",
     )
     with tempfile.TemporaryDirectory() as temporary:
@@ -1396,6 +1398,8 @@ HOTPLUG=1
         environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
         environment["HYPRCTL_LOG"] = str(reload_log)
         environment["OMARCHY_DISPLAY_SYNC_DRM_ROOT"] = str(drm_root)
+        monitor_config = temporary_path / "monitors.lua"
+        environment["OMARCHY_DISPLAY_SYNC_MONITOR_CONFIG"] = str(monitor_config)
         subprocess.run(
             [str(display_sync), "--from-stdin"],
             input=events,
@@ -1412,6 +1416,59 @@ HOTPLUG=1
                 'eval hl.monitor({ output = "", mode = "modeline 149 1920 2008 2052 2200 1080 1084 1089 1125 -hsync -vsync", scale = "1" })',
             ],
             "native display sync handles QEMU DisplayID and legacy EDID hotplug modes",
+        )
+
+        expected_auto = reload_log.read_text(encoding="utf-8").splitlines()[:2]
+
+        def sync_once():
+            reload_log.write_text("", encoding="utf-8")
+            subprocess.run(
+                [str(display_sync), "--once"],
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                timeout=5,
+                check=True,
+            )
+            return reload_log.read_text(encoding="utf-8").splitlines()
+
+        check(
+            sync_once() == expected_auto,
+            "config reload resync applies live modes without waiting for a hotplug event",
+        )
+        monitor_config.write_text("local omarchy_monitor_scale = 1.25 -- user zoom\n")
+        expected_zoom = [re.sub(r'scale = "[^"]+"', 'scale = "1.25"', line) for line in expected_auto]
+        check(sync_once() == expected_zoom, "reload resync preserves explicit user zoom")
+        reload_log.write_text("", encoding="utf-8")
+        subprocess.run(
+            [str(display_sync), "--from-stdin"],
+            input="ACTION=change\nHOTPLUG=1\n\n",
+            text=True,
+            env=environment,
+            timeout=5,
+            check=True,
+        )
+        check(
+            reload_log.read_text().splitlines() == expected_zoom,
+            "hotplug resync also preserves explicit user zoom",
+        )
+        # A later configuration reload must not reuse the prior zoom or EDID.
+        monitor_config.write_text("local omarchy_monitor_scale = 2\n")
+        (connector / "edid").write_bytes(legacy_edid)
+        expected_resized = expected_auto[1].replace('scale = "1"', 'scale = "2"')
+        check(
+            sync_once() == [expected_resized, expected_resized],
+            "resync rereads a resized display and a newly selected zoom",
+        )
+        # 1920x1080 cannot use exactly 1.7: select a valid nearby scale (5/3).
+        monitor_config.write_text("local omarchy_monitor_scale = 1.7\n")
+        check(
+            all('scale = "1.666667"' in line for line in sync_once()),
+            "resized displays select the nearest scale with integral logical dimensions",
+        )
+        monitor_config.write_text('local omarchy_monitor_scale = "auto"\n')
+        check(
+            sync_once() == [expected_auto[1], expected_auto[1]],
+            "returning to automatic zoom restores live EDID density scaling",
         )
 
     shell_files = [


### PR DESCRIPTION
A Hyprland configuration reload can restore Aquamarine's cached preferred display mode without generating a DRM hotplug event. After a VM window resize, the guest can therefore render at the old dimensions while absolute pointer input follows the current window, making clicks land away from the visible controls.

Add `--once` to the existing display-sync helper and invoke it after `config.reloaded` in the QEMU guest profile. Both reload and hotplug synchronization reread Omarchy's numeric zoom setting; automatic zoom still follows live EDID density, and resized modes select the nearest scale with integral logical dimensions. This reuses the existing EDID decoder and does not create another watcher on each reload.

Validation:
- `python3 guest/tests/verify.py` passes, including regression coverage for resync without hotplug, explicit zoom on reload and hotplug, fresh EDID/zoom reads, valid-scale adjustment, and return to automatic zoom.
- A Lua harness verified that each reload invokes one resync and that the hook is only installed for the QEMU guest.
- `make test` reaches six failures/errors in existing boot-export and authentication tests on this Linux VM. The identical six reproduce on unchanged fork `main` (`768d03d`). macOS CI will provide the full-suite result.
- `make guest` could not build because Docker is unavailable here. No supply-chain pins or checksums changed.

The original desktop incident was cleared by applying the live EDID: the guest changed from stale 6016×3384 to current 4112×2582. The reload gap is verified in the integration code; the exact event that initiated that incident was not captured.

Reviewed first in dbachelder/try-omarchy#4.

