### PR TITLE
[feat] Add Touch ID unlock for guest 1Password

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ Loopback binding prevents devices on Wi-Fi, Ethernet, or the wider LAN from
 connecting. It does not isolate the listener from other users or processes on
 the same Mac; guest SSH authentication is still required.
 
+### Touch ID for 1Password
+
+An optional process-scoped integration can use the Mac's Touch ID to unlock
+1Password inside the guest. Existing synced passwords and passkeys stay managed
+by 1Password. See [setup and authorization boundaries](docs/onepassword-touch-id.md).
+
 ### Touch ID for sudo
 
 The native authentication bridge can enroll this Mac and use

--- a/docs/onepassword-touch-id.md
+++ b/docs/onepassword-touch-id.md
@@ -27,6 +27,13 @@ the Mac's **Unlock 1Password in the focused Try Omarchy guest** prompt.
 If Touch ID is denied or unavailable, a guest password dialog uses the standard
 polkit PAM session. The 1Password account-password option remains available.
 
+The fallback asks for the guest Linux user's password, not the 1Password account
+password. It follows the guest's normal PAM lockout policy. Repeated failed or
+abandoned authentication attempts can temporarily block this path even while the
+1Password account password still works. Check the guest's authentication journal
+and `faillock --user "$USER"` before retrying repeatedly; this integration does
+not disable or bypass password lockouts.
+
 Disable the integration without changing PAM or deleting enrollment:
 
 ```sh

--- a/docs/onepassword-touch-id.md
+++ b/docs/onepassword-touch-id.md
@@ -1,0 +1,70 @@
+# Touch ID for 1Password in the guest
+
+This opt-in integration unlocks 1Password for Linux using Touch ID on the Mac.
+1Password continues to manage the vault and passkeys in the guest. It does not
+forward credentials to the Mac or create a separate passkey store.
+
+## Requirements and setup
+
+Use a host helper with the `onepassword-unlock` operation, an already paired
+Touch ID guest, and 1Password installed at `/opt/1Password/1password`. The guest
+needs Python GObject bindings, GTK 3, and PolkitAgent introspection. The installer
+checks these dependencies and does not install packages automatically.
+
+Sign in to 1Password in the guest, enable **Unlock using system authentication**,
+then lock and unlock once with the account password. Keep the app running.
+1Password's own policy still requires the account password after app restart and
+when its password-confirmation interval expires.
+
+From this checkout in the guest, run:
+
+```sh
+sudo guest/scripts/install-onepassword-touch-id.sh "$USER"
+```
+
+Then lock 1Password and use its fingerprint button. Focus the VM while approving
+the Mac's **Unlock 1Password in the focused Try Omarchy guest** prompt.
+If Touch ID is denied or unavailable, a guest password dialog uses the standard
+polkit PAM session. The 1Password account-password option remains available.
+
+Disable the integration without changing PAM or deleting enrollment:
+
+```sh
+sudo systemctl disable --now "try-omarchy-onepassword-touch-id@$USER.service"
+```
+
+The installer retains replaced files in a root-private directory under
+`/var/lib/try-omarchy/onepassword-backup.*`. A host update and guest installation
+are both required. Updating only the host does not update an existing guest.
+
+## Authorization boundary
+
+A root-owned agent registers with polkit for the main, installed 1Password
+process belonging to the configured guest account. It does not replace the
+session-wide agent. Executable ownership, permissions, process start time,
+UID, and the active local display session are checked. The installed executable
+and its parent directories must be root-owned and not group/other-writable.
+
+Only `BeginAuthentication` from the current system-bus owner of polkit is
+accepted. Only `com.1password.1Password.unlock` with the exact guest-user
+identity can request Touch ID. CLI, SSH-agent, and other authentication requests
+for that process use the normal PAM password path in an unprivileged GTK dialog.
+Other processes remain with their existing desktop authentication agents.
+
+The Mac signs a versioned, nonce-bearing request with the dedicated unlock
+operation, service, and matching user identities. The guest verifies the pinned
+key, signature, request binding, and expiry, then rechecks process, session, and
+cancellation before responding to polkit's original cookie. The cookie is not
+sent to the Mac. Passwords are handled only by the unprivileged dialog and the
+standard polkit authentication helper; a successful dialog exit cannot itself
+create an authorization response.
+
+A nonblocking exclusive lock serializes requests on the shared authentication
+port. Contention uses password fallback. Closing or disabling the agent removes
+its process registrations; the desktop agent remains intact. No blanket `YES`
+polkit rules or shared PAM changes are installed.
+
+This is a root-trusting VM design: a compromised root user can change the guest's
+authentication policy. Touch ID approval does not attest the guest application or
+make a compromised guest trustworthy. Passkeys remain subject to 1Password's
+normal guest-side security boundary.

--- a/guest/native-overlay/usr/lib/systemd/system/try-omarchy-onepassword-touch-id@.service
+++ b/guest/native-overlay/usr/lib/systemd/system/try-omarchy-onepassword-touch-id@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Touch ID unlock for 1Password in Try Omarchy (%i)
+After=polkit.service systemd-logind.service
+Requires=polkit.service
+ConditionPathExists=/dev/virtio-ports/dev.tryomarchy.authentication
+ConditionPathExists=/var/lib/try-omarchy/native-authentication.json
+
+[Service]
+Type=simple
+ExecStart=/usr/local/lib/try-omarchy/onepassword-touch-id-agent --user %i
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=5
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/native-authentication-broker
@@ -1,11 +1,12 @@
 #!/usr/bin/python3 -I
-"""Root-only broker for signed Try Omarchy Touch ID sudo approvals."""
+"""Root-only broker for signed Try Omarchy authentication approvals."""
 
 from __future__ import annotations
 
 import base64
 import binascii
 import hashlib
+import fcntl
 import json
 import os
 from pathlib import Path
@@ -97,14 +98,14 @@ def validate_request(request: dict[str, object]) -> None:
         set(request) != REQUEST_FIELDS
         or request.get("type") != "authorize"
         or request.get("version") != PROTOCOL_VERSION
-        or request.get("operation") not in {"disable", "enroll", "sudo"}
-        or request.get("service") != "sudo"
+        or request.get("operation") not in {"disable", "enroll", "sudo", "onepassword-unlock"}
         or not isinstance(request.get("requestId"), str)
         or not isinstance(request.get("challenge"), str)
         or not isinstance(request.get("guestId"), str)
         or not isinstance(request.get("user"), str)
         or not isinstance(request.get("requestingUser"), str)
         or not isinstance(request.get("tty"), str)
+        or not isinstance(request.get("service"), str)
     ):
         raise AuthorizationError("invalid authentication request")
     try:
@@ -117,6 +118,15 @@ def validate_request(request: dict[str, object]) -> None:
         or not HEX_32_PATTERN.fullmatch(request["guestId"])
     ):
         raise AuthorizationError("invalid request identity")
+    if request["operation"] == "onepassword-unlock":
+        if (request["service"] != "com.1password.1Password.unlock"
+            or not ACCOUNT_PATTERN.fullmatch(request["user"])
+            or request["requestingUser"] != request["user"]
+            or request["tty"]):
+            raise AuthorizationError("invalid 1Password unlock context")
+        return
+    if request["service"] != "sudo":
+        raise AuthorizationError("invalid sudo authentication service")
     if request["operation"] in {"disable", "enroll"}:
         if request["user"] or request["requestingUser"] or request["tty"]:
             raise AuthorizationError("control request carries sudo context")
@@ -392,6 +402,10 @@ def exchange(request: dict[str, object], timeout: float = 65) -> dict[str, objec
             or stat.S_IMODE(info.st_mode) != 0o600
         ):
             raise AuthorizationError("authentication endpoint is not a root-only character device")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise AuthorizationError("another Touch ID request is in progress") from error
         return exchange_on_descriptor(descriptor, request, timeout)
     finally:
         os.close(descriptor)
@@ -620,7 +634,26 @@ def authenticate_pam() -> bool:
         return False
 
 
+def authenticate_onepassword(user: str) -> None:
+    if os.getuid() != 0 or os.geteuid() != 0:
+        raise AuthorizationError("1Password authorization requires the root agent")
+    pinned_public_key, guest_id = load_state()
+    request = make_request(
+        "onepassword-unlock", guest_id=guest_id, user=user, requesting_user=user,
+        service="com.1password.1Password.unlock",
+    )
+    response = exchange(request)
+    verify_approval(request, response, pinned_public_key=pinned_public_key)
+
+
 def main() -> int:
+    if len(sys.argv) == 3 and sys.argv[1] == "onepassword-unlock":
+        try:
+            authenticate_onepassword(sys.argv[2])
+            return 0
+        except (AuthorizationError, OSError, subprocess.SubprocessError, TimeoutError):
+            print("Touch ID approval unavailable; use the normal password prompt.", file=sys.stderr)
+            return 1
     if len(sys.argv) != 2 or sys.argv[1] not in {"disable", "enroll", "migrate", "pam"}:
         print(
             "usage: native-authentication-broker disable|enroll|migrate|pam",

--- a/guest/native-overlay/usr/local/lib/try-omarchy/onepassword-password-dialog
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/onepassword-password-dialog
@@ -1,0 +1,82 @@
+#!/usr/bin/python3 -I
+"""Unprivileged GTK password fallback using the standard polkit PAM session."""
+
+import json
+import os
+import sys
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("PolkitAgent", "1.0")
+from gi.repository import Gtk, Polkit, PolkitAgent
+
+
+def main():
+    if os.getuid() == 0:
+        return 1
+    request = json.loads(sys.stdin.buffer.readline(16385))
+    identities = request["identities"]
+    available = [item[1]["uid"] for item in identities if item[0] == "unix-user"]
+    if not available:
+        return 1
+    uid = os.getuid() if os.getuid() in available else available[0]
+    session = PolkitAgent.Session.new(Polkit.UnixUser.new(uid), request["cookie"])
+    dialog = Gtk.Dialog(title="1Password — System Authentication")
+    dialog.set_default_size(440, 180)
+    dialog.set_resizable(False)
+    dialog.set_modal(True)
+    dialog.set_border_width(16)
+    dialog.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    dialog.add_button("Authenticate", Gtk.ResponseType.OK)
+    box = dialog.get_content_area()
+    explanation = Gtk.Label(label=request["message"])
+    explanation.set_line_wrap(True)
+    box.pack_start(explanation, False, False, 8)
+    prompt = Gtk.Label(label="")
+    box.pack_start(prompt, False, False, 8)
+    entry = Gtk.Entry()
+    entry.set_visibility(False)
+    entry.set_activates_default(True)
+    box.pack_start(entry, False, False, 8)
+    dialog.set_default_response(Gtk.ResponseType.OK)
+    result = {"success": False, "waiting": False}
+
+    def on_request(session, text, echo):
+        prompt.set_text(text)
+        entry.set_text("")
+        entry.set_visibility(echo)
+        entry.set_sensitive(True)
+        entry.grab_focus()
+        result["waiting"] = True
+        dialog.present()
+
+    def response(dialog, response_id):
+        if response_id == Gtk.ResponseType.OK and result["waiting"]:
+            result["waiting"] = False
+            secret = entry.get_text()
+            entry.set_text("")
+            entry.set_sensitive(False)
+            session.response(secret)
+            secret = None
+        elif response_id != Gtk.ResponseType.OK:
+            session.cancel()
+            Gtk.main_quit()
+
+    def completed(session, authorized):
+        result["success"] = authorized
+        Gtk.main_quit()
+
+    session.connect("request", on_request)
+    session.connect("show-info", lambda session, text: prompt.set_text(text))
+    session.connect("show-error", lambda session, text: prompt.set_text(text))
+    session.connect("completed", completed)
+    dialog.connect("response", response)
+    dialog.show_all()
+    session.initiate()
+    Gtk.main()
+    dialog.destroy()
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/guest/native-overlay/usr/local/lib/try-omarchy/onepassword-touch-id-agent
+++ b/guest/native-overlay/usr/local/lib/try-omarchy/onepassword-touch-id-agent
@@ -1,0 +1,307 @@
+#!/usr/bin/python3 -I
+"""Process-scoped polkit agent for 1Password, with signed host Touch ID unlock."""
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import pwd
+import signal
+import stat
+import subprocess
+import sys
+import threading
+import time
+
+UNLOCK = "com.1password.1Password.unlock"
+AUTHORITY = "org.freedesktop.PolicyKit1"
+AUTHORITY_PATH = "/org/freedesktop/PolicyKit1/Authority"
+AGENT_INTERFACE = "org.freedesktop.PolicyKit1.AuthenticationAgent"
+EXECUTABLE = Path("/opt/1Password/1password")
+HELPERS = Path("/usr/local/lib/try-omarchy")
+AGENT_XML = '''<node><interface name="org.freedesktop.PolicyKit1.AuthenticationAgent">
+<method name="BeginAuthentication"><arg type="s" direction="in"/>
+<arg type="s" direction="in"/><arg type="s" direction="in"/>
+<arg type="a{ss}" direction="in"/><arg type="s" direction="in"/>
+<arg type="a(sa{sv})" direction="in"/></method>
+<method name="CancelAuthentication"><arg type="s" direction="in"/></method>
+</interface></node>'''
+
+
+def trusted_executable(path):
+    for entry in (path, *path.parents):
+        info = entry.lstat()
+        if info.st_uid != 0 or info.st_mode & 0o022 or stat.S_ISLNK(info.st_mode):
+            return False
+    return stat.S_ISREG(path.lstat().st_mode)
+
+
+def process_start_time(text):
+    return int(text[text.rindex(")") + 2:].split()[19])
+
+
+@dataclass(frozen=True)
+class Process:
+    pid: int
+    uid: int
+    start: int
+
+    @classmethod
+    def inspect(cls, pid, uid):
+        directory = Path(f"/proc/{pid}")
+        if directory.stat().st_uid != uid:
+            raise ValueError("process owner changed")
+        if Path(os.readlink(directory / "exe")) != EXECUTABLE:
+            raise ValueError("not the installed 1Password executable")
+        if not trusted_executable(EXECUTABLE):
+            raise ValueError("unsafe 1Password installation")
+        arguments = (directory / "cmdline").read_bytes().split(b"\0")
+        if any(arg.startswith(b"--type=") for arg in arguments):
+            raise ValueError("not the main 1Password process")
+        uids = next(line.split()[1:] for line in (directory / "status").read_text().splitlines()
+                    if line.startswith("Uid:"))
+        if any(int(value) != uid for value in uids):
+            raise ValueError("unexpected process identity")
+        return cls(pid, uid, process_start_time((directory / "stat").read_text()))
+
+    def alive(self):
+        try:
+            return self == self.inspect(self.pid, self.uid)
+        except (OSError, ValueError, StopIteration):
+            return False
+
+
+def unlock_identity(action, identities, uid):
+    return action == UNLOCK and identities == [("unix-user", {"uid": uid})]
+
+
+class Agent:
+    def __init__(self, username):
+        import gi
+        from gi.repository import Gio, GLib
+        self.Gio, self.GLib = Gio, GLib
+        self.user = pwd.getpwnam(username)
+        if self.user.pw_uid == 0:
+            raise ValueError("a non-root guest account is required")
+        self.bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        self.nodes = Gio.DBusNodeInfo.new_for_xml(AGENT_XML)
+        self.registered = {}
+        self.pending = {}
+        self.lock = threading.Lock()
+        self.stopping = False
+        self.owner = None
+        self.loop = GLib.MainLoop()
+
+    def call(self, method, value, signature=None):
+        return self.bus.call_sync(AUTHORITY, AUTHORITY_PATH, AUTHORITY + ".Authority",
+            method, value, self.GLib.VariantType.new(signature) if signature else None,
+            self.Gio.DBusCallFlags.NONE, 5000, None)
+
+    def authority_owner(self):
+        reply = self.bus.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+            "org.freedesktop.DBus", "GetNameOwner", self.GLib.Variant("(s)", (AUTHORITY,)),
+            self.GLib.VariantType.new("(s)"), self.Gio.DBusCallFlags.NONE, 3000, None)
+        return reply.unpack()[0]
+
+    def authority_sender(self, sender):
+        return sender == self.authority_owner()
+
+    def active(self):
+        # The GUI application runs in user@.service, so use logind's display session.
+        result = subprocess.run(["/usr/bin/loginctl", "show-user", str(self.user.pw_uid),
+            "--property=Display", "--value"], capture_output=True, text=True, timeout=3)
+        session = result.stdout.strip()
+        if result.returncode or not session or not session.isalnum():
+            return False
+        result = subprocess.run(["/usr/bin/loginctl", "show-session", session,
+            "--property=Active", "--property=Remote", "--property=User"],
+            capture_output=True, text=True, timeout=3)
+        fields = dict(line.split("=", 1) for line in result.stdout.splitlines() if "=" in line)
+        return result.returncode == 0 and fields == {
+            "Active": "yes", "Remote": "no", "User": str(self.user.pw_uid)}
+
+    def subject(self, process):
+        V = self.GLib.Variant
+        return ("unix-process", {"pid": V("u", process.pid), "uid": V("i", process.uid),
+                                 "start-time": V("t", process.start)})
+
+    def scan(self):
+        if self.stopping:
+            return False
+        try:
+            owner = self.authority_owner()
+            if owner != self.owner:
+                for pid in list(self.registered):
+                    self.unregister(pid)
+                self.owner = owner
+            available = self.active()
+            for pid, (process, path, registration) in list(self.registered.items()):
+                if available and process.alive():
+                    continue
+                self.unregister(pid)
+            if available:
+                for directory in Path("/proc").iterdir():
+                    if not directory.name.isdigit() or len(self.registered) >= 4:
+                        continue
+                    pid = int(directory.name)
+                    if pid in self.registered:
+                        continue
+                    try:
+                        process = Process.inspect(pid, self.user.pw_uid)
+                    except (OSError, ValueError, StopIteration):
+                        continue
+                    path = f"/dev/tryomarchy/OnePassword/{pid}"
+                    registration = self.bus.register_object(path, self.nodes.interfaces[0],
+                        self.handle, None, None)
+                    try:
+                        self.call("RegisterAuthenticationAgent", self.GLib.Variant(
+                            "((sa{sv})ss)", (self.subject(process), "C.UTF-8", path)))
+                    except Exception:
+                        self.bus.unregister_object(registration)
+                        continue
+                    self.registered[pid] = (process, path, registration)
+                    print("1Password authentication agent attached.", flush=True)
+        except (OSError, ValueError, subprocess.SubprocessError, self.GLib.Error):
+            print("Waiting for the local guest session and polkit.", flush=True)
+        return True
+
+    def unregister(self, pid):
+        process, path, registration = self.registered.pop(pid)
+        with self.lock:
+            for request in self.pending.values():
+                if request["process"] == process:
+                    request["cancel"].set()
+        try:
+            self.call("UnregisterAuthenticationAgent", self.GLib.Variant(
+                "((sa{sv})s)", (self.subject(process), path)))
+        except Exception:
+            pass
+        self.bus.unregister_object(registration)
+
+    def handle(self, connection, sender, path, interface, method, parameters, invocation):
+        try:
+            if not self.authority_sender(sender):
+                raise ValueError("untrusted caller")
+            if method == "CancelAuthentication":
+                cookie, = parameters.unpack()
+                with self.lock:
+                    request = self.pending.get(cookie)
+                    if request:
+                        request["cancel"].set()
+                invocation.return_value(None)
+                return
+            action, message, icon, details, cookie, identities = parameters.unpack()
+            pid = int(path.rsplit("/", 1)[1])
+            process = self.registered[pid][0]
+            if not process.alive() or not self.active() or len(cookie) > 4096:
+                raise ValueError("inactive request")
+            with self.lock:
+                if self.pending:
+                    raise ValueError("another request is active")
+                request = {"cancel": threading.Event(), "process": process,
+                           "sender": sender, "invocation": invocation}
+                self.pending[cookie] = request
+            threading.Thread(target=self.authenticate,
+                args=(cookie, action, message, identities, request), daemon=True).start()
+        except Exception:
+            invocation.return_dbus_error(AUTHORITY + ".Error.Cancelled",
+                                         "Authentication unavailable; use your account password.")
+
+    def run_child(self, arguments, request, payload=None, user=False):
+        options = {}
+        environment = {"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8"}
+        if user:
+            environment.update(HOME=self.user.pw_dir, USER=self.user.pw_name,
+                LOGNAME=self.user.pw_name, XDG_RUNTIME_DIR=f"/run/user/{self.user.pw_uid}",
+                DBUS_SESSION_BUS_ADDRESS=f"unix:path=/run/user/{self.user.pw_uid}/bus")
+            # Only the unprivileged dialog consumes the user's display settings.
+            settings = subprocess.run(["/usr/bin/systemctl", "--user", "show-environment"],
+                user=self.user.pw_uid, group=self.user.pw_gid, extra_groups=[],
+                env=environment, capture_output=True, text=True, timeout=3)
+            for line in settings.stdout.splitlines():
+                key, _, value = line.partition("=")
+                if key in {"DISPLAY", "WAYLAND_DISPLAY", "XDG_CURRENT_DESKTOP"}:
+                    environment[key] = value
+            options.update(user=self.user.pw_uid, group=self.user.pw_gid, extra_groups=[])
+        child = subprocess.Popen(arguments, stdin=subprocess.PIPE if payload else subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=environment,
+            start_new_session=True, **options)
+        try:
+            if payload:
+                child.stdin.write(payload)
+                child.stdin.close()
+            deadline = time.monotonic() + 120
+            while child.poll() is None:
+                if request["cancel"].wait(0.1) or time.monotonic() > deadline:
+                    return False
+            return child.returncode == 0 and not request["cancel"].is_set()
+        finally:
+            if child.poll() is None:
+                os.killpg(child.pid, signal.SIGTERM)
+                try:
+                    child.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    os.killpg(child.pid, signal.SIGKILL)
+                    child.wait()
+
+    def authenticate(self, cookie, action, message, identities, request):
+        success = False
+        try:
+            if unlock_identity(action, identities, self.user.pw_uid):
+                success = self.run_child([str(HELPERS / "native-authentication-broker"),
+                    "onepassword-unlock", self.user.pw_name], request)
+                if success:
+                    if (request["cancel"].is_set() or not request["process"].alive()
+                        or not self.active() or not self.authority_sender(request["sender"])):
+                        success = False
+                    else:
+                        self.call("AuthenticationAgentResponse2", self.GLib.Variant("(us(sa{sv}))",
+                            (self.user.pw_uid, cookie,
+                             ("unix-user", {"uid": self.GLib.Variant("u", self.user.pw_uid)}))))
+            if not success and not request["cancel"].is_set() and request["process"].alive():
+                # Standard PAM authentication handles password fallback and non-unlock actions.
+                # The dialog runs as the guest user; its exit status alone never authorizes anything.
+                import json
+                payload = json.dumps({"cookie": cookie, "message": message[:1024],
+                    "identities": identities}).encode() + b"\n"
+                success = self.run_child([str(HELPERS / "onepassword-password-dialog")],
+                                        request, payload, user=True)
+        except Exception:
+            print("1Password authentication could not complete.", flush=True)
+        finally:
+            self.GLib.idle_add(self.finish, cookie, request, success)
+
+    def finish(self, cookie, request, success):
+        with self.lock:
+            if self.pending.get(cookie) is not request:
+                return False
+            del self.pending[cookie]
+        if success and not request["cancel"].is_set():
+            request["invocation"].return_value(None)
+        else:
+            request["invocation"].return_dbus_error(AUTHORITY + ".Error.Cancelled",
+                "Authentication cancelled; you can unlock with your account password.")
+        return False
+
+    def stop(self):
+        self.stopping = True
+        for pid in list(self.registered):
+            self.unregister(pid)
+        self.loop.quit()
+        return False
+
+    def run(self):
+        self.scan()
+        self.GLib.timeout_add_seconds(2, self.scan)
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            self.GLib.unix_signal_add(self.GLib.PRIORITY_DEFAULT, signum, self.stop)
+        self.loop.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--user", required=True)
+    args = parser.parse_args()
+    if os.getuid() != 0:
+        parser.error("the authentication agent must run as root")
+    Agent(args.user).run()

--- a/guest/scripts/install-onepassword-touch-id.sh
+++ b/guest/scripts/install-onepassword-touch-id.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ $# == 1 && $1 =~ ^[a-z_][a-z0-9_-]{0,31}$ && $1 != root ]] || {
+  echo "Usage: sudo install-onepassword-touch-id.sh GUEST_USER" >&2
+  exit 64
+}
+(( EUID == 0 )) || { echo "Run this installer with sudo." >&2; exit 1; }
+guest_user=$1
+getent passwd "$guest_user" >/dev/null
+source_dir=$(cd "$(dirname "$0")/../native-overlay" && pwd)
+python3 -I -c 'import gi; gi.require_version("Gtk", "3.0"); gi.require_version("PolkitAgent", "1.0"); from gi.repository import Gtk, PolkitAgent'
+[[ -f /var/lib/try-omarchy/native-authentication.json ]] || {
+  echo "Pair this guest using the Touch ID setup first." >&2
+  exit 1
+}
+[[ -x /opt/1Password/1password ]] || { echo "Install 1Password first." >&2; exit 1; }
+backup_dir=$(mktemp -d /var/lib/try-omarchy/onepassword-backup.XXXXXXXX)
+chmod 700 "$backup_dir"
+helpers=/usr/local/lib/try-omarchy
+unit=/usr/lib/systemd/system/try-omarchy-onepassword-touch-id@.service
+for name in native-authentication-broker onepassword-touch-id-agent onepassword-password-dialog; do
+  [[ ! -L $helpers/$name ]] || { echo "Refusing symlink destination." >&2; exit 1; }
+  if [[ -f $helpers/$name ]]; then
+    cp -p "$helpers/$name" "$backup_dir/$name"
+  fi
+  install -o root -g root -m 755 "$source_dir$helpers/$name" "$helpers/$name"
+done
+[[ ! -L $unit ]] || { echo "Refusing symlink unit." >&2; exit 1; }
+if [[ -f $unit ]]; then cp -p "$unit" "$backup_dir/$(basename "$unit")"; fi
+install -o root -g root -m 644 "$source_dir$unit" "$unit"
+systemctl daemon-reload
+systemctl enable --now "try-omarchy-onepassword-touch-id@$guest_user.service"
+printf '1Password Touch ID enabled. Previous files retained in %s\n' "$backup_dir"
+printf 'Disable with: sudo systemctl disable --now try-omarchy-onepassword-touch-id@%s.service\n' "$guest_user"

--- a/guest/scripts/install-onepassword-touch-id.sh
+++ b/guest/scripts/install-onepassword-touch-id.sh
@@ -30,6 +30,7 @@ done
 if [[ -f $unit ]]; then cp -p "$unit" "$backup_dir/$(basename "$unit")"; fi
 install -o root -g root -m 644 "$source_dir$unit" "$unit"
 systemctl daemon-reload
-systemctl enable --now "try-omarchy-onepassword-touch-id@$guest_user.service"
+systemctl enable "try-omarchy-onepassword-touch-id@$guest_user.service"
+systemctl restart "try-omarchy-onepassword-touch-id@$guest_user.service"
 printf '1Password Touch ID enabled. Previous files retained in %s\n' "$backup_dir"
 printf 'Disable with: sudo systemctl disable --now try-omarchy-onepassword-touch-id@%s.service\n' "$guest_user"

--- a/guest/tests/test_launcher_stale_cleanup.py
+++ b/guest/tests/test_launcher_stale_cleanup.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class StaleRunCleanupTests(unittest.TestCase):
+    def test_unavailable_or_incomplete_process_inventory_preserves_live_sockets(self):
+        for mode, preserved in [('denied', True), ('empty', True), ('launcher', True), ('qemu', True), ('stale', False)]:
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory(prefix='try-omarchy-reaper-test-') as directory:
+                candidate = Path(directory) / 'omarchy-qemu-gpu.ABCDEF'
+                candidate.mkdir(mode=0o700)
+                (candidate / '.run-qemu-gpu.owner').write_text('run-qemu-gpu:v1:111111:0')
+                (candidate / '.qemu.pid').write_text('222222')
+                (candidate / 'authentication.sock').write_text('test socket placeholder')
+                source = (ROOT / 'macos/run-qemu-gpu.sh').read_text()
+                function = source[source.index('reap_stale_work_dirs() {'):source.index('\nreap_stale_work_dirs\n')]
+                function = function.replace('/private/tmp/omarchy-qemu-gpu.??????', directory + '/omarchy-qemu-gpu.??????')
+                prologue = '''
+_qps_owner() { id -u; }
+_qps_permissions() { echo 700; }
+ps() {
+  case "$MODE" in
+    denied) return 1 ;;
+    empty) return 0 ;;
+    launcher) printf '%s\\n' "$$" 111111 ;;
+    qemu) printf '%s\\n' "$$" 222222 ;;
+    stale) printf '%s\\n' "$$" ;;
+  esac
+}
+'''
+                subprocess.run(['/bin/bash', '-eu', '-c', prologue + function + '\nreap_stale_work_dirs'],
+                               env={**os.environ, 'MODE': mode}, stdout=subprocess.DEVNULL, check=True)
+                self.assertEqual(candidate.exists(), preserved)

--- a/guest/tests/test_native_authentication_bridge.py
+++ b/guest/tests/test_native_authentication_bridge.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Protocol tests for signed, sudo-only native authentication."""
+"""Protocol tests for signed native authentication."""
 
 from __future__ import annotations
 
@@ -127,6 +127,25 @@ class NativeAuthenticationProtocolTests(unittest.TestCase):
         ).stdout
         response["signature"] = base64.b64encode(signature).decode("ascii")
         return response
+
+    def test_onepassword_approval_is_bound_to_action_and_identity(self):
+        request = self.request()
+        request.update(operation="onepassword-unlock", service="com.1password.1Password.unlock", tty="")
+        broker.validate_request(request)
+        response = self.approved_response(request)
+        broker.verify_approval(request, response, pinned_public_key=self.public_key, now=response["issuedAt"])
+        for field, value in [("service", "sudo"), ("requestingUser", "other"), ("tty", "/dev/pts/4")]:
+            changed = {**request, field: value}
+            with self.subTest(field=field), self.assertRaises(broker.AuthorizationError):
+                broker.validate_request(changed)
+        for field, value in [("user", "other"), ("challenge", "cd" * 32), ("requestId", "33333333-3333-4333-8333-333333333333")]:
+            changed = {**request, field: value}
+            # Re-labeling a signed response cannot authorize another request.
+            forged = {**response, field: value}
+            with self.subTest(field=field), self.assertRaises(broker.AuthorizationError):
+                broker.verify_approval(changed, forged, pinned_public_key=self.public_key, now=response["issuedAt"])
+        with self.assertRaises(broker.AuthorizationError):
+            broker.verify_approval(request, response, pinned_public_key=self.public_key, now=response["expiresAt"] + 1)
 
     def test_request_encoding_matches_the_host_schema(self) -> None:
         request = self.request()

--- a/guest/tests/test_onepassword_touch_id.py
+++ b/guest/tests/test_onepassword_touch_id.py
@@ -1,0 +1,92 @@
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+agent = SourceFileLoader("onepassword_touch_id_agent", str(
+    ROOT / "native-overlay/usr/local/lib/try-omarchy/onepassword-touch-id-agent")).load_module()
+
+
+class OnePasswordAuthorizationTests(unittest.TestCase):
+    def harness(self, *, alive=True, active=True, sender=True, canceled=False):
+        service = agent.Agent.__new__(agent.Agent)
+        service.user = SimpleNamespace(pw_uid=1000, pw_name="test")
+        service.GLib = SimpleNamespace(Variant=lambda signature, value: value,
+                                      idle_add=lambda callback, *args: callback(*args))
+        service.call = mock.Mock()
+        service.active = mock.Mock(return_value=active)
+        service.authority_sender = mock.Mock(return_value=sender)
+        service.run_child = mock.Mock(return_value=True)
+        service.lock = threading.Lock()
+        request = {"process": SimpleNamespace(alive=lambda: alive),
+                   "sender": ":1.25", "cancel": threading.Event(),
+                   "invocation": mock.Mock()}
+        if canceled:
+            request["cancel"].set()
+        service.pending = {"cookie": request}
+        return service, request
+
+    def authenticate(self, service, request, action=agent.UNLOCK, uid=1000):
+        service.authenticate("cookie", action, "Authenticate", [("unix-user", {"uid": uid})], request)
+
+    def test_only_unlock_uses_touch_id_and_replies_with_the_requested_identity(self):
+        service, request = self.harness()
+        self.authenticate(service, request)
+        self.assertEqual(service.run_child.call_count, 1)
+        self.assertIn("onepassword-unlock", service.run_child.call_args.args[0])
+        service.call.assert_called_once_with("AuthenticationAgentResponse2",
+            (1000, "cookie", ("unix-user", {"uid": 1000})))
+        request["invocation"].return_value.assert_called_once_with(None)
+
+    def test_other_actions_and_other_users_never_receive_host_approval(self):
+        for action, uid in [("com.1password.1Password.authorizeCLI", 1000),
+                            ("com.1password.1Password.authorizeSshAgent", 1000),
+                            ("org.freedesktop.policykit.exec", 1000), (agent.UNLOCK, 0)]:
+            with self.subTest(action=action, uid=uid):
+                service, request = self.harness()
+                self.authenticate(service, request, action, uid)
+                service.call.assert_not_called()
+                self.assertTrue(service.run_child.call_args.kwargs["user"])
+                self.assertTrue(service.run_child.call_args.args[0][0].endswith("onepassword-password-dialog"))
+
+    def test_denied_touch_id_uses_pam_fallback_without_forging_a_response(self):
+        service, request = self.harness()
+        service.run_child.side_effect = [False, True]
+        self.authenticate(service, request)
+        self.assertEqual(service.run_child.call_count, 2)
+        service.call.assert_not_called()
+
+    def test_cancellation_cannot_be_overridden_by_late_approval(self):
+        service, request = self.harness(canceled=True)
+        self.authenticate(service, request)
+        service.call.assert_not_called()
+        request["invocation"].return_value.assert_not_called()
+        request["invocation"].return_dbus_error.assert_called_once()
+
+    def test_process_exit_session_change_and_authority_restart_invalidate_approval(self):
+        for options in [{"alive": False}, {"active": False}, {"sender": False}]:
+            with self.subTest(options=options):
+                service, request = self.harness(**options)
+                self.authenticate(service, request)
+                service.call.assert_not_called()
+
+    def test_unauthenticated_dbus_caller_is_rejected_before_processing_request(self):
+        service, request = self.harness(sender=False)
+        invocation = mock.Mock()
+        parameters = mock.Mock()
+        service.handle(None, ":1.99", "/fake", agent.AGENT_INTERFACE,
+                       "BeginAuthentication", parameters, invocation)
+        parameters.unpack.assert_not_called()
+        service.run_child.assert_not_called()
+        invocation.return_dbus_error.assert_called_once()
+
+    def test_stat_parser_handles_parentheses_and_spaces_in_process_names(self):
+        fields = ["S"] + ["0"] * 18 + ["123456"] + ["0"] * 4
+        self.assertEqual(agent.process_start_time("42 (1Password (main)) " + " ".join(fields)), 123456)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
+++ b/macos/Sources/OmarchyVMHelper/NativeAuthenticationBridge.swift
@@ -9,6 +9,7 @@ enum NativeAuthenticationOperation: String, Equatable {
     case disable
     case enroll
     case sudo
+    case onePasswordUnlock = "onepassword-unlock"
 
     var localizedReason: String {
         switch self {
@@ -18,6 +19,8 @@ enum NativeAuthenticationOperation: String, Equatable {
             "Pair this Try Omarchy guest for Touch ID sudo testing"
         case .sudo:
             "Approve sudo in the focused Try Omarchy guest"
+        case .onePasswordUnlock:
+            "Unlock 1Password in the focused Try Omarchy guest"
         }
     }
 }
@@ -55,21 +58,25 @@ struct NativeAuthenticationRequest: Equatable {
               let user = object["user"] as? String,
               let requestingUser = object["requestingUser"] as? String,
               let service = object["service"] as? String,
-              service == "sudo",
               let tty = object["tty"] as? String else {
             throw HelperError.io("guest sent an invalid authentication request")
         }
 
         switch operation {
         case .disable, .enroll:
-            guard user.isEmpty, requestingUser.isEmpty, tty.isEmpty else {
+            guard service == "sudo", user.isEmpty, requestingUser.isEmpty, tty.isEmpty else {
                 throw HelperError.io("guest sent an invalid authentication control request")
             }
         case .sudo:
-            guard isAccountName(user),
+            guard service == "sudo", isAccountName(user),
                   isAccountName(requestingUser),
                   isInteractiveTTY(tty) else {
                 throw HelperError.io("guest sent invalid sudo authentication context")
+            }
+        case .onePasswordUnlock:
+            guard service == "com.1password.1Password.unlock",
+                  isAccountName(user), requestingUser == user, tty.isEmpty else {
+                throw HelperError.io("guest sent invalid 1Password unlock context")
             }
         }
 
@@ -239,7 +246,7 @@ final class SecureEnclaveAuthorizationSigner: HostAuthorizationSigning, @uncheck
         if request.operation == .disable {
             throw HelperError.io("disable request reached the signing path")
         }
-        if request.operation == .sudo && !keyAlreadyExists {
+        if request.operation != .enroll && !keyAlreadyExists {
             fputs("[authentication-bridge] Touch ID sudo is not enrolled for this Mac.\n", stderr)
             return nil
         }

--- a/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
+++ b/macos/Tests/OmarchyVMHelperTests/NativeAuthenticationBridgeTests.swift
@@ -47,6 +47,25 @@ struct NativeAuthenticationBridgeTests {
         )
     }
 
+    @Test("1Password unlock is separated from sudo and other 1Password actions")
+    func onePasswordRequestSchema() throws {
+        let line = Data(
+            #"{"challenge":"\#(challenge)","guestId":"\#(guestID)","operation":"onepassword-unlock","requestId":"\#(requestID)","requestingUser":"test","service":"com.1password.1Password.unlock","tty":"","type":"authorize","user":"test","version":3}"#.utf8
+        )
+        let request = try NativeAuthenticationRequest.decode(line)
+        #expect(request.operation == .onePasswordUnlock)
+        #expect(request.operation.localizedReason == "Unlock 1Password in the focused Try Omarchy guest")
+        for (field, value) in [
+            ("service", "sudo"), ("service", "com.1password.1Password.authorizeCLI"),
+            ("requestingUser", "other"), ("tty", "/dev/pts/4"), ("operation", "sudo"),
+        ] {
+            var object = try #require(JSONSerialization.jsonObject(with: line) as? [String: Any])
+            object[field] = value
+            let invalid = try JSONSerialization.data(withJSONObject: object)
+            #expect(throws: HelperError.self) { try NativeAuthenticationRequest.decode(invalid) }
+        }
+    }
+
     @Test("enrollment cannot smuggle sudo context")
     func enrollmentSchema() throws {
         let valid = Data(

--- a/macos/run-qemu-gpu.sh
+++ b/macos/run-qemu-gpu.sh
@@ -1133,10 +1133,8 @@ reap_stale_work_dirs() {
   local marker=""
   local marker_value=""
   local launcher_pid=""
-  local launcher_command=""
   local qemu_marker=""
   local stale_qemu_pid=""
-  local qemu_command=""
 
   for candidate in /private/tmp/omarchy-qemu-gpu.??????; do
     [[ -d $candidate && ! -L $candidate ]] || continue
@@ -1149,20 +1147,27 @@ reap_stale_work_dirs() {
     [[ $marker_value =~ ^run-qemu-gpu:v1:([0-9]+):([0-9]+)$ ]] || continue
 
     launcher_pid=${BASH_REMATCH[1]}
-    launcher_command=$(ps -p "$launcher_pid" -o command= 2>/dev/null || true)
-    [[ $launcher_command != *"run-qemu-gpu.sh"* ]] || continue
-
+    stale_qemu_pid=""
     qemu_marker="$candidate/.qemu.pid"
     if [[ -f $qemu_marker && ! -L $qemu_marker ]]; then
       stale_qemu_pid=$(<"$qemu_marker")
-      if [[ $stale_qemu_pid =~ ^[0-9]+$ ]]; then
-        qemu_command=$(ps -p "$stale_qemu_pid" -o command= 2>/dev/null || true)
-        if [[ $qemu_command == *"$qemu_bin"* &&
-              $qemu_command == *"unix:/tmp/${candidate##*/}/qmp.sock"* ]]; then
-          continue
-        fi
-      fi
+      [[ $stale_qemu_pid =~ ^[0-9]+$ ]] || continue
     fi
+
+    # A failed ps is not evidence that a process exited. Obtain a complete UID
+    # inventory after reading the marker, and prove it contains this launcher.
+    local process_ids="" inspected_pid="" inspection_valid=0 run_is_alive=0
+    if ! process_ids=$(ps -U "$(id -u)" -o pid= 2>/dev/null); then
+      continue
+    fi
+    while read -r inspected_pid; do
+      [[ $inspected_pid =~ ^[0-9]+$ ]] || continue
+      [[ $inspected_pid != "$$" ]] || inspection_valid=1
+      if [[ $inspected_pid == "$launcher_pid" || $inspected_pid == "$stale_qemu_pid" ]]; then
+        run_is_alive=1
+      fi
+    done <<<"$process_ids"
+    (( inspection_valid == 1 && run_is_alive == 0 )) || continue
 
     echo "[qemu-gpu] Removing a verified stale disposable run: $candidate" >&2
     /bin/rm -rf "$candidate"


### PR DESCRIPTION
## What changes

Adds opt-in Mac Touch ID unlock for 1Password running inside the Linux guest. A locked desktop app or connected browser extension requests system authentication, the focused VM shows a dedicated Mac Touch ID prompt, and the signed approval unlocks guest 1Password. Vaults and passkeys remain managed by guest 1Password; no host password manager or passkey forwarding is required.

Canceling or failing Touch ID opens a compact floating guest-password dialog using the standard polkit PAM session. The 1Password account-password option remains available. Setup reuses existing Touch ID enrollment and requires both an updated host helper and the explicit guest installer documented in `docs/onepassword-touch-id.md`.

## Authorization and lifecycle

- Adds a distinct signed `onepassword-unlock` operation bound to the exact 1Password unlock service and guest identity. Existing sudo requests retain their validation rules.
- Registers a root-owned polkit agent only for verified installed 1Password processes in the active local guest session. Checks executable ownership, UID, process start time, current polkit sender, cancellation, and session state. Other desktop processes retain their existing authentication agents.
- Keeps passwords in an unprivileged GTK dialog backed by `PolkitAgent.Session`. A successful dialog exit alone cannot authorize a request. Other 1Password actions use the PAM path.
- Serializes the shared authentication device so simultaneous requests cannot consume each other's responses. Does not install blanket polkit authorization rules or change PAM policy.
- Preserves launcher socket directories when process inspection fails or either recorded process is still alive. This prevents cleanup from severing native bridges during a running VM; isolated regression fixtures cover unavailable process inspection and live/stale processes.

## Validation

- Refreshed against upstream v0.4.0 (`7c7acee`). Full `make test` passed, including 269 native tests, guest tests, launcher/network/storage contracts, and disk-resize tests. Authentication coverage includes signed request separation, replay/expiry checks, polkit caller validation, cancellation, and fallback.
- The launcher conflict resolution retains upstream's active-process snapshot checks and the additional fresh PID inventory check. Both the large-process-list contract and unavailable/incomplete/live/stale process fixtures pass.
- Release Swift helper build.
- Earlier local app packaging passed deep/strict code-signature verification; the installed feature was exercised with an existing persistent guest.
- Live user-confirmed checks: desktop Touch ID unlock, Firefox extension Touch ID unlock, selection of a 1Password passkey and successful website sign-in, and canceled Touch ID followed by successful guest-password unlock in the compact floating dialog.
- The fallback honors the guest's normal password lockout policy; the setup guide includes diagnosis for temporary lockouts.

The live app used an existing integrated local build. The refreshed PR includes current upstream `main` and was tested separately. Physical Touch ID authorization was not repeated for this refresh. A fresh factory guest image and QEMU runtime rebuild are not part of this validation.
