### PR TITLE
[fix] Move Reset below Launch in the start menu

### DIFF
--- a/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
+++ b/macos/Sources/OmarchyVMHelper/StartMenuWindow.swift
@@ -783,8 +783,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
             permissionCard,
             integrationHeading,
             integrationCard,
-            resetSection,
             launchButton,
+            resetSection,
             footerContainer,
         ])
         stack.orientation = .vertical
@@ -795,8 +795,8 @@ final class StartMenuWindow: NSObject, NSWindowDelegate {
         stack.setCustomSpacing(16, after: permissionCard)
         stack.setCustomSpacing(6, after: integrationHeading)
         stack.setCustomSpacing(12, after: integrationCard)
-        stack.setCustomSpacing(12, after: resetSection)
-        stack.setCustomSpacing(8, after: launchButton)
+        stack.setCustomSpacing(12, after: launchButton)
+        stack.setCustomSpacing(8, after: resetSection)
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         let document = StartMenuDocumentView()


### PR DESCRIPTION
Reset currently appears above Launch in the start menu, making it easy to hit the destructive action while intending to start the VM. Move Launch above Reset, retaining the 12-point gap between actions and the 8-point gap before the footer.

This changes only the stack order and spacing. Launch remains the Return-key action; the existing reset confirmation, button styling, and enabled states are unchanged.

Validation: `make test` passed, including 242 native tests, 103 guest tests, and shell/storage contracts. The optional virtio-pinch guest ABI test was skipped because `QEMU_PINCH_TEST_BINARY` was not configured. `git diff --check` passed. The change has not been installed in a local app bundle or visually exercised in the running app.

Screenshot:
<img width="712" height="944" alt="image" src="https://github.com/user-attachments/assets/5d5dbafb-f8c4-42cf-a7c4-476a264d9e18" />
