### PR TITLE
[feat] Improve macOS VirGL frame pacing by reducing GPU fence polling delay

### DIFF
--- a/macos/build-qemu-gpu-runtime.sh
+++ b/macos/build-qemu-gpu-runtime.sh
@@ -53,6 +53,7 @@ pinch_patch="$native_dir/patches/qemu-cocoa-pinch-zoom.patch"
 audio_device_patch="$native_dir/patches/qemu-sdl-audio-device-selection.patch"
 shared_folder_patch="$native_dir/patches/qemu-9p-guest-owner.patch"
 strchrnul_patch="$native_dir/patches/qemu-darwin-strchrnul-compat.patch"
+fence_poll_patch="$native_dir/patches/qemu-darwin-gpu-fence-poll.patch"
 prepare_runtime="$native_dir/prepare-qemu-gpu-runtime.sh"
 pinned_bottles="$native_dir/pinned-runtime-bottles.sh"
 
@@ -72,6 +73,7 @@ pause_ownership_patch_sha256=1a5729b36eb3e437395d41883a10c3c652df71d289d5df84d95
 pinch_patch_sha256=37acb8895dddd35fc66812d0c49ec5fc697f9127e9e12ed2e60d17999bf32aee
 audio_device_patch_sha256=03aca71c26163c337338cc3b2013c35430690fc0e8b66c5ce92a42f59a9b3334
 shared_folder_patch_sha256=41247692501655393ae3a40f56915472ab29b6e89c5173e33db1f62cca56632f
+fence_poll_patch_sha256=82a836c8f720fff09bea8c990133f88907e7ee2e0fd5b68451771065009d9743
 strchrnul_patch_sha256=ec1048dd0e8ebe53bf7e8a3bca9bf2f5f4336cd607d4cd077437470e9a32094a
 macos_deployment_target=15.0
 
@@ -347,6 +349,8 @@ verify_file_sha "Try Omarchy SDL audio-device patch" \
   "$audio_device_patch" "$audio_device_patch_sha256"
 verify_file_sha "Try Omarchy 9p shared-folder patch" \
   "$shared_folder_patch" "$shared_folder_patch_sha256"
+verify_file_sha "Try Omarchy Darwin GPU fence polling patch" \
+  "$fence_poll_patch" "$fence_poll_patch_sha256"
 verify_file_sha "Try Omarchy Darwin strchrnul compatibility patch" \
   "$strchrnul_patch" "$strchrnul_patch_sha256"
 
@@ -361,6 +365,7 @@ patch -d "$source_dir" -p1 -f -i "$pause_ownership_patch"
 patch -d "$source_dir" -p1 -f -i "$audio_device_patch"
 patch -d "$source_dir" -p1 -f -i "$shared_folder_patch"
 patch -d "$source_dir" -p1 -f -i "$strchrnul_patch"
+patch -d "$source_dir" -p1 -f -i "$fence_poll_patch"
 patch -d "$source_dir" -p1 -f -i "$pinch_patch"
 
 virgl_root="$dependency_root/virglrenderer/$virgl_version"

--- a/macos/patches/qemu-darwin-gpu-fence-poll.patch
+++ b/macos/patches/qemu-darwin-gpu-fence-poll.patch
@@ -1,0 +1,16 @@
+--- a/hw/display/virtio-gpu-virgl.c
++++ b/hw/display/virtio-gpu-virgl.c
+@@ -1389,7 +1389,13 @@
+     virgl_renderer_poll();
+     virtio_gpu_process_cmdq(g);
+     if (!QTAILQ_EMPTY(&g->cmdq) || !QTAILQ_EMPTY(&g->fenceq)) {
++#ifdef CONFIG_DARWIN
++        /* ANGLE fences are polled on the render thread. The generic 10 ms
++         * interval exceeds an entire 120 Hz frame and stalls guest uploads. */
++        timer_mod(gl->fence_poll, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 1);
++#else
+         timer_mod(gl->fence_poll, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
++#endif
+     }
+ }
+ 


### PR DESCRIPTION
## Problem and change

On the macOS ANGLE/VirGL path, QEMU waits 10 ms before polling pending GPU fences again. That exceeds the 8.33 ms frame period of a 120 Hz display and can delay guest progress into a later frame.

Add a checksum-pinned QEMU source patch that uses a 1 ms interval under `CONFIG_DARWIN`. Other platforms retain 10 ms, and the existing pending command/fence queue check still controls timer rearming. No guest protocol or package changes are required.

This overlaps with the GPU fence polling portion of #168 and follows its Darwin-scoped implementation. It intentionally leaves the display refresh timestamp change, HDR, video decoding, and audio timer changes to that PR.

## Existing experimental evidence

A controlled 10 ms → 1 ms → 10 ms comparison on an M3 Max, using a native Wayland/EGL client with presentation feedback, produced:

| Interval | Presentations/s at 120 Hz | Median submit-to-presentation time |
|---|---:|---:|
| Original 10 ms | ~60 | ~32.4 ms |
| 1 ms | ~120 | ~15.8 ms |
| Restored 10 ms | ~60 | ~32.4 ms |

At 60 Hz, both intervals sustained approximately 60 presentations/s. Simple clears and a workload with 200 scissored rectangle clears showed the same pattern. Runs lasted 12 seconds and excluded the first two seconds from steady-state summaries.

These measure guest virtual-display presentation, not physical panel scanout or end-to-end input latency. The isolated A/B/A experiment used a diagnostic binary modification; it is supporting evidence, not validation of the final source-built package. A later source-built integration of #168 also reached approximately 120 presentations/s, but included other display changes.

## Validation and draft status

- Source patch applies in a dry run against the retained pinned QEMU source fixture.
- Build script shell syntax and whitespace checks pass.
- Full `make test` passed using the installed Xcode toolchain, including 242 Swift tests in 54 suites and the guest, build/cache, shell, and storage checks. The initial Command Line Tools run failed to load Swift Testing macros; the Xcode rerun resolved that toolchain issue.

Before marking ready:

- [ ] Build and test the standalone source-built packaged runtime.
- [ ] Repeat controlled 60/120 Hz comparisons on that package.
- [ ] Measure host CPU usage and wakeups at idle and under sustained load.
- [ ] Check resizing, refresh-rate transitions, background/foreground, and suspend/resume.

More frequent polling can increase CPU usage and wakeups while GPU work remains pending. This PR remains a draft until the standalone runtime and that tradeoff are validated.
